### PR TITLE
fix: remove task definition retries check

### DIFF
--- a/rules/utils/cloud/element.js
+++ b/rules/utils/cloud/element.js
@@ -29,9 +29,6 @@ module.exports.hasZeebeCalledDecisionOrTaskDefinition = checkFlowNode(
       properties: {
         type: {
           required: true
-        },
-        retries: {
-          required: true
         }
       }
     }
@@ -101,9 +98,6 @@ module.exports.hasZeebeTaskDefinition = checkFlowNode(
     type: 'zeebe:TaskDefinition',
     properties: {
       type: {
-        required: true
-      },
-      retries: {
         required: true
       }
     }

--- a/rules/utils/element.js
+++ b/rules/utils/element.js
@@ -343,8 +343,7 @@ module.exports.checkProperties = checkProperties;
  *   {
  *     type: 'zeebe:TaskDefinition',
  *     properties: {
- *       type: { required: true },
- *       retries: { required: true }
+ *       type: { required: true }
  *     }
  *   }
  * ]);
@@ -415,8 +414,7 @@ module.exports.hasExtensionElementsOfTypes = function(types, exclusive = false) 
  *   {
  *     type: 'zeebe:TaskDefinition',
  *     properties: {
- *       type: { required: true },
- *       retries: { required: true }
+ *       type: { required: true }
  *     }
  *   }
  * );

--- a/test/camunda-cloud/camunda-cloud-1-0.spec.js
+++ b/test/camunda-cloud/camunda-cloud-1-0.spec.js
@@ -130,7 +130,7 @@ function createValid(executionPlatformVersion = '1.0.0') {
         <bpmn:process>
           <bpmn:serviceTask id="ServiceTask_1">
             <bpmn:extensionElements>
-              <zeebe:taskDefinition type="foo" retries="bar" />
+              <zeebe:taskDefinition type="foo" />
             </bpmn:extensionElements>
           </bpmn:serviceTask>
           <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="ServiceTask_1">
@@ -146,7 +146,7 @@ function createValid(executionPlatformVersion = '1.0.0') {
         <bpmn:process>
           <bpmn:serviceTask id="ServiceTask_1">
             <bpmn:extensionElements>
-              <zeebe:taskDefinition type="foo" retries="bar" />
+              <zeebe:taskDefinition type="foo" />
             </bpmn:extensionElements>
           </bpmn:serviceTask>
           <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="ServiceTask_1">
@@ -165,7 +165,7 @@ function createValid(executionPlatformVersion = '1.0.0') {
       moddleElement: createModdle(createCloudProcess(`
         <bpmn:serviceTask id="ServiceTask_1">
           <bpmn:extensionElements>
-            <zeebe:taskDefinition type="foo" retries="bar" />
+            <zeebe:taskDefinition type="foo" />
           </bpmn:extensionElements>
         </bpmn:serviceTask>
         <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="ServiceTask_1">
@@ -319,7 +319,7 @@ function createValid(executionPlatformVersion = '1.0.0') {
       moddleElement: createModdle(createCloudProcess(`
         <bpmn:serviceTask id="ServiceTask_1">
           <bpmn:extensionElements>
-            <zeebe:taskDefinition type="foo" retries="bar" />
+            <zeebe:taskDefinition type="foo" />
           </bpmn:extensionElements>
         </bpmn:serviceTask>
       `))
@@ -334,7 +334,7 @@ function createValid(executionPlatformVersion = '1.0.0') {
             </bpmn:extensionElements>
           </bpmn:multiInstanceLoopCharacteristics>
           <bpmn:extensionElements>
-            <zeebe:taskDefinition type="foo" retries="bar" />
+            <zeebe:taskDefinition type="foo" />
           </bpmn:extensionElements>
         </bpmn:serviceTask>
       `))
@@ -349,7 +349,7 @@ function createValid(executionPlatformVersion = '1.0.0') {
             </bpmn:extensionElements>
           </bpmn:multiInstanceLoopCharacteristics>
           <bpmn:extensionElements>
-            <zeebe:taskDefinition type="foo" retries="bar" />
+            <zeebe:taskDefinition type="foo" />
           </bpmn:extensionElements>
         </bpmn:serviceTask>
       `))
@@ -491,7 +491,7 @@ function createInvalid(executionPlatformVersion = '1.0.0') {
       moddleElement: createModdle(createCloudProcess(`
         <bpmn:serviceTask id="ServiceTask_1">
           <bpmn:extensionElements>
-            <zeebe:taskDefinition type="foo" retries="bar" />
+            <zeebe:taskDefinition type="foo" />
           </bpmn:extensionElements>
         </bpmn:serviceTask>
         <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="ServiceTask_1" />
@@ -511,7 +511,7 @@ function createInvalid(executionPlatformVersion = '1.0.0') {
       moddleElement: createModdle(createCloudProcess(`
         <bpmn:serviceTask id="ServiceTask_1">
           <bpmn:extensionElements>
-            <zeebe:taskDefinition type="foo" retries="bar" />
+            <zeebe:taskDefinition type="foo" />
           </bpmn:extensionElements>
         </bpmn:serviceTask>
         <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="ServiceTask_1">
@@ -537,7 +537,7 @@ function createInvalid(executionPlatformVersion = '1.0.0') {
       moddleElement: createModdle(createCloudProcess(`
         <bpmn:serviceTask id="ServiceTask_1">
           <bpmn:extensionElements>
-            <zeebe:taskDefinition type="foo" retries="bar" />
+            <zeebe:taskDefinition type="foo" />
           </bpmn:extensionElements>
         </bpmn:serviceTask>
         <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="ServiceTask_1">
@@ -918,7 +918,7 @@ function createInvalid(executionPlatformVersion = '1.0.0') {
       moddleElement: createModdle(createCloudProcess(`
         <bpmn:serviceTask id="ServiceTask_1">
           <bpmn:extensionElements>
-            <zeebe:taskDefinition retries="bar" />
+            <zeebe:taskDefinition />
           </bpmn:extensionElements>
         </bpmn:serviceTask>
       `)),
@@ -943,7 +943,7 @@ function createInvalid(executionPlatformVersion = '1.0.0') {
         <bpmn:serviceTask id="ServiceTask_1">
           <bpmn:multiInstanceLoopCharacteristics />
           <bpmn:extensionElements>
-            <zeebe:taskDefinition type="foo" retries="bar" />
+            <zeebe:taskDefinition type="foo" />
           </bpmn:extensionElements>
         </bpmn:serviceTask>
       `)),

--- a/test/camunda-cloud/camunda-cloud-1-1.spec.js
+++ b/test/camunda-cloud/camunda-cloud-1-1.spec.js
@@ -20,7 +20,7 @@ function createValid(executionPlatformVersion = '1.1.0') {
       moddleElement: createModdle(createCloudProcess(`
         <bpmn:businessRuleTask id="BusinessRuleTask_1">
           <bpmn:extensionElements>
-            <zeebe:taskDefinition type="foo" retries="bar" />
+            <zeebe:taskDefinition type="foo" />
           </bpmn:extensionElements>
         </bpmn:businessRuleTask>
       `))
@@ -35,7 +35,7 @@ function createValid(executionPlatformVersion = '1.1.0') {
             </bpmn:extensionElements>
           </bpmn:multiInstanceLoopCharacteristics>
           <bpmn:extensionElements>
-            <zeebe:taskDefinition type="foo" retries="bar" />
+            <zeebe:taskDefinition type="foo" />
           </bpmn:extensionElements>
         </bpmn:businessRuleTask>
       `))
@@ -50,7 +50,7 @@ function createValid(executionPlatformVersion = '1.1.0') {
             </bpmn:extensionElements>
           </bpmn:multiInstanceLoopCharacteristics>
           <bpmn:extensionElements>
-            <zeebe:taskDefinition type="foo" retries="bar" />
+            <zeebe:taskDefinition type="foo" />
           </bpmn:extensionElements>
         </bpmn:businessRuleTask>
       `))
@@ -98,7 +98,7 @@ function createValid(executionPlatformVersion = '1.1.0') {
       moddleElement: createModdle(createCloudProcess(`
         <bpmn:scriptTask id="ScriptTask_1">
           <bpmn:extensionElements>
-            <zeebe:taskDefinition type="foo" retries="bar" />
+            <zeebe:taskDefinition type="foo" />
           </bpmn:extensionElements>
         </bpmn:scriptTask>
       `))
@@ -113,7 +113,7 @@ function createValid(executionPlatformVersion = '1.1.0') {
             </bpmn:extensionElements>
           </bpmn:multiInstanceLoopCharacteristics>
           <bpmn:extensionElements>
-            <zeebe:taskDefinition type="foo" retries="bar" />
+            <zeebe:taskDefinition type="foo" />
           </bpmn:extensionElements>
         </bpmn:scriptTask>
       `))
@@ -128,7 +128,7 @@ function createValid(executionPlatformVersion = '1.1.0') {
             </bpmn:extensionElements>
           </bpmn:multiInstanceLoopCharacteristics>
           <bpmn:extensionElements>
-            <zeebe:taskDefinition type="foo" retries="bar" />
+            <zeebe:taskDefinition type="foo" />
           </bpmn:extensionElements>
         </bpmn:scriptTask>
       `))
@@ -140,7 +140,7 @@ function createValid(executionPlatformVersion = '1.1.0') {
       moddleElement: createModdle(createCloudProcess(`
         <bpmn:sendTask id="SendTask_1">
           <bpmn:extensionElements>
-            <zeebe:taskDefinition type="foo" retries="bar" />
+            <zeebe:taskDefinition type="foo" />
           </bpmn:extensionElements>
         </bpmn:sendTask>
       `))
@@ -155,7 +155,7 @@ function createValid(executionPlatformVersion = '1.1.0') {
             </bpmn:extensionElements>
           </bpmn:multiInstanceLoopCharacteristics>
           <bpmn:extensionElements>
-            <zeebe:taskDefinition type="foo" retries="bar" />
+            <zeebe:taskDefinition type="foo" />
           </bpmn:extensionElements>
         </bpmn:sendTask>
       `))
@@ -170,7 +170,7 @@ function createValid(executionPlatformVersion = '1.1.0') {
             </bpmn:extensionElements>
           </bpmn:multiInstanceLoopCharacteristics>
           <bpmn:extensionElements>
-            <zeebe:taskDefinition type="foo" retries="bar" />
+            <zeebe:taskDefinition type="foo" />
           </bpmn:extensionElements>
         </bpmn:sendTask>
       `))
@@ -204,7 +204,7 @@ function createInvalid(executionPlatformVersion = '1.1.0') {
       moddleElement: createModdle(createCloudProcess(`
         <bpmn:businessRuleTask id="BusinessRuleTask_1">
           <bpmn:extensionElements>
-            <zeebe:taskDefinition retries="bar" />
+            <zeebe:taskDefinition />
           </bpmn:extensionElements>
         </bpmn:businessRuleTask>
       `)),
@@ -229,7 +229,7 @@ function createInvalid(executionPlatformVersion = '1.1.0') {
         <bpmn:businessRuleTask id="BusinessRuleTask_1">
           <bpmn:multiInstanceLoopCharacteristics />
           <bpmn:extensionElements>
-            <zeebe:taskDefinition type="foo" retries="bar" />
+            <zeebe:taskDefinition type="foo" />
           </bpmn:extensionElements>
         </bpmn:businessRuleTask>
       `)),
@@ -309,7 +309,7 @@ function createInvalid(executionPlatformVersion = '1.1.0') {
       moddleElement: createModdle(createCloudProcess(`
         <bpmn:scriptTask id="ScriptTask_1">
           <bpmn:extensionElements>
-            <zeebe:taskDefinition retries="bar" />
+            <zeebe:taskDefinition />
           </bpmn:extensionElements>
         </bpmn:scriptTask>
       `)),
@@ -334,7 +334,7 @@ function createInvalid(executionPlatformVersion = '1.1.0') {
         <bpmn:scriptTask id="ScriptTask_1">
           <bpmn:multiInstanceLoopCharacteristics />
           <bpmn:extensionElements>
-            <zeebe:taskDefinition type="foo" retries="bar" />
+            <zeebe:taskDefinition type="foo" />
           </bpmn:extensionElements>
         </bpmn:scriptTask>
       `)),
@@ -370,7 +370,7 @@ function createInvalid(executionPlatformVersion = '1.1.0') {
       moddleElement: createModdle(createCloudProcess(`
         <bpmn:sendTask id="SendTask_1">
           <bpmn:extensionElements>
-            <zeebe:taskDefinition retries="bar" />
+            <zeebe:taskDefinition />
           </bpmn:extensionElements>
         </bpmn:sendTask>
       `)),
@@ -395,7 +395,7 @@ function createInvalid(executionPlatformVersion = '1.1.0') {
         <bpmn:sendTask id="SendTask_1">
           <bpmn:multiInstanceLoopCharacteristics />
           <bpmn:extensionElements>
-            <zeebe:taskDefinition type="foo" retries="bar" />
+            <zeebe:taskDefinition type="foo" />
           </bpmn:extensionElements>
         </bpmn:sendTask>
       `)),

--- a/test/camunda-cloud/camunda-cloud-1-2.spec.js
+++ b/test/camunda-cloud/camunda-cloud-1-2.spec.js
@@ -29,7 +29,7 @@ function createValid(executionPlatformVersion = '1.2.0') {
         <bpmn:intermediateThrowEvent id="EndEvent_1">
           <bpmn:messageEventDefinition id="MessageEventDefinition_1" />
           <bpmn:extensionElements>
-            <zeebe:taskDefinition type="foo" retries="bar" />
+            <zeebe:taskDefinition type="foo" />
           </bpmn:extensionElements>
         </bpmn:intermediateThrowEvent>
       `))

--- a/test/utils/cloud/element.spec.js
+++ b/test/utils/cloud/element.spec.js
@@ -143,9 +143,7 @@ describe('util - cloud - element', function() {
       const businessRuleTask = createElement('bpmn:BusinessRuleTask', {
         extensionElements: createElement('bpmn:ExtensionElements', {
           values: [
-            createElement('zeebe:TaskDefinition', {
-              retries: 'bar'
-            })
+            createElement('zeebe:TaskDefinition')
           ]
         })
       });
@@ -160,34 +158,6 @@ describe('util - cloud - element', function() {
         error: {
           type: 'propertyRequired',
           requiredProperty: 'type'
-        }
-      });
-    });
-
-
-    it('should return errors (no retries)', function() {
-
-      // given
-      const businessRuleTask = createElement('bpmn:BusinessRuleTask', {
-        extensionElements: createElement('bpmn:ExtensionElements', {
-          values: [
-            createElement('zeebe:TaskDefinition', {
-              type: 'foo'
-            })
-          ]
-        })
-      });
-
-      // when
-      const result = hasZeebeCalledDecisionOrTaskDefinition(businessRuleTask);
-
-      // then
-      expect(result).to.eql({
-        message: 'Element of type <zeebe:TaskDefinition> must have property <retries>',
-        path: [ 'extensionElements', 'values', 0, 'retries' ],
-        error: {
-          type: 'propertyRequired',
-          requiredProperty: 'retries'
         }
       });
     });
@@ -580,8 +550,7 @@ describe('util - cloud - element', function() {
         extensionElements: createElement('bpmn:ExtensionElements', {
           values: [
             createElement('zeebe:TaskDefinition', {
-              type: 'foo',
-              retries: 'bar'
+              type: 'foo'
             })
           ]
         })
@@ -621,9 +590,7 @@ describe('util - cloud - element', function() {
       const serviceTask = createElement('bpmn:ServiceTask', {
         extensionElements: createElement('bpmn:ExtensionElements', {
           values: [
-            createElement('zeebe:TaskDefinition', {
-              retries: 'bar'
-            })
+            createElement('zeebe:TaskDefinition')
           ]
         })
       });
@@ -638,34 +605,6 @@ describe('util - cloud - element', function() {
         error: {
           type: 'propertyRequired',
           requiredProperty: 'type'
-        }
-      });
-    });
-
-
-    it('should return errors (no retries)', function() {
-
-      // given
-      const serviceTask = createElement('bpmn:ServiceTask', {
-        extensionElements: createElement('bpmn:ExtensionElements', {
-          values: [
-            createElement('zeebe:TaskDefinition', {
-              type: 'foo'
-            })
-          ]
-        })
-      });
-
-      // when
-      const result = hasZeebeTaskDefinition(serviceTask);
-
-      // then
-      expect(result).to.eql({
-        message: 'Element of type <zeebe:TaskDefinition> must have property <retries>',
-        path: [ 'extensionElements', 'values', 0, 'retries' ],
-        error: {
-          type: 'propertyRequired',
-          requiredProperty: 'retries'
         }
       });
     });

--- a/test/utils/element.spec.js
+++ b/test/utils/element.spec.js
@@ -278,15 +278,15 @@ describe('util - element', function() {
       it('should not return errors', function() {
 
         // given
-        const taskDefinition = createElement('zeebe:TaskDefinition', {
-          type: 'foo',
-          retries: 'bar'
+        const loopCharacteristics = createElement('zeebe:LoopCharacteristics', {
+          outputCollection: 'foo',
+          outputElement: 'bar'
         });
 
         // when
-        const results = checkProperties(taskDefinition, {
-          type: {
-            dependendRequired: 'retries'
+        const results = checkProperties(loopCharacteristics, {
+          outputCollection: {
+            dependendRequired: 'outputElement'
           }
         });
 
@@ -298,25 +298,25 @@ describe('util - element', function() {
       it('should return errors (parentNode === node)', function() {
 
         // given
-        const taskDefinition = createElement('zeebe:TaskDefinition', {
-          retries: 'bar'
+        const loopCharacteristics = createElement('zeebe:LoopCharacteristics', {
+          outputElement: 'bar'
         });
 
         // when
-        const results = checkProperties(taskDefinition, {
-          type: {
-            dependendRequired: 'retries'
+        const results = checkProperties(loopCharacteristics, {
+          outputCollection: {
+            dependendRequired: 'outputElement'
           }
         });
 
         // then
         expect(results).to.eql([
           {
-            message: 'Element of type <zeebe:TaskDefinition> must have property <type> if property <retries> is set',
-            path: [ 'type' ],
+            message: 'Element of type <zeebe:LoopCharacteristics> must have property <outputCollection> if property <outputElement> is set',
+            path: [ 'outputCollection' ],
             error: {
               type: ERROR_TYPES.PROPERTY_DEPENDEND_REQUIRED,
-              dependendRequiredProperty: 'type'
+              dependendRequiredProperty: 'outputCollection'
             }
           }
         ]);
@@ -326,33 +326,35 @@ describe('util - element', function() {
       it('should return errors (parentNode !== node)', function() {
 
         // given
-        const taskDefinition = createElement('zeebe:TaskDefinition', {
-          retries: 'bar'
+        const loopCharacteristics = createElement('zeebe:LoopCharacteristics', {
+          outputElement: 'bar'
         });
 
         const serviceTask = createElement('bpmn:ServiceTask', {
-          extensionElements: createElement('bpmn:ExtensionElements', {
-            values: [
-              taskDefinition
-            ]
+          loopCharacteristics: createElement('bpmn:MultiInstanceLoopCharacteristics', {
+            extensionElements: createElement('bpmn:ExtensionElements', {
+              values: [
+                loopCharacteristics
+              ]
+            })
           })
         });
 
         // when
-        const results = checkProperties(taskDefinition, {
-          type: {
-            dependendRequired: 'retries'
+        const results = checkProperties(loopCharacteristics, {
+          outputCollection: {
+            dependendRequired: 'outputElement'
           }
         }, serviceTask);
 
         // then
         expect(results).to.eql([
           {
-            message: 'Element of type <zeebe:TaskDefinition> must have property <type> if property <retries> is set',
-            path: [ 'extensionElements', 'values', 0, 'type' ],
+            message: 'Element of type <zeebe:LoopCharacteristics> must have property <outputCollection> if property <outputElement> is set',
+            path: [ 'loopCharacteristics', 'extensionElements', 'values', 0, 'outputCollection' ],
             error: {
               type: ERROR_TYPES.PROPERTY_DEPENDEND_REQUIRED,
-              dependendRequiredProperty: 'type'
+              dependendRequiredProperty: 'outputCollection'
             }
           }
         ]);
@@ -819,9 +821,7 @@ describe('util - element', function() {
       const serviceTask = createElement('bpmn:ServiceTask', {
         extensionElements: createElement('bpmn:ExtensionElements', {
           values: [
-            createElement('zeebe:TaskDefinition', {
-              retries: 'bar'
-            })
+            createElement('zeebe:TaskDefinition')
           ]
         })
       });


### PR DESCRIPTION
`zeebe:retries` property of `zeebe:TaskDefinition` extension elements isn't required.

---

Related to https://github.com/camunda/camunda-modeler/pull/2861#issuecomment-1084430700