### PR TITLE
fix: remove lanes check

### DIFF
--- a/rules/camunda-cloud-1-0-checks.js
+++ b/rules/camunda-cloud-1-0-checks.js
@@ -6,7 +6,6 @@ const {
   hasEventDefinitionOfType,
   hasEventDefinitionOfTypeOrNone,
   hasMessageReference,
-  hasNoLanes,
   isNotBpmn,
   withTranslations
 } = require('./utils/element');
@@ -36,6 +35,7 @@ module.exports = [
   'bpmn:MessageFlow',
   'bpmn:ParallelGateway',
   'bpmn:Participant',
+  'bpmn:Process',
   'bpmn:SequenceFlow',
   'bpmn:TextAnnotation',
   {
@@ -132,15 +132,6 @@ module.exports = [
         'Element of type <bpmn:Message> must have property <name>': 'A <Message Intermediate Catch Event> with <Message Reference> must have a defined <Name>',
         'Element of type <bpmn:Message> must have extension element of type <zeebe:Subscription>': 'A <Message Intermediate Catch Event> with <Message Reference> must have a defined <Subscription correlation key>',
         'Element of type <zeebe:Subscription> must have property <correlationKey>': 'A <Message Intermediate Catch Event> with <Message Reference> must have a defined <Subscription correlation key>'
-      }
-    )
-  },
-  {
-    type: 'bpmn:Process',
-    check: withTranslations(
-      hasNoLanes,
-      {
-        'Element of type <bpmn:Process> (<bpmn:LaneSet>) not supported by {{ executionPlatform }}': 'A <Lane> is not supported by Camunda Platform 8 (Zeebe 1.0)'
       }
     )
   },

--- a/rules/utils/element.js
+++ b/rules/utils/element.js
@@ -131,14 +131,6 @@ module.exports.hasMultiInstanceLoopCharacteristics = function(node) {
   return true;
 };
 
-module.exports.hasNoLanes = function(node) {
-  const laneSets = node.get('laneSets');
-
-  return !laneSets
-    || !laneSets.length
-    || getElementNotSupportedError(node.$type, 'bpmn:LaneSet', [ 'laneSets' ]);
-};
-
 module.exports.isNotBpmn = function(node) {
   return !is(node, 'bpmn:BaseElement');
 };

--- a/test/camunda-cloud/camunda-cloud-1-0.spec.js
+++ b/test/camunda-cloud/camunda-cloud-1-0.spec.js
@@ -260,6 +260,21 @@ function createValid(executionPlatformVersion = '1.0.0') {
       `))
     },
 
+    // bpmn:Process
+    {
+      name: 'process (lanes)',
+      moddleElement: createModdle(createCloudDefinitions(`
+        <bpmn:collaboration id="Collaboration_1">
+          <bpmn:participant id="Participant_1" processRef="Process_1" />
+        </bpmn:collaboration>
+        <bpmn:process id="Process_1">
+          <bpmn:laneSet id="LaneSet_1">
+            <bpmn:lane id="Lane_1" />
+          </bpmn:laneSet>
+        </bpmn:process>
+      `))
+    },
+
     // bpmn:ReceiveTask
     {
       name: 'receive task',
@@ -1026,33 +1041,6 @@ function createInvalid(executionPlatformVersion = '1.0.0') {
         error: {
           type: ERROR_TYPES.PROPERTY_REQUIRED,
           requiredProperty: 'correlationKey'
-        }
-      }
-    },
-
-    // bpmn:Process
-    {
-      name: 'lane',
-      moddleElement: createModdle(createCloudDefinitions(`
-        <bpmn:collaboration id="Collaboration_1">
-          <bpmn:participant id="Participant_1" processRef="Process_1" />
-        </bpmn:collaboration>
-        <bpmn:process id="Process_1">
-          <bpmn:laneSet id="LaneSet_1">
-            <bpmn:lane id="Lane_1" />
-          </bpmn:laneSet>
-        </bpmn:process>
-      `)),
-      report: {
-        id: 'Process_1',
-        message: 'A <Lane> is not supported by Camunda Platform 8 (Zeebe 1.0)',
-        path: [
-          'laneSets'
-        ],
-        error: {
-          type: ERROR_TYPES.ELEMENT_TYPE,
-          elementType: 'bpmn:Process',
-          propertyType: 'bpmn:LaneSet'
         }
       }
     },

--- a/test/utils/element.spec.js
+++ b/test/utils/element.spec.js
@@ -27,7 +27,6 @@ const {
   hasMessageReference,
   hasMultiInstanceLoopCharacteristics,
   hasNoEventDefinition,
-  hasNoLanes,
   withTranslations
 } = require('../../rules/utils/element');
 
@@ -1281,55 +1280,6 @@ describe('util - element', function() {
           type: 'elementType',
           elementType: 'bpmn:StartEvent',
           propertyType: 'bpmn:ErrorEventDefinition'
-        }
-      });
-    });
-
-  });
-
-
-  describe('#hasNoLanes', function() {
-
-    it('should not return error', function() {
-
-      // given
-      const node = createElement('bpmn:Process');
-
-      // when
-      const result = hasNoLanes(node);
-
-      // then
-      expect(result).to.be.true;
-    });
-
-
-    it('should return error', function() {
-
-      // given
-      const node = createElement('bpmn:Process', {
-        laneSets: [
-          createElement('bpmn:LaneSet', {
-            lanes: [
-              createElement('bpmn:Lane'),
-              createElement('bpmn:Lane')
-            ]
-          })
-        ]
-      });
-
-      // when
-      const result = hasNoLanes(node);
-
-      // then
-      expect(result).to.eql({
-        message: 'Element of type <bpmn:Process> (<bpmn:LaneSet>) not supported by {{ executionPlatform }}',
-        path: [
-          'laneSets'
-        ],
-        error: {
-          type: 'elementType',
-          elementType: 'bpmn:Process',
-          propertyType: 'bpmn:LaneSet'
         }
       });
     });


### PR DESCRIPTION
Lanes are actually supported by Zeebe. The engine will not throw an error when deploying a BPMN with lanes.