### PR TITLE
Add User Task Forms Rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ module.exports = {
         'loop-characteristics': 'error',
         'message-reference': 'error',
         'no-template': 'error',
-        'subscription': 'error'
+        'subscription': 'error',
+        'user-task-form': 'error'
       }
     },
     'camunda-cloud-1-1': {
@@ -24,7 +25,8 @@ module.exports = {
         'loop-characteristics': 'error',
         'message-reference': 'error',
         'no-template': 'error',
-        'subscription': 'error'
+        'subscription': 'error',
+        'user-task-form': 'error'
       }
     },
     'camunda-cloud-1-2': {
@@ -36,7 +38,8 @@ module.exports = {
         'loop-characteristics': 'error',
         'message-reference': 'error',
         'no-template': 'error',
-        'subscription': 'error'
+        'subscription': 'error',
+        'user-task-form': 'error'
       }
     },
     'camunda-cloud-1-3': {
@@ -48,7 +51,8 @@ module.exports = {
         'loop-characteristics': 'error',
         'message-reference': 'error',
         'no-template': 'error',
-        'subscription': 'error'
+        'subscription': 'error',
+        'user-task-form': 'error'
       }
     },
     'camunda-cloud-8-0': {
@@ -59,7 +63,8 @@ module.exports = {
         'error-reference': 'error',
         'loop-characteristics': 'error',
         'message-reference': 'error',
-        'subscription': 'error'
+        'subscription': 'error',
+        'user-task-form': 'error'
       }
     }
   }

--- a/rules/user-task-form.js
+++ b/rules/user-task-form.js
@@ -1,0 +1,93 @@
+const { is } = require('bpmnlint-utils');
+
+const {
+  findExtensionElement,
+  findExtensionElements,
+  hasProperties
+} = require('./utils/element');
+
+const { reportErrors } = require('./utils/reporter');
+
+module.exports = function() {
+  function check(node, reporter) {
+    if (!is(node, 'bpmn:UserTask')) {
+      return;
+    }
+
+    const formDefinition = findExtensionElement(node, 'zeebe:FormDefinition');
+
+    if (!formDefinition) {
+      return;
+    }
+
+    let errors = hasProperties(formDefinition, {
+      formKey: {
+        required: true
+      }
+    }, node);
+
+    if (errors && errors.length) {
+      reportErrors(node, reporter, errors);
+
+      return;
+    }
+
+    const formKey = formDefinition.get('formKey');
+
+    const userTaskForm = findUserTaskForm(node, formKey);
+
+    if (!userTaskForm) {
+      return;
+    }
+
+    errors = hasProperties(userTaskForm, {
+      body: {
+        required: true
+      }
+    }, node);
+
+    if (errors && errors.length) {
+      reportErrors(node, reporter, errors);
+    }
+  }
+
+  return {
+    check
+  };
+};
+
+function findUserTaskForm(node, formKey) {
+  const process = findParent(node, 'bpmn:Process');
+
+  if (!process) {
+    return;
+  }
+
+  const userTaskForms = findExtensionElements(process, 'zeebe:UserTaskForm');
+
+  if (userTaskForms && userTaskForms.length) {
+    return userTaskForms.find(userTaskForm => {
+      const id = userTaskForm.get('id');
+
+      return `camunda-forms:bpmn:${ id }` === formKey;
+    });
+  }
+}
+
+function findParent(node, type) {
+  if (!node) {
+    return null;
+  }
+
+  const parent = node.$parent;
+
+  if (!parent) {
+    return node;
+  }
+
+  if (is(parent, type)) {
+    return parent;
+  }
+
+  return findParent(parent, type);
+}

--- a/rules/utils/element.js
+++ b/rules/utils/element.js
@@ -40,6 +40,8 @@ function findExtensionElements(node, types) {
   return values.filter(value => isAny(value, types));
 }
 
+module.exports.findExtensionElements = findExtensionElements;
+
 function findExtensionElement(node, types) {
   const extensionElements = findExtensionElements(node, types);
 

--- a/test/camunda-cloud/integration/camunda-cloud-1-0-invalid.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-1-0-invalid.bpmn
@@ -4,6 +4,9 @@
     <bpmn:participant id="Participant_1lhpzkq" processRef="Process_07pko08" />
   </bpmn:collaboration>
   <bpmn:process id="Process_07pko08" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:userTaskForm id="userTaskForm_243ufpi"></zeebe:userTaskForm>
+    </bpmn:extensionElements>
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1c9prry</bpmn:outgoing>
     </bpmn:startEvent>
@@ -58,8 +61,12 @@
       <bpmn:outgoing>Flow_0k2v5e1</bpmn:outgoing>
     </bpmn:receiveTask>
     <bpmn:userTask id="Activity_18h7yic">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formKey="camunda-forms:bpmn:userTaskForm_243ufpi" />
+      </bpmn:extensionElements>
       <bpmn:incoming>Flow_0uqdyxp</bpmn:incoming>
       <bpmn:outgoing>Flow_1a5127t</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1su3e35</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:endEvent id="Event_195u06h">
       <bpmn:incoming>Flow_1a5127t</bpmn:incoming>
@@ -95,6 +102,13 @@
       <bpmn:incoming>Flow_11x8rdy</bpmn:incoming>
       <bpmn:errorEventDefinition id="ErrorEventDefinition_16vp8au" />
     </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1su3e35" sourceRef="Activity_18h7yic" targetRef="Activity_1xbg5rg" />
+    <bpmn:userTask id="Activity_1xbg5rg">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formKey="" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1su3e35</bpmn:incoming>
+    </bpmn:userTask>
     <bpmn:textAnnotation id="TextAnnotation_092byka">
       <bpmn:text>foo</bpmn:text>
     </bpmn:textAnnotation>
@@ -173,6 +187,10 @@
         <di:waypoint x="215" y="267" />
         <di:waypoint x="270" y="267" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1su3e35_di" bpmnElement="Flow_1su3e35">
+        <di:waypoint x="1180" y="380" />
+        <di:waypoint x="1270" y="380" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="249" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -210,6 +228,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0gcrrhl_di" bpmnElement="Event_195u06h">
         <dc:Bounds x="1262" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1s59gp0_di" bpmnElement="Activity_1xbg5rg">
+        <dc:Bounds x="1270" y="340" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_09495yf_di" bpmnElement="Activity_09495yf" isExpanded="true">
         <dc:Bounds x="1280" y="167" width="350" height="200" />

--- a/test/camunda-cloud/integration/camunda-cloud-1-0-valid.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-1-0-valid.bpmn
@@ -4,6 +4,9 @@
     <bpmn:participant id="Participant_1lhpzkq" processRef="Process_07pko08" />
   </bpmn:collaboration>
   <bpmn:process id="Process_07pko08" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:userTaskForm id="userTaskForm_0iprp5h">{}</zeebe:userTaskForm>
+    </bpmn:extensionElements>
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1c9prry</bpmn:outgoing>
     </bpmn:startEvent>
@@ -63,6 +66,9 @@
       <bpmn:outgoing>Flow_0k2v5e1</bpmn:outgoing>
     </bpmn:receiveTask>
     <bpmn:userTask id="Activity_18h7yic">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formKey="camunda-forms:bpmn:userTaskForm_0iprp5h" />
+      </bpmn:extensionElements>
       <bpmn:incoming>Flow_0uqdyxp</bpmn:incoming>
       <bpmn:outgoing>Flow_1a5127t</bpmn:outgoing>
     </bpmn:userTask>
@@ -216,9 +222,6 @@
       <bpmndi:BPMNShape id="Event_0gcrrhl_di" bpmnElement="Event_195u06h">
         <dc:Bounds x="1262" y="472" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0wspz7j_di" bpmnElement="Gateway_1adft3c" isMarkerVisible="true">
-        <dc:Bounds x="715" y="355" width="50" height="50" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_09495yf_di" bpmnElement="Activity_09495yf" isExpanded="true">
         <dc:Bounds x="1280" y="167" width="350" height="200" />
       </bpmndi:BPMNShape>
@@ -227,6 +230,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_16u5s1h_di" bpmnElement="Event_0el3zk8">
         <dc:Bounds x="442" y="482" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0wspz7j_di" bpmnElement="Gateway_1adft3c" isMarkerVisible="true">
+        <dc:Bounds x="715" y="355" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_092byka_di" bpmnElement="TextAnnotation_092byka">
         <dc:Bounds x="370" y="140" width="100" height="30" />

--- a/test/camunda-cloud/integration/camunda-cloud-1-0.spec.js
+++ b/test/camunda-cloud/integration/camunda-cloud-1-0.spec.js
@@ -75,6 +75,9 @@ describe('integration - camunda-cloud-1-0', function() {
 
       expect(reports[ 'camunda-compat/subscription' ]).to.exist;
       expect(reports[ 'camunda-compat/subscription' ]).to.have.length(1);
+
+      expect(reports[ 'camunda-compat/user-task-form' ]).to.exist;
+      expect(reports[ 'camunda-compat/user-task-form' ]).to.have.length(2);
     });
 
   });

--- a/test/camunda-cloud/integration/camunda-cloud-1-1-invalid.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-1-1-invalid.bpmn
@@ -4,6 +4,9 @@
     <bpmn:participant id="Participant_1lhpzkq" processRef="Process_07pko08" />
   </bpmn:collaboration>
   <bpmn:process id="Process_07pko08" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:userTaskForm id="userTaskForm_0bqu0t6"></zeebe:userTaskForm>
+    </bpmn:extensionElements>
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1c9prry</bpmn:outgoing>
       <bpmn:outgoing>Flow_00dv1kp</bpmn:outgoing>
@@ -59,8 +62,12 @@
       <bpmn:outgoing>Flow_0k2v5e1</bpmn:outgoing>
     </bpmn:receiveTask>
     <bpmn:userTask id="Activity_18h7yic">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formKey="camunda-forms:bpmn:userTaskForm_0bqu0t6" />
+      </bpmn:extensionElements>
       <bpmn:incoming>Flow_0uqdyxp</bpmn:incoming>
       <bpmn:outgoing>Flow_1a5127t</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1wi6jrz</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:endEvent id="Event_195u06h">
       <bpmn:incoming>Flow_1a5127t</bpmn:incoming>
@@ -136,6 +143,13 @@
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1c7yptg</bpmn:incoming>
     </bpmn:sendTask>
+    <bpmn:sequenceFlow id="Flow_1wi6jrz" sourceRef="Activity_18h7yic" targetRef="Activity_0zphmgg" />
+    <bpmn:userTask id="Activity_0zphmgg">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formKey="" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1wi6jrz</bpmn:incoming>
+    </bpmn:userTask>
     <bpmn:textAnnotation id="TextAnnotation_092byka">
       <bpmn:text>foo</bpmn:text>
     </bpmn:textAnnotation>
@@ -237,6 +251,10 @@
         <di:waypoint x="215" y="267" />
         <di:waypoint x="270" y="267" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1wi6jrz_di" bpmnElement="Flow_1wi6jrz">
+        <di:waypoint x="1180" y="380" />
+        <di:waypoint x="1270" y="380" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="249" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -274,6 +292,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0gcrrhl_di" bpmnElement="Event_195u06h">
         <dc:Bounds x="1262" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18fudj2_di" bpmnElement="Activity_0zphmgg">
+        <dc:Bounds x="1270" y="340" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_09495yf_di" bpmnElement="Activity_09495yf" isExpanded="true">
         <dc:Bounds x="1280" y="167" width="350" height="200" />

--- a/test/camunda-cloud/integration/camunda-cloud-1-1.spec.js
+++ b/test/camunda-cloud/integration/camunda-cloud-1-1.spec.js
@@ -101,6 +101,9 @@ describe('integration - camunda-cloud-1-1', function() {
 
       expect(reports[ 'camunda-compat/subscription' ]).to.exist;
       expect(reports[ 'camunda-compat/subscription' ]).to.have.length(1);
+
+      expect(reports[ 'camunda-compat/user-task-form' ]).to.exist;
+      expect(reports[ 'camunda-compat/user-task-form' ]).to.have.length(2);
     });
 
   });

--- a/test/camunda-cloud/integration/camunda-cloud-1-2-invalid.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-1-2-invalid.bpmn
@@ -4,6 +4,9 @@
     <bpmn:participant id="Participant_1lhpzkq" processRef="Process_07pko08" />
   </bpmn:collaboration>
   <bpmn:process id="Process_07pko08" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:userTaskForm id="userTaskForm_35gi9j6"></zeebe:userTaskForm>
+    </bpmn:extensionElements>
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1c9prry</bpmn:outgoing>
       <bpmn:outgoing>Flow_00dv1kp</bpmn:outgoing>
@@ -59,8 +62,12 @@
       <bpmn:outgoing>Flow_0k2v5e1</bpmn:outgoing>
     </bpmn:receiveTask>
     <bpmn:userTask id="Activity_18h7yic">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formKey="camunda-forms:bpmn:userTaskForm_35gi9j6" />
+      </bpmn:extensionElements>
       <bpmn:incoming>Flow_0uqdyxp</bpmn:incoming>
       <bpmn:outgoing>Flow_1a5127t</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0ka813d</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:endEvent id="Event_195u06h">
       <bpmn:incoming>Flow_1a5127t</bpmn:incoming>
@@ -148,6 +155,13 @@
       <bpmn:incoming>Flow_0n84ml1</bpmn:incoming>
       <bpmn:messageEventDefinition id="MessageEventDefinition_04t0675" />
     </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0ka813d" sourceRef="Activity_18h7yic" targetRef="Activity_0lfznj6" />
+    <bpmn:userTask id="Activity_0lfznj6">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formKey="" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0ka813d</bpmn:incoming>
+    </bpmn:userTask>
     <bpmn:textAnnotation id="TextAnnotation_092byka">
       <bpmn:text>foo</bpmn:text>
     </bpmn:textAnnotation>
@@ -258,6 +272,10 @@
         <di:waypoint x="215" y="267" />
         <di:waypoint x="270" y="267" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ka813d_di" bpmnElement="Flow_0ka813d">
+        <di:waypoint x="1180" y="380" />
+        <di:waypoint x="1270" y="380" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="249" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -295,6 +313,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0gcrrhl_di" bpmnElement="Event_195u06h">
         <dc:Bounds x="1262" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0s4okhk_di" bpmnElement="Activity_0lfznj6">
+        <dc:Bounds x="1270" y="340" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_09495yf_di" bpmnElement="Activity_09495yf" isExpanded="true">
         <dc:Bounds x="1280" y="167" width="350" height="200" />

--- a/test/camunda-cloud/integration/camunda-cloud-1-2.spec.js
+++ b/test/camunda-cloud/integration/camunda-cloud-1-2.spec.js
@@ -127,6 +127,9 @@ describe('integration - camunda-cloud-1-2', function() {
 
       expect(reports[ 'camunda-compat/subscription' ]).to.exist;
       expect(reports[ 'camunda-compat/subscription' ]).to.have.length(1);
+
+      expect(reports[ 'camunda-compat/user-task-form' ]).to.exist;
+      expect(reports[ 'camunda-compat/user-task-form' ]).to.have.length(2);
     });
 
   });

--- a/test/camunda-cloud/integration/camunda-cloud-1-3-invalid.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-1-3-invalid.bpmn
@@ -4,6 +4,9 @@
     <bpmn:participant id="Participant_1lhpzkq" processRef="Process_07pko08" />
   </bpmn:collaboration>
   <bpmn:process id="Process_07pko08" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:userTaskForm id="userTaskForm_0irlo3i"></zeebe:userTaskForm>
+    </bpmn:extensionElements>
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1c9prry</bpmn:outgoing>
       <bpmn:outgoing>Flow_00dv1kp</bpmn:outgoing>
@@ -59,8 +62,12 @@
       <bpmn:outgoing>Flow_0k2v5e1</bpmn:outgoing>
     </bpmn:receiveTask>
     <bpmn:userTask id="Activity_18h7yic">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formKey="camunda-forms:bpmn:userTaskForm_0irlo3i" />
+      </bpmn:extensionElements>
       <bpmn:incoming>Flow_0uqdyxp</bpmn:incoming>
       <bpmn:outgoing>Flow_1a5127t</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0196u99</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:endEvent id="Event_195u06h">
       <bpmn:incoming>Flow_1a5127t</bpmn:incoming>
@@ -146,6 +153,13 @@
       <bpmn:incoming>Flow_0n84ml1</bpmn:incoming>
       <bpmn:messageEventDefinition id="MessageEventDefinition_04t0675" />
     </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0196u99" sourceRef="Activity_18h7yic" targetRef="Activity_1xughen" />
+    <bpmn:userTask id="Activity_1xughen">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formKey="" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0196u99</bpmn:incoming>
+    </bpmn:userTask>
     <bpmn:textAnnotation id="TextAnnotation_092byka">
       <bpmn:text>foo</bpmn:text>
     </bpmn:textAnnotation>
@@ -256,6 +270,10 @@
         <di:waypoint x="215" y="267" />
         <di:waypoint x="270" y="267" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0196u99_di" bpmnElement="Flow_0196u99">
+        <di:waypoint x="1180" y="380" />
+        <di:waypoint x="1270" y="380" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="249" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -293,6 +311,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0gcrrhl_di" bpmnElement="Event_195u06h">
         <dc:Bounds x="1262" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0l5qeoe_di" bpmnElement="Activity_1xughen">
+        <dc:Bounds x="1270" y="340" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_09495yf_di" bpmnElement="Activity_09495yf" isExpanded="true">
         <dc:Bounds x="1280" y="167" width="350" height="200" />

--- a/test/camunda-cloud/integration/camunda-cloud-1-3.spec.js
+++ b/test/camunda-cloud/integration/camunda-cloud-1-3.spec.js
@@ -153,6 +153,9 @@ describe('integration - camunda-cloud-1-3', function() {
 
       expect(reports[ 'camunda-compat/subscription' ]).to.exist;
       expect(reports[ 'camunda-compat/subscription' ]).to.have.length(1);
+
+      expect(reports[ 'camunda-compat/user-task-form' ]).to.exist;
+      expect(reports[ 'camunda-compat/user-task-form' ]).to.have.length(2);
     });
 
   });

--- a/test/camunda-cloud/integration/camunda-cloud-8-0-invalid.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-8-0-invalid.bpmn
@@ -4,6 +4,9 @@
     <bpmn:participant id="Participant_1lhpzkq" processRef="Process_07pko08" />
   </bpmn:collaboration>
   <bpmn:process id="Process_07pko08" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:userTaskForm id="userTaskForm_2nls4jr"></zeebe:userTaskForm>
+    </bpmn:extensionElements>
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1c9prry</bpmn:outgoing>
       <bpmn:outgoing>Flow_00dv1kp</bpmn:outgoing>
@@ -59,8 +62,12 @@
       <bpmn:outgoing>Flow_0k2v5e1</bpmn:outgoing>
     </bpmn:receiveTask>
     <bpmn:userTask id="Activity_18h7yic">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formKey="camunda-forms:bpmn:userTaskForm_2nls4jr" />
+      </bpmn:extensionElements>
       <bpmn:incoming>Flow_0uqdyxp</bpmn:incoming>
       <bpmn:outgoing>Flow_1a5127t</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0sw5u2l</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:endEvent id="Event_195u06h">
       <bpmn:incoming>Flow_1a5127t</bpmn:incoming>
@@ -146,6 +153,13 @@
       <bpmn:incoming>Flow_0n84ml1</bpmn:incoming>
       <bpmn:messageEventDefinition id="MessageEventDefinition_04t0675" />
     </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0sw5u2l" sourceRef="Activity_18h7yic" targetRef="Activity_08oewfm" />
+    <bpmn:userTask id="Activity_08oewfm">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formKey="" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0sw5u2l</bpmn:incoming>
+    </bpmn:userTask>
     <bpmn:textAnnotation id="TextAnnotation_092byka">
       <bpmn:text>foo</bpmn:text>
     </bpmn:textAnnotation>
@@ -256,6 +270,10 @@
         <di:waypoint x="215" y="267" />
         <di:waypoint x="270" y="267" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0sw5u2l_di" bpmnElement="Flow_0sw5u2l">
+        <di:waypoint x="1180" y="380" />
+        <di:waypoint x="1270" y="380" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="249" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -293,6 +311,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0gcrrhl_di" bpmnElement="Event_195u06h">
         <dc:Bounds x="1262" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1km6ix6_di" bpmnElement="Activity_08oewfm">
+        <dc:Bounds x="1270" y="340" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_09495yf_di" bpmnElement="Activity_09495yf" isExpanded="true">
         <dc:Bounds x="1280" y="167" width="350" height="200" />

--- a/test/camunda-cloud/integration/camunda-cloud-8-0.spec.js
+++ b/test/camunda-cloud/integration/camunda-cloud-8-0.spec.js
@@ -176,6 +176,9 @@ describe('integration - camunda-cloud-8-0', function() {
 
       expect(reports[ 'camunda-compat/subscription' ]).to.exist;
       expect(reports[ 'camunda-compat/subscription' ]).to.have.length(1);
+
+      expect(reports[ 'camunda-compat/user-task-form' ]).to.exist;
+      expect(reports[ 'camunda-compat/user-task-form' ]).to.have.length(2);
     });
 
   });

--- a/test/camunda-cloud/user-task-form.spec.js
+++ b/test/camunda-cloud/user-task-form.spec.js
@@ -1,0 +1,97 @@
+const RuleTester = require('bpmnlint/lib/testers/rule-tester');
+
+const rule = require('../../rules/user-task-form');
+
+const {
+  createModdle,
+  createProcess
+} = require('../helper');
+
+const { ERROR_TYPES } = require('../../rules/utils/element');
+
+const valid = [
+  {
+    name: 'user task (user task form)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:extensionElements>
+        <zeebe:userTaskForm id="userTaskForm_1">{}</zeebe:userTaskForm>
+      </bpmn:extensionElements>
+      <bpmn:userTask id="UserTask_1">
+        <bpmn:extensionElements>
+          <zeebe:formDefinition formKey="camunda-forms:bpmn:userTaskForm_1" />
+        </bpmn:extensionElements>
+      </bpmn:userTask>
+    `))
+  },
+  {
+    name: 'user task',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:userTask id="UserTask_1" />
+    `))
+  }
+];
+
+const invalid = [
+  {
+    name: 'user task (no form key)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:userTask id="UserTask_1">
+        <bpmn:extensionElements>
+          <zeebe:formDefinition />
+        </bpmn:extensionElements>
+      </bpmn:userTask>
+    `)),
+    report: {
+      id: 'UserTask_1',
+      message: 'Element of type <zeebe:FormDefinition> must have property <formKey>',
+      path: [
+        'extensionElements',
+        'values',
+        0,
+        'formKey'
+      ],
+      error: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'zeebe:FormDefinition',
+        parentNode: 'UserTask_1',
+        requiredProperty: 'formKey'
+      }
+    }
+  },
+  {
+    name: 'user task (empty user task form)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:extensionElements>
+        <zeebe:userTaskForm id="userTaskForm_1"></zeebe:userTaskForm>
+      </bpmn:extensionElements>
+      <bpmn:userTask id="UserTask_1">
+        <bpmn:extensionElements>
+          <zeebe:formDefinition formKey="camunda-forms:bpmn:userTaskForm_1" />
+        </bpmn:extensionElements>
+      </bpmn:userTask>
+    `)),
+    report: {
+      id: 'UserTask_1',
+      message: 'Element of type <zeebe:UserTaskForm> must have property <body>',
+      path: [
+        'rootElements',
+        0,
+        'extensionElements',
+        'values',
+        0,
+        'body'
+      ],
+      error: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'zeebe:UserTaskForm',
+        parentNode: 'UserTask_1',
+        requiredProperty: 'body'
+      }
+    }
+  }
+];
+
+RuleTester.verify('user-task-form', rule, {
+  valid,
+  invalid
+});

--- a/test/configs.spec.js
+++ b/test/configs.spec.js
@@ -12,7 +12,8 @@ describe('configs', function() {
     'loop-characteristics': 'error',
     'message-reference': 'error',
     'no-template': 'error',
-    'subscription': 'error'
+    'subscription': 'error',
+    'user-task-form': 'error'
   }));
 
 
@@ -24,7 +25,8 @@ describe('configs', function() {
     'loop-characteristics': 'error',
     'message-reference': 'error',
     'no-template': 'error',
-    'subscription': 'error'
+    'subscription': 'error',
+    'user-task-form': 'error'
   }));
 
 
@@ -36,7 +38,8 @@ describe('configs', function() {
     'loop-characteristics': 'error',
     'message-reference': 'error',
     'no-template': 'error',
-    'subscription': 'error'
+    'subscription': 'error',
+    'user-task-form': 'error'
   }));
 
 
@@ -48,7 +51,8 @@ describe('configs', function() {
     'loop-characteristics': 'error',
     'message-reference': 'error',
     'no-template': 'error',
-    'subscription': 'error'
+    'subscription': 'error',
+    'user-task-form': 'error'
   }));
 
 
@@ -59,7 +63,8 @@ describe('configs', function() {
     'error-reference': 'error',
     'loop-characteristics': 'error',
     'message-reference': 'error',
-    'subscription': 'error'
+    'subscription': 'error',
+    'user-task-form': 'error'
   }));
 
 });


### PR DESCRIPTION
This rule ensures that

* `zeebe:FormDefinition` elements have a `zeebe:formKey` property
* `zeebe:UserTaskForm` elements are not empty

---

Related to https://github.com/bpmn-io/internal-docs/issues/532