### PR TITLE
fix: lint subscription only if start event child of sub process

### DIFF
--- a/rules/has-subscription.js
+++ b/rules/has-subscription.js
@@ -14,7 +14,8 @@ const { reportErrors } = require('./utils/reporter');
 
 module.exports = function() {
   function check(node, reporter) {
-    if (!isAny(node, [ 'bpmn:CatchEvent', 'bpmn:ThrowEvent', 'bpmn:ReceiveTask' ])) {
+    if (!isAny(node, [ 'bpmn:CatchEvent', 'bpmn:ThrowEvent', 'bpmn:ReceiveTask' ])
+      || (is(node, 'bpmn:StartEvent') && !is(node.$parent, 'bpmn:SubProcess'))) {
       return;
     }
 

--- a/test/camunda-cloud/has-subscription.spec.js
+++ b/test/camunda-cloud/has-subscription.spec.js
@@ -19,6 +19,19 @@ const valid = [
           <bpmn:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_1" />
         </bpmn:startEvent>
       </bpmn:process>
+      <bpmn:message id="Message_1" name="Message_1" />
+    `))
+  },
+  {
+    name: 'start event (event sub process)',
+    moddleElement: createModdle(createDefinitions(`
+      <bpmn:process id="Process_1">
+        <bpmn:subProcess id="SubProcess_1" triggeredByEvent="true">
+          <bpmn:startEvent id="StartEvent_1" isInterrupting="false">
+            <bpmn:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_1" />
+          </bpmn:startEvent>
+        </bpmn:subProcess>
+      </bpmn:process>
       <bpmn:message id="Message_1" name="Message_1">
         <bpmn:extensionElements>
           <zeebe:subscription correlationKey="foo" />
@@ -62,9 +75,11 @@ const invalid = [
     name: 'message start event (no subscription)',
     moddleElement: createModdle(createDefinitions(`
       <bpmn:process id="Process_1">
-        <bpmn:startEvent id="StartEvent_1">
-          <bpmn:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_1" />
-        </bpmn:startEvent>
+        <bpmn:subProcess id="SubProcess_1" triggeredByEvent="true">
+          <bpmn:startEvent id="StartEvent_1" isInterrupting="false">
+            <bpmn:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_1" />
+          </bpmn:startEvent>
+        </bpmn:subProcess>
       </bpmn:process>
       <bpmn:message id="Message_1" name="Message_1" />
     `)),
@@ -87,9 +102,11 @@ const invalid = [
     name: 'message start event (no correlation key)',
     moddleElement: createModdle(createDefinitions(`
       <bpmn:process id="Process_1">
-        <bpmn:startEvent id="StartEvent_1">
-          <bpmn:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_1" />
-        </bpmn:startEvent>
+        <bpmn:subProcess id="SubProcess_1" triggeredByEvent="true">
+          <bpmn:startEvent id="StartEvent_1" isInterrupting="false">
+            <bpmn:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_1" />
+          </bpmn:startEvent>
+        </bpmn:subProcess>
       </bpmn:process>
       <bpmn:message id="Message_1" name="Message_1">
         <bpmn:extensionElements>


### PR DESCRIPTION
Message start events only need a `zeebe:Subscription` extension element with a `zeebe:correlationKey` property if they are children of an event sub process. The Zeebe engine validates that correctly (cf. https://github.com/camunda/zeebe/blob/1.3.0/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/MessageValidator.java#L49).

---

Related to https://github.com/camunda/camunda-modeler/issues/2983