### PR TITLE
feat(rules): add `duplicate-task-headers` rule

### DIFF
--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -345,3 +345,48 @@ const ERROR_TYPES = {
   }
 }
 ```
+
+## ❌ Property Value Duplicated Error
+
+### Type Definition
+
+```js
+/**
+ * @typedef PropertyValueDuplicatedError
+ *
+ * @type {Object}
+ *
+ * @property {string} id
+ * @property {(number|string)[]|null} path
+ * @property {Object} error
+ * @property {ERROR_TYPES} error.type
+ * @property {import('moddle/lib/base')} error.node
+ * @property {import('moddle/lib/base')|null} error.parentNode
+ * @property {string} error.duplicatedProperty
+ * @property {string} error.duplicatedPropertyValue
+ * @property {import('moddle/lib/base')[]} error.properties
+ * @property {string} error.propertiesName
+ */
+```
+
+### Example
+
+```js
+{
+  id: 'ServiceTask_1',
+  message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <foo>',
+  path: null,
+  error: {
+    type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
+    node: Base { $type: 'zeebe:TaskHeaders', ... },
+    parentNode: Base { $type: 'zeebe:ServiceTask', ... },
+    duplicatedProperty: 'key',
+    duplicatedPropertyValue: 'foo',
+    properties: [
+      Base { $type: 'zeebe:Header', ... },
+      Base { $type: 'zeebe:Header', ... }
+    ],
+    propertiesName: 'values'
+  }
+}
+```

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports = {
       rules: {
         'called-decision-or-task-definition': [ 'error', calledDecisionOrTaskDefinitionConfig.camundaCloud10 ],
         'called-element': 'error',
+        'duplicate-task-headers': 'error',
         'element-type': [ 'error', elementTypeConfig.camundaCloud10 ],
         'error-reference': 'error',
         'loop-characteristics': 'error',
@@ -20,6 +21,7 @@ module.exports = {
       rules: {
         'called-decision-or-task-definition': [ 'error', calledDecisionOrTaskDefinitionConfig.camundaCloud11 ],
         'called-element': 'error',
+        'duplicate-task-headers': 'error',
         'element-type': [ 'error', elementTypeConfig.camundaCloud11 ],
         'error-reference': 'error',
         'loop-characteristics': 'error',
@@ -33,6 +35,7 @@ module.exports = {
       rules: {
         'called-decision-or-task-definition': [ 'error', calledDecisionOrTaskDefinitionConfig.camundaCloud12 ],
         'called-element': 'error',
+        'duplicate-task-headers': 'error',
         'element-type': [ 'error', elementTypeConfig.camundaCloud12 ],
         'error-reference': 'error',
         'loop-characteristics': 'error',
@@ -46,6 +49,7 @@ module.exports = {
       rules: {
         'called-decision-or-task-definition': [ 'error', calledDecisionOrTaskDefinitionConfig.camundaCloud13 ],
         'called-element': 'error',
+        'duplicate-task-headers': 'error',
         'element-type': [ 'error', elementTypeConfig.camundaCloud12 ],
         'error-reference': 'error',
         'loop-characteristics': 'error',
@@ -59,6 +63,7 @@ module.exports = {
       rules: {
         'called-decision-or-task-definition': [ 'error', calledDecisionOrTaskDefinitionConfig.camundaCloud13 ],
         'called-element': 'error',
+        'duplicate-task-headers': 'error',
         'element-type': [ 'error', elementTypeConfig.camundaCloud12 ],
         'error-reference': 'error',
         'loop-characteristics': 'error',

--- a/rules/duplicate-task-headers.js
+++ b/rules/duplicate-task-headers.js
@@ -1,0 +1,57 @@
+const {
+  is,
+  isAny
+} = require('bpmnlint-utils');
+
+const {
+  findExtensionElement,
+  getMessageEventDefinition,
+  hasDuplicatedPropertyValues
+} = require('./utils/element');
+
+const { reportErrors } = require('./utils/reporter');
+
+module.exports = function() {
+  function check(node, reporter) {
+    if (!is(node, 'bpmn:UserTask') && !isZeebeServiceTask(node)) {
+      return;
+    }
+
+    const taskHeaders = findExtensionElement(node, 'zeebe:TaskHeaders');
+
+    if (!taskHeaders) {
+      return;
+    }
+
+    const errors = hasDuplicatedPropertyValues(taskHeaders, 'values', 'key', node);
+
+    if (errors && errors.length) {
+      reportErrors(node, reporter, errors);
+    }
+  }
+
+  return {
+    check
+  };
+};
+
+// helpers //////////
+
+function isZeebeServiceTask(element) {
+  if (is(element, 'zeebe:ZeebeServiceTask')) {
+    return true;
+  }
+
+  if (isAny(element, [
+    'bpmn:EndEvent',
+    'bpmn:IntermediateThrowEvent'
+  ])) {
+    return getMessageEventDefinition(element);
+  }
+
+  if (is(element, 'bpmn:BusinessRuleTask')) {
+    return findExtensionElement(element, 'zeebe:TaskDefinition');
+  }
+
+  return false;
+}

--- a/rules/user-task-form.js
+++ b/rules/user-task-form.js
@@ -56,6 +56,8 @@ module.exports = function() {
   };
 };
 
+// helpers //////////
+
 function findUserTaskForm(node, formKey) {
   const process = findParent(node, 'bpmn:Process');
 

--- a/rules/utils/element.js
+++ b/rules/utils/element.js
@@ -5,7 +5,10 @@ const {
   some
 } = require('min-dash');
 
-const { isAny } = require('bpmnlint-utils');
+const {
+  is,
+  isAny
+} = require('bpmnlint-utils');
 
 const { getPath } = require('@bpmn-io/moddle-utils');
 
@@ -13,12 +16,22 @@ const { ERROR_TYPES } = require('./error-types');
 
 module.exports.ERROR_TYPES = ERROR_TYPES;
 
-module.exports.getEventDefinition = function(node) {
+function getEventDefinition(node) {
   const eventDefinitions = node.get('eventDefinitions');
 
   if (eventDefinitions) {
     return eventDefinitions[ 0 ];
   }
+}
+
+module.exports.getEventDefinition = getEventDefinition;
+
+module.exports.getMessageEventDefinition = function(node) {
+  if (is(node, 'bpmn:ReceiveTask')) {
+    return node;
+  }
+
+  return getEventDefinition(node);
 };
 
 function findExtensionElements(node, types) {

--- a/rules/utils/error-types.js
+++ b/rules/utils/error-types.js
@@ -5,5 +5,6 @@ module.exports.ERROR_TYPES = Object.freeze({
   PROPERTY_DEPENDEND_REQUIRED: 'propertyDependendRequired',
   PROPERTY_NOT_ALLOWED: 'propertyNotAllowed',
   PROPERTY_REQUIRED: 'propertyRequired',
-  PROPERTY_TYPE_NOT_ALLOWED: 'propertyTypeNotAllowed'
+  PROPERTY_TYPE_NOT_ALLOWED: 'propertyTypeNotAllowed',
+  PROPERTY_VALUE_DUPLICATED: 'propertyValueDuplicated'
 });

--- a/test/camunda-cloud/duplicate-task-headers.spec.js
+++ b/test/camunda-cloud/duplicate-task-headers.spec.js
@@ -1,0 +1,398 @@
+const RuleTester = require('bpmnlint/lib/testers/rule-tester');
+
+const rule = require('../../rules/duplicate-task-headers');
+
+const {
+  createModdle,
+  createProcess
+} = require('../helper');
+
+const { ERROR_TYPES } = require('../../rules/utils/element');
+
+const valid = [
+  {
+    name: 'service task',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:serviceTask id="ServiceTask_1">
+        <bpmn:extensionElements>
+          <zeebe:taskHeaders>
+            <zeebe:header key="key1" />
+            <zeebe:header key="key2" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    `))
+  },
+  {
+    name: 'send task',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:sendTask id="SendTask_1">
+        <bpmn:extensionElements>
+          <zeebe:taskHeaders>
+            <zeebe:header key="key1" />
+            <zeebe:header key="key2" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+      </bpmn:sendTask>
+    `))
+  },
+  {
+    name: 'user task',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:userTask id="UserTask_1">
+        <bpmn:extensionElements>
+          <zeebe:taskHeaders>
+            <zeebe:header key="key1" />
+            <zeebe:header key="key2" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+      </bpmn:userTask>
+    `))
+  },
+  {
+    name: 'business rule task',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:businessRuleTask id="BusinessRuleTask_1">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+          <zeebe:taskHeaders>
+            <zeebe:header key="key1" />
+            <zeebe:header key="key2" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+      </bpmn:businessRuleTask>
+    `))
+  },
+  {
+    name: 'script task',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:scriptTask id="ScriptTask_1">
+        <bpmn:extensionElements>
+          <zeebe:taskHeaders>
+            <zeebe:header key="key1" />
+            <zeebe:header key="key2" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+    `))
+  },
+  {
+    name: 'message throw event',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:intermediateThrowEvent id="MessageEvent_1">
+        <bpmn:messageEventDefinition id="MessageEventDefinition_1" />
+        <bpmn:extensionElements>
+          <zeebe:taskHeaders>
+            <zeebe:header key="key1" />
+            <zeebe:header key="key2" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+      </bpmn:intermediateThrowEvent>
+    `))
+  }
+];
+
+const invalid = [
+  {
+    name: 'service task',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:serviceTask id="ServiceTask_1">
+        <bpmn:extensionElements>
+          <zeebe:taskHeaders>
+            <zeebe:header key="foo" />
+            <zeebe:header key="foo" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    `)),
+    report: {
+      id: 'ServiceTask_1',
+      message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <foo>',
+      path: null,
+      error: {
+        type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
+        node: 'zeebe:TaskHeaders',
+        parentNode: 'ServiceTask_1',
+        duplicatedProperty: 'key',
+        duplicatedPropertyValue: 'foo',
+        properties: [
+          'zeebe:Header',
+          'zeebe:Header'
+        ],
+        propertiesName: 'values'
+      }
+    }
+  },
+  {
+    name: 'service task (multiple duplicates)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:serviceTask id="ServiceTask_1">
+        <bpmn:extensionElements>
+          <zeebe:taskHeaders>
+            <zeebe:header key="foo" />
+            <zeebe:header key="foo" />
+            <zeebe:header key="foo" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    `)),
+    report: [
+      {
+        id: 'ServiceTask_1',
+        message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <foo>',
+        path: null,
+        error: {
+          type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
+          node: 'zeebe:TaskHeaders',
+          parentNode: 'ServiceTask_1',
+          duplicatedProperty: 'key',
+          duplicatedPropertyValue: 'foo',
+          properties: [
+            'zeebe:Header',
+            'zeebe:Header',
+            'zeebe:Header'
+          ],
+          propertiesName: 'values'
+        }
+      }
+    ]
+  },
+  {
+    name: 'service task (multiple duplicates)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:serviceTask id="ServiceTask_1">
+        <bpmn:extensionElements>
+          <zeebe:taskHeaders>
+            <zeebe:header key="foo" />
+            <zeebe:header key="foo" />
+            <zeebe:header key="bar" />
+            <zeebe:header key="bar" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    `)),
+    report: [
+      {
+        id: 'ServiceTask_1',
+        message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <foo>',
+        path: null,
+        error: {
+          type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
+          node: 'zeebe:TaskHeaders',
+          parentNode: 'ServiceTask_1',
+          duplicatedProperty: 'key',
+          duplicatedPropertyValue: 'foo',
+          properties: [
+            'zeebe:Header',
+            'zeebe:Header'
+          ],
+          propertiesName: 'values'
+        }
+      },
+      {
+        id: 'ServiceTask_1',
+        message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <bar>',
+        path: null,
+        error: {
+          type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
+          node: 'zeebe:TaskHeaders',
+          parentNode: 'ServiceTask_1',
+          duplicatedProperty: 'key',
+          duplicatedPropertyValue: 'bar',
+          properties: [
+            'zeebe:Header',
+            'zeebe:Header'
+          ],
+          propertiesName: 'values'
+        }
+      }
+    ]
+  },
+  {
+    name: 'service task (no key)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:serviceTask id="ServiceTask_1">
+        <bpmn:extensionElements>
+          <zeebe:taskHeaders>
+            <zeebe:header />
+            <zeebe:header />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    `)),
+    report: {
+      id: 'ServiceTask_1',
+      message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <undefined>',
+      path: null,
+      error: {
+        type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
+        node: 'zeebe:TaskHeaders',
+        parentNode: 'ServiceTask_1',
+        duplicatedProperty: 'key',
+        duplicatedPropertyValue: undefined,
+        properties: [
+          'zeebe:Header',
+          'zeebe:Header'
+        ],
+        propertiesName: 'values'
+      }
+    }
+  },
+  {
+    name: 'send task',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:sendTask id="SendTask_1">
+        <bpmn:extensionElements>
+          <zeebe:taskHeaders>
+            <zeebe:header key="foo" />
+            <zeebe:header key="foo" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+      </bpmn:sendTask>
+    `)),
+    report: {
+      id: 'SendTask_1',
+      message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <foo>',
+      path: null,
+      error: {
+        type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
+        node: 'zeebe:TaskHeaders',
+        parentNode: 'SendTask_1',
+        duplicatedProperty: 'key',
+        duplicatedPropertyValue: 'foo',
+        properties: [
+          'zeebe:Header',
+          'zeebe:Header'
+        ],
+        propertiesName: 'values'
+      }
+    }
+  },
+  {
+    name: 'user task',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:userTask id="UserTask_1">
+        <bpmn:extensionElements>
+          <zeebe:taskHeaders>
+            <zeebe:header key="foo" />
+            <zeebe:header key="foo" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+      </bpmn:userTask>
+    `)),
+    report: {
+      id: 'UserTask_1',
+      message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <foo>',
+      path: null,
+      error: {
+        type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
+        node: 'zeebe:TaskHeaders',
+        parentNode: 'UserTask_1',
+        duplicatedProperty: 'key',
+        duplicatedPropertyValue: 'foo',
+        properties: [
+          'zeebe:Header',
+          'zeebe:Header'
+        ],
+        propertiesName: 'values'
+      }
+    }
+  },
+  {
+    name: 'business rule task',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:businessRuleTask id="BusinessRuleTask_1">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+          <zeebe:taskHeaders>
+            <zeebe:header key="foo" />
+            <zeebe:header key="foo" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+      </bpmn:businessRuleTask>
+    `)),
+    report: {
+      id: 'BusinessRuleTask_1',
+      message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <foo>',
+      path: null,
+      error: {
+        type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
+        node: 'zeebe:TaskHeaders',
+        parentNode: 'BusinessRuleTask_1',
+        duplicatedProperty: 'key',
+        duplicatedPropertyValue: 'foo',
+        properties: [
+          'zeebe:Header',
+          'zeebe:Header'
+        ],
+        propertiesName: 'values'
+      }
+    }
+  },
+  {
+    name: 'script task',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:scriptTask id="ScriptTask_1">
+        <bpmn:extensionElements>
+          <zeebe:taskHeaders>
+            <zeebe:header key="foo" />
+            <zeebe:header key="foo" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+    `)),
+    report: {
+      id: 'ScriptTask_1',
+      message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <foo>',
+      path: null,
+      error: {
+        type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
+        node: 'zeebe:TaskHeaders',
+        parentNode: 'ScriptTask_1',
+        duplicatedProperty: 'key',
+        duplicatedPropertyValue: 'foo',
+        properties: [
+          'zeebe:Header',
+          'zeebe:Header'
+        ],
+        propertiesName: 'values'
+      }
+    }
+  },
+  {
+    name: 'message throw event',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:intermediateThrowEvent id="MessageEvent_1">
+        <bpmn:messageEventDefinition id="MessageEventDefinition_1" />
+        <bpmn:extensionElements>
+          <zeebe:taskHeaders>
+            <zeebe:header key="foo" />
+            <zeebe:header key="foo" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+      </bpmn:intermediateThrowEvent>
+    `)),
+    report: {
+      id: 'MessageEvent_1',
+      message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <foo>',
+      path: null,
+      error: {
+        type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
+        node: 'zeebe:TaskHeaders',
+        parentNode: 'MessageEvent_1',
+        duplicatedProperty: 'key',
+        duplicatedPropertyValue: 'foo',
+        properties: [
+          'zeebe:Header',
+          'zeebe:Header'
+        ],
+        propertiesName: 'values'
+      }
+    }
+  }
+];
+
+RuleTester.verify('task-headers', rule, {
+  valid,
+  invalid
+});

--- a/test/configs.spec.js
+++ b/test/configs.spec.js
@@ -7,6 +7,7 @@ describe('configs', function() {
   it('camunda-cloud-1-0', expectRules(configs, 'camunda-cloud-1-0', {
     'called-decision-or-task-definition': 'error',
     'called-element': 'error',
+    'duplicate-task-headers': 'error',
     'element-type': 'error',
     'error-reference': 'error',
     'loop-characteristics': 'error',
@@ -20,6 +21,7 @@ describe('configs', function() {
   it('camunda-cloud-1-1', expectRules(configs, 'camunda-cloud-1-1', {
     'called-decision-or-task-definition': 'error',
     'called-element': 'error',
+    'duplicate-task-headers': 'error',
     'element-type': 'error',
     'error-reference': 'error',
     'loop-characteristics': 'error',
@@ -33,6 +35,7 @@ describe('configs', function() {
   it('camunda-cloud-1-2', expectRules(configs, 'camunda-cloud-1-2', {
     'called-decision-or-task-definition': 'error',
     'called-element': 'error',
+    'duplicate-task-headers': 'error',
     'element-type': 'error',
     'error-reference': 'error',
     'loop-characteristics': 'error',
@@ -46,6 +49,7 @@ describe('configs', function() {
   it('camunda-cloud-1-3', expectRules(configs, 'camunda-cloud-1-3', {
     'called-decision-or-task-definition': 'error',
     'called-element': 'error',
+    'duplicate-task-headers': 'error',
     'element-type': 'error',
     'error-reference': 'error',
     'loop-characteristics': 'error',
@@ -59,6 +63,7 @@ describe('configs', function() {
   it('camunda-cloud-8-0', expectRules(configs, 'camunda-cloud-8-0', {
     'called-decision-or-task-definition': 'error',
     'called-element': 'error',
+    'duplicate-task-headers': 'error',
     'element-type': 'error',
     'error-reference': 'error',
     'loop-characteristics': 'error',

--- a/test/utils/element.spec.js
+++ b/test/utils/element.spec.js
@@ -3,6 +3,7 @@ const { expect } = require('chai');
 const {
   ERROR_TYPES,
   formatTypes,
+  hasDuplicatedPropertyValues,
   hasExtensionElementOfType,
   hasExtensionElementsOfTypes,
   hasProperties,
@@ -281,6 +282,138 @@ describe('utils/element', function() {
           }
         }
       ]);
+    });
+
+  });
+
+
+  describe('#hasDuplicatedPropertyValues', function() {
+
+    it('should not return errors', function() {
+
+      // given
+      const taskHeaders = createElement('zeebe:TaskHeaders', {
+        values: [
+          createElement('zeebe:Header', {
+            key: 'foo'
+          }),
+          createElement('zeebe:Header', {
+            key: 'bar'
+          }),
+          createElement('zeebe:Header', {
+            key: 'baz'
+          })
+        ]
+      });
+
+      // when
+      const errors = hasDuplicatedPropertyValues(taskHeaders, 'values', 'key');
+
+      // then
+      expect(errors).to.be.empty;
+    });
+
+
+    it('should return error', function() {
+
+      // given
+      const taskHeaders = createElement('zeebe:TaskHeaders', {
+        values: [
+          createElement('zeebe:Header', {
+            key: 'foo'
+          }),
+          createElement('zeebe:Header', {
+            key: 'foo'
+          }),
+          createElement('zeebe:Header', {
+            key: 'bar'
+          }),
+          createElement('zeebe:Header', {
+            key: 'baz'
+          })
+        ]
+      });
+
+      // when
+      const errors = hasDuplicatedPropertyValues(taskHeaders, 'values', 'key');
+
+      // then
+      expect(errors).to.exist;
+      expect(errors).to.have.length(1);
+
+      expect(errors[ 0 ]).eql({
+        message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <foo>',
+        path: null,
+        error: {
+          type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
+          node: taskHeaders,
+          parentNode: null,
+          duplicatedProperty: 'key',
+          duplicatedPropertyValue: 'foo',
+          properties: taskHeaders.get('values').filter(header => header.get('key') === 'foo'),
+          propertiesName: 'values'
+        }
+      });
+    });
+
+
+    it('should return errors', function() {
+
+      // given
+      const taskHeaders = createElement('zeebe:TaskHeaders', {
+        values: [
+          createElement('zeebe:Header', {
+            key: 'foo'
+          }),
+          createElement('zeebe:Header', {
+            key: 'foo'
+          }),
+          createElement('zeebe:Header', {
+            key: 'bar'
+          }),
+          createElement('zeebe:Header', {
+            key: 'bar'
+          }),
+          createElement('zeebe:Header', {
+            key: 'baz'
+          })
+        ]
+      });
+
+      // when
+      const errors = hasDuplicatedPropertyValues(taskHeaders, 'values', 'key');
+
+      // then
+      expect(errors).to.exist;
+      expect(errors).to.have.length(2);
+
+      expect(errors[ 0 ]).eql({
+        message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <foo>',
+        path: null,
+        error: {
+          type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
+          node: taskHeaders,
+          parentNode: null,
+          duplicatedProperty: 'key',
+          duplicatedPropertyValue: 'foo',
+          properties: taskHeaders.get('values').filter(header => header.get('key') === 'foo'),
+          propertiesName: 'values'
+        }
+      });
+
+      expect(errors[ 1 ]).eql({
+        message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <bar>',
+        path: null,
+        error: {
+          type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
+          node: taskHeaders,
+          parentNode: null,
+          duplicatedProperty: 'key',
+          duplicatedPropertyValue: 'bar',
+          properties: taskHeaders.get('values').filter(header => header.get('key') === 'bar'),
+          propertiesName: 'values'
+        }
+      });
     });
 
   });


### PR DESCRIPTION
Related to https://github.com/camunda/linting/issues/4

Adds the `duplicate-task-headers` rule to check for duplicate `zeebe:Header` elements (by key).