### PR TITLE
Camunda 8 modeling only

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const calledDecisionOrTaskDefinitionConfig = require('./rules/called-decision-or
 const camundaCloud10Rules = {
   'called-decision-or-task-definition': [ 'error', calledDecisionOrTaskDefinitionConfig.camundaCloud10 ],
   'called-element': 'error',
+  'collapsed-subprocess': 'error',
   'duplicate-task-headers': 'error',
   'element-type': [ 'error', elementTypeConfig.camundaCloud10 ],
   'error-reference': 'error',

--- a/rules/collapsed-subprocess.js
+++ b/rules/collapsed-subprocess.js
@@ -1,0 +1,38 @@
+const { is } = require('bpmnlint-utils');
+
+const { ERROR_TYPES } = require('./utils/element');
+
+const { reportErrors } = require('./utils/reporter');
+
+module.exports = function() {
+  function check(di, reporter) {
+
+    if (!isCollapsedSubProcess(di)) {
+      return;
+    }
+
+    const node = di.bpmnElement;
+
+    const error = {
+      message: `A <${ node.$type }> must be expanded.`,
+      error: {
+        type: ERROR_TYPES.ELEMENT_COLLAPSED_NOT_ALLOWED,
+        node: node,
+        parentNode: null
+      }
+    };
+
+    reportErrors(node, reporter, error);
+  }
+
+  return {
+    check
+  };
+};
+
+
+function isCollapsedSubProcess(di) {
+  return is(di, 'bpmndi:BPMNShape') &&
+         is(di.bpmnElement, 'bpmn:SubProcess') &&
+         di.get('isExpanded') === false;
+}

--- a/rules/utils/error-types.js
+++ b/rules/utils/error-types.js
@@ -1,5 +1,6 @@
 module.exports.ERROR_TYPES = Object.freeze({
   ELEMENT_TYPE_NOT_ALLOWED: 'elementTypeNotAllowed',
+  ELEMENT_COLLAPSED_NOT_ALLOWED: 'elementCollapsedNotAllowed',
   EXTENSION_ELEMENT_NOT_ALLOWED: 'extensionElementNotAllowed',
   EXTENSION_ELEMENT_REQUIRED: 'extensionElementRequired',
   PROPERTY_DEPENDEND_REQUIRED: 'propertyDependendRequired',

--- a/test/camunda-cloud/collapsed-subprocess.spec.js
+++ b/test/camunda-cloud/collapsed-subprocess.spec.js
@@ -46,14 +46,38 @@ const invalid = [
     `,
     `
     <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
-      <bpmndi:BPMNShape id="Activity_1ehskbd_di" bpmnElement="Activity_1ehskbd" isExpanded="false">
-        <dc:Bounds x="155" y="80" width="100" height="80" />
-      </bpmndi:BPMNShape>
-    </bpmndi:BPMNPlane>
+      <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+        <bpmndi:BPMNShape id="Activity_1ehskbd_di" bpmnElement="Activity_1ehskbd" isExpanded="false">
+          <dc:Bounds x="155" y="80" width="100" height="80" />
+        </bpmndi:BPMNShape>
+      </bpmndi:BPMNPlane>
     </bpmndi:BPMNDiagram>
     <bpmndi:BPMNDiagram id="BPMNDiagram_08bzev3">
         <bpmndi:BPMNPlane id="BPMNPlane_0brduj8" bpmnElement="Activity_1ehskbd" />
+    </bpmndi:BPMNDiagram>
+    `)),
+    report: {
+      id: 'Activity_1ehskbd',
+      message: 'A <bpmn:SubProcess> must be expanded.',
+      error: {
+        type: ERROR_TYPES.ELEMENT_COLLAPSED_NOT_ALLOWED,
+        node: 'Activity_1ehskbd',
+        parentNode: null
+      }
+    }
+  },
+  {
+    name: 'legacy collapsed Subprocess',
+    moddleElement: createModdle(createProcess(`
+    <bpmn:subProcess id="Activity_1ehskbd" />
+    `,
+    `
+    <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+      <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+        <bpmndi:BPMNShape id="Activity_1ehskbd_di" bpmnElement="Activity_1ehskbd" isExpanded="false">
+          <dc:Bounds x="155" y="80" width="100" height="80" />
+        </bpmndi:BPMNShape>
+      </bpmndi:BPMNPlane>
     </bpmndi:BPMNDiagram>
     `)),
     report: {

--- a/test/camunda-cloud/collapsed-subprocess.spec.js
+++ b/test/camunda-cloud/collapsed-subprocess.spec.js
@@ -1,0 +1,101 @@
+const RuleTester = require('bpmnlint/lib/testers/rule-tester');
+
+const rule = require('../../rules/collapsed-subprocess');
+
+const {
+  createModdle,
+  createProcess
+} = require('../helper');
+
+const { ERROR_TYPES } = require('../../rules/utils/element');
+
+const valid = [
+  {
+    name: 'Expanded Subprocess',
+    moddleElement: createModdle(createProcess(`
+    <bpmn:subProcess id="Activity_1ehskbd" />
+    `,
+    `
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+        <bpmndi:BPMNShape id="Activity_1ehskbd_di" bpmnElement="Activity_1ehskbd" isExpanded="true">
+        <dc:Bounds x="160" y="120" width="350" height="200" />
+        </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+    `))
+  },
+  {
+    name: 'Expanded adHocSubProcess',
+    moddleElement: createModdle(createProcess(`
+    <bpmn:adHocSubProcess id="Activity_1ehskbd" />
+    `,
+    `
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+        <bpmndi:BPMNShape id="Activity_1ehskbd_di" bpmnElement="Activity_1ehskbd" isExpanded="true">
+        <dc:Bounds x="160" y="120" width="350" height="200" />
+        </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+    `))
+  }
+];
+
+const invalid = [
+  {
+    name: 'Collapsed Subprocess',
+    moddleElement: createModdle(createProcess(`
+    <bpmn:subProcess id="Activity_1ehskbd" />
+    `,
+    `
+    <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_1ehskbd_di" bpmnElement="Activity_1ehskbd" isExpanded="false">
+        <dc:Bounds x="155" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+    <bpmndi:BPMNDiagram id="BPMNDiagram_08bzev3">
+        <bpmndi:BPMNPlane id="BPMNPlane_0brduj8" bpmnElement="Activity_1ehskbd" />
+    </bpmndi:BPMNDiagram>
+    `)),
+    report: {
+      id: 'Activity_1ehskbd',
+      message: 'A <bpmn:SubProcess> must be expanded.',
+      error: {
+        type: ERROR_TYPES.ELEMENT_COLLAPSED_NOT_ALLOWED,
+        node: 'Activity_1ehskbd',
+        parentNode: null
+      }
+    }
+  },
+  {
+    name: 'Collapsed adHocSubProcess',
+    moddleElement: createModdle(createProcess(`
+    <bpmn:adHocSubProcess id="Activity_1ehskbd" />
+    `,
+    `
+    <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_1ehskbd_di" bpmnElement="Activity_1ehskbd" isExpanded="false">
+        <dc:Bounds x="155" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+    <bpmndi:BPMNDiagram id="BPMNDiagram_08bzev3">
+        <bpmndi:BPMNPlane id="BPMNPlane_0brduj8" bpmnElement="Activity_1ehskbd" />
+    </bpmndi:BPMNDiagram>
+    `)),
+    report: {
+      id: 'Activity_1ehskbd',
+      message: 'A <bpmn:AdHocSubProcess> must be expanded.',
+      error: {
+        type: ERROR_TYPES.ELEMENT_COLLAPSED_NOT_ALLOWED,
+        node: 'Activity_1ehskbd',
+        parentNode: null
+      }
+    }
+  }
+];
+
+RuleTester.verify('subprocess', rule, {
+  valid,
+  invalid
+});

--- a/test/config/configs.spec.js
+++ b/test/config/configs.spec.js
@@ -7,6 +7,7 @@ describe('configs', function() {
   it('camunda-cloud-1-0', expectRules(configs, 'camunda-cloud-1-0', {
     'called-decision-or-task-definition': [ 'error', require('../../rules/called-decision-or-task-definition/config').camundaCloud10 ],
     'called-element': 'error',
+    'collapsed-subprocess': 'error',
     'duplicate-task-headers': 'error',
     'element-type': [ 'error', require('../../rules/element-type/config').camundaCloud10 ],
     'error-reference': 'error',
@@ -24,6 +25,7 @@ describe('configs', function() {
   it('camunda-cloud-1-1', expectRules(configs, 'camunda-cloud-1-1', {
     'called-decision-or-task-definition': [ 'error', require('../../rules/called-decision-or-task-definition/config').camundaCloud11 ],
     'called-element': 'error',
+    'collapsed-subprocess': 'error',
     'duplicate-task-headers': 'error',
     'element-type': [ 'error', require('../../rules/element-type/config').camundaCloud11 ],
     'error-reference': 'error',
@@ -41,6 +43,7 @@ describe('configs', function() {
   it('camunda-cloud-1-2', expectRules(configs, 'camunda-cloud-1-2', {
     'called-decision-or-task-definition': [ 'error', require('../../rules/called-decision-or-task-definition/config').camundaCloud12 ],
     'called-element': 'error',
+    'collapsed-subprocess': 'error',
     'duplicate-task-headers': 'error',
     'element-type': [ 'error', require('../../rules/element-type/config').camundaCloud12 ],
     'error-reference': 'error',
@@ -58,6 +61,7 @@ describe('configs', function() {
   it('camunda-cloud-1-3', expectRules(configs, 'camunda-cloud-1-3', {
     'called-decision-or-task-definition': [ 'error', require('../../rules/called-decision-or-task-definition/config').camundaCloud13 ],
     'called-element': 'error',
+    'collapsed-subprocess': 'error',
     'duplicate-task-headers': 'error',
     'element-type': [ 'error', require('../../rules/element-type/config').camundaCloud12 ],
     'error-reference': 'error',
@@ -75,6 +79,7 @@ describe('configs', function() {
   it('camunda-cloud-8-0', expectRules(configs, 'camunda-cloud-8-0', {
     'called-decision-or-task-definition': [ 'error', require('../../rules/called-decision-or-task-definition/config').camundaCloud13 ],
     'called-element': 'error',
+    'collapsed-subprocess': 'error',
     'duplicate-task-headers': 'error',
     'element-type': [ 'error', require('../../rules/element-type/config').camundaCloud12 ],
     'error-reference': 'error',
@@ -91,6 +96,7 @@ describe('configs', function() {
   it('camunda-cloud-8-1', expectRules(configs, 'camunda-cloud-8-1', {
     'called-decision-or-task-definition': [ 'error', require('../../rules/called-decision-or-task-definition/config').camundaCloud13 ],
     'called-element': 'error',
+    'collapsed-subprocess': 'error',
     'duplicate-task-headers': 'error',
     'element-type': [ 'error', require('../../rules/element-type/config').camundaCloud81 ],
     'error-reference': 'error',


### PR DESCRIPTION
This PR adds lint rules to support modeling of all elements in Camunda 8.x. ~~It also adds the none-task to the list of supported elements.~~

Undefined Task will be handled in a separate PR

Because we have a whitelist of supported elements, we only need to add collapsed subprocesses as unsupported.

downstream PR: https://github.com/camunda/linting/pull/33
closes https://github.com/camunda/bpmnlint-plugin-camunda-compat/issues/46