### PR TITLE
fix(subprocess): lint element without `isExpanded`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to [bpmnlint-plugin-camunda-compat](https://github.com/camun
 
 ___Note:__ Yet to be released changes appear here._
 
+## 0.14.1
+
+* `FIX`: lint subprocesses without `isExpanded` attribute ([#55](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/55))
+* `FIX`: correct typo in `FEEL_EXPRESSION_INVALID` message ([#55](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/55))
+
 ## 0.14.0
 
 * `FEAT`: add `feel` rule to validate feel expressions ([#51](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/51))

--- a/rules/collapsed-subprocess.js
+++ b/rules/collapsed-subprocess.js
@@ -34,5 +34,5 @@ module.exports = function() {
 function isCollapsedSubProcess(di) {
   return is(di, 'bpmndi:BPMNShape') &&
          is(di.bpmnElement, 'bpmn:SubProcess') &&
-         di.get('isExpanded') === false;
+         di.get('isExpanded') !== true;
 }

--- a/rules/feel.js
+++ b/rules/feel.js
@@ -38,7 +38,7 @@ module.exports = function() {
 
           errors.push(
             {
-              message: `Property <${ propertyName }> is not valid FEEL expression`,
+              message: `Property <${ propertyName }> is not a valid FEEL expression`,
               path: path
                 ? [ ...path, propertyName ]
                 : [ propertyName ],

--- a/test/camunda-cloud/collapsed-subprocess.spec.js
+++ b/test/camunda-cloud/collapsed-subprocess.spec.js
@@ -64,6 +64,32 @@ const invalid = [
     }
   },
   {
+    name: 'Collapsed Subprocess (no isExpanded attribute)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:subProcess id="SubProcess_1" />
+    `, `
+      <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+        <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+          <bpmndi:BPMNShape id="SubProcess_1_di" bpmnElement="SubProcess_1">
+            <dc:Bounds x="155" y="80" width="100" height="80" />
+          </bpmndi:BPMNShape>
+        </bpmndi:BPMNPlane>
+      </bpmndi:BPMNDiagram>
+      <bpmndi:BPMNDiagram id="BPMNDiagram_08bzev3">
+          <bpmndi:BPMNPlane id="BPMNPlane_0brduj8" bpmnElement="SubProcess_1" />
+      </bpmndi:BPMNDiagram>
+    `)),
+    report: {
+      id: 'SubProcess_1',
+      message: 'A <bpmn:SubProcess> must be expanded.',
+      data: {
+        type: ERROR_TYPES.ELEMENT_COLLAPSED_NOT_ALLOWED,
+        node: 'SubProcess_1',
+        parentNode: null
+      }
+    }
+  },
+  {
     name: 'legacy collapsed Subprocess',
     moddleElement: createModdle(createProcess(`
       <bpmn:subProcess id="SubProcess_1" />

--- a/test/camunda-cloud/feel.spec.js
+++ b/test/camunda-cloud/feel.spec.js
@@ -60,7 +60,7 @@ const invalid = [
     `)),
     report: {
       id: 'Task_1',
-      message: 'Property <source> is not valid FEEL expression',
+      message: 'Property <source> is not a valid FEEL expression',
       path: [
         'extensionElements',
         'values',
@@ -88,7 +88,7 @@ const invalid = [
     `)),
     report: {
       id: 'StartEvent_1',
-      message: 'Property <timeCycle> is not valid FEEL expression',
+      message: 'Property <timeCycle> is not a valid FEEL expression',
       path: [
         'eventDefinitions',
         0,


### PR DESCRIPTION
![electron_iGBkyEaBP8](https://user-images.githubusercontent.com/21984219/199927329-ade8f434-00bb-492e-acc1-da531cbe3095.gif)

...also fixes a typo in the FEEL message, while we're at it.