### PR TITLE
feat: add `sequence-flow-condition` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const camundaCloud10Rules = {
   'message-reference': 'error',
   'no-template': 'error',
   'no-zeebe-properties': 'error',
+  'sequence-flow-condition': 'error',
   'subscription': 'error',
   'timer': [ 'error', { version: '1.0' } ],
   'user-task-form': 'error',

--- a/rules/inclusive-gateway.js
+++ b/rules/inclusive-gateway.js
@@ -1,6 +1,6 @@
 const { is } = require('bpmnlint-utils');
 
-const { hasProperties, ERROR_TYPES } = require('./utils/element');
+const { ERROR_TYPES } = require('./utils/element');
 
 const { reportErrors } = require('./utils/reporter');
 
@@ -25,24 +25,6 @@ module.exports = function() {
       };
 
       reportErrors(node, reporter, error);
-    }
-
-    const outgoing = node.get('outgoing');
-
-    if (outgoing && outgoing.length > 1) {
-      for (let sequenceFlow of outgoing) {
-        if (node.get('default') !== sequenceFlow) {
-          const errors = hasProperties(sequenceFlow, {
-            conditionExpression: {
-              required: true
-            }
-          }, sequenceFlow);
-
-          if (errors.length) {
-            reportErrors(sequenceFlow, reporter, errors);
-          }
-        }
-      }
     }
   }
 

--- a/rules/sequence-flow-condition.js
+++ b/rules/sequence-flow-condition.js
@@ -1,0 +1,35 @@
+const { isAny } = require('bpmnlint-utils');
+
+const { hasProperties } = require('./utils/element');
+
+const { reportErrors } = require('./utils/reporter');
+
+module.exports = function() {
+  function check(node, reporter) {
+    if (!isAny(node, [ 'bpmn:ExclusiveGateway', 'bpmn:InclusiveGateway' ])) {
+      return;
+    }
+
+    const outgoing = node.get('outgoing');
+
+    if (outgoing && outgoing.length > 1) {
+      for (let sequenceFlow of outgoing) {
+        if (node.get('default') !== sequenceFlow) {
+          const errors = hasProperties(sequenceFlow, {
+            conditionExpression: {
+              required: true
+            }
+          }, sequenceFlow);
+
+          if (errors.length) {
+            reportErrors(sequenceFlow, reporter, errors);
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    check
+  };
+};

--- a/test/camunda-cloud/inclusive-gateway.spec.js
+++ b/test/camunda-cloud/inclusive-gateway.spec.js
@@ -11,55 +11,15 @@ const { ERROR_TYPES } = require('../../rules/utils/element');
 
 const valid = [
   {
-    name: 'inclusive gateway (1 outgoing sequence flow)',
+    name: 'inclusive gateway (1 incoming sequence flow)',
     moddleElement: createModdle(createProcess(`
+      <bpmn:startEvent id="StartEvent_1">
+        <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+      </bpmn:startEvent>
       <bpmn:inclusiveGateway id="InclusiveGateway_1">
-        <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
-      </bpmn:inclusiveGateway>
-      <bpmn:endEvent id="EndEvent_1">
         <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
-      </bpmn:endEvent>
-      <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="InclusiveGateway_1" targetRef="EndEvent_1" />
-    `))
-  },
-  {
-    name: 'inclusive gateway (2 outgoing sequence flows with condition)',
-    moddleElement: createModdle(createProcess(`
-      <bpmn:inclusiveGateway id="InclusiveGateway_1">
-        <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
-        <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
       </bpmn:inclusiveGateway>
-      <bpmn:endEvent id="EndEvent_1">
-        <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
-      </bpmn:endEvent>
-      <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="InclusiveGateway_1" targetRef="EndEvent_1">
-        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=foo</bpmn:conditionExpression>
-      </bpmn:sequenceFlow>
-      <bpmn:endEvent id="EndEvent_2">
-        <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
-      </bpmn:endEvent>
-      <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="InclusiveGateway_1" targetRef="EndEvent_2">
-        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=bar</bpmn:conditionExpression>
-      </bpmn:sequenceFlow>
-    `))
-  },
-  {
-    name: 'inclusive gateway (2 outgoing sequence flows, 1 default, 1 with condition)',
-    moddleElement: createModdle(createProcess(`
-      <bpmn:inclusiveGateway id="InclusiveGateway_1" default="SequenceFlow_2">
-        <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
-        <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
-      </bpmn:inclusiveGateway>
-      <bpmn:endEvent id="EndEvent_1">
-        <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
-      </bpmn:endEvent>
-      <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="InclusiveGateway_1" targetRef="EndEvent_1">
-        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=foo</bpmn:conditionExpression>
-      </bpmn:sequenceFlow>
-      <bpmn:endEvent id="EndEvent_2">
-        <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
-      </bpmn:endEvent>
-      <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="InclusiveGateway_1" targetRef="EndEvent_2" />
+      <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="StartEvent_1" targetRef="InclusiveGateway_1" />
     `))
   },
   {
@@ -102,83 +62,6 @@ const invalid = [
         property: 'incoming'
       }
     }
-  },
-  {
-    name: 'inclusive gateway (2 outgoing sequence flows, one without condition)',
-    moddleElement: createModdle(createProcess(`
-      <bpmn:inclusiveGateway id="InclusiveGateway_1">
-        <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
-        <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
-      </bpmn:inclusiveGateway>
-      <bpmn:endEvent id="EndEvent_1">
-        <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
-      </bpmn:endEvent>
-      <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="InclusiveGateway_1" targetRef="EndEvent_1">
-        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=foo</bpmn:conditionExpression>
-      </bpmn:sequenceFlow>
-      <bpmn:endEvent id="EndEvent_2">
-        <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
-      </bpmn:endEvent>
-      <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="InclusiveGateway_1" targetRef="EndEvent_2" />
-    `)),
-    report: {
-      id: 'SequenceFlow_2',
-      message: 'Element of type <bpmn:SequenceFlow> must have property <conditionExpression>',
-      path: [
-        'conditionExpression'
-      ],
-      data: {
-        type: ERROR_TYPES.PROPERTY_REQUIRED,
-        node: 'SequenceFlow_2',
-        parentNode: null,
-        requiredProperty: 'conditionExpression'
-      }
-    }
-  },
-  {
-    name: 'inclusive gateway (2 outgoing sequence flows, 2 without condition)',
-    moddleElement: createModdle(createProcess(`
-      <bpmn:inclusiveGateway id="InclusiveGateway_1">
-        <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
-        <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
-      </bpmn:inclusiveGateway>
-      <bpmn:endEvent id="EndEvent_1">
-        <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
-      </bpmn:endEvent>
-      <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="InclusiveGateway_1" targetRef="EndEvent_1" />
-      <bpmn:endEvent id="EndEvent_2">
-        <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
-      </bpmn:endEvent>
-      <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="InclusiveGateway_1" targetRef="EndEvent_2" />
-    `)),
-    report: [
-      {
-        id: 'SequenceFlow_1',
-        message: 'Element of type <bpmn:SequenceFlow> must have property <conditionExpression>',
-        path: [
-          'conditionExpression'
-        ],
-        data: {
-          type: ERROR_TYPES.PROPERTY_REQUIRED,
-          node: 'SequenceFlow_1',
-          parentNode: null,
-          requiredProperty: 'conditionExpression'
-        }
-      },
-      {
-        id: 'SequenceFlow_2',
-        message: 'Element of type <bpmn:SequenceFlow> must have property <conditionExpression>',
-        path: [
-          'conditionExpression'
-        ],
-        data: {
-          type: ERROR_TYPES.PROPERTY_REQUIRED,
-          node: 'SequenceFlow_2',
-          parentNode: null,
-          requiredProperty: 'conditionExpression'
-        }
-      }
-    ]
   }
 ];
 

--- a/test/camunda-cloud/sequence-flow-condition.spec.js
+++ b/test/camunda-cloud/sequence-flow-condition.spec.js
@@ -1,0 +1,263 @@
+const RuleTester = require('bpmnlint/lib/testers/rule-tester');
+
+const rule = require('../../rules/sequence-flow-condition');
+
+const {
+  createModdle,
+  createProcess
+} = require('../helper');
+
+const { ERROR_TYPES } = require('../../rules/utils/element');
+
+const valid = [
+  {
+    name: 'inclusive gateway (2 outgoing sequence flows with condition)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:inclusiveGateway id="InclusiveGateway_1">
+        <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+        <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
+      </bpmn:inclusiveGateway>
+      <bpmn:endEvent id="EndEvent_1">
+        <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="InclusiveGateway_1" targetRef="EndEvent_1">
+        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=foo</bpmn:conditionExpression>
+      </bpmn:sequenceFlow>
+      <bpmn:endEvent id="EndEvent_2">
+        <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="InclusiveGateway_1" targetRef="EndEvent_2">
+        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=bar</bpmn:conditionExpression>
+      </bpmn:sequenceFlow>
+    `))
+  },
+  {
+    name: 'inclusive gateway (2 outgoing sequence flows, 1 default, 1 with condition)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:inclusiveGateway id="InclusiveGateway_1" default="SequenceFlow_2">
+        <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+        <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
+      </bpmn:inclusiveGateway>
+      <bpmn:endEvent id="EndEvent_1">
+        <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="InclusiveGateway_1" targetRef="EndEvent_1">
+        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=foo</bpmn:conditionExpression>
+      </bpmn:sequenceFlow>
+      <bpmn:endEvent id="EndEvent_2">
+        <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="InclusiveGateway_1" targetRef="EndEvent_2" />
+    `))
+  },
+  {
+    name: 'exclusive gateway (2 outgoing sequence flows with condition)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:exclusiveGateway id="ExclusiveGateway_1">
+        <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+        <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
+      </bpmn:exclusiveGateway>
+      <bpmn:endEvent id="EndEvent_1">
+        <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="ExclusiveGateway_1" targetRef="EndEvent_1">
+        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=foo</bpmn:conditionExpression>
+      </bpmn:sequenceFlow>
+      <bpmn:endEvent id="EndEvent_2">
+        <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="ExclusiveGateway_1" targetRef="EndEvent_2">
+        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=bar</bpmn:conditionExpression>
+      </bpmn:sequenceFlow>
+    `))
+  },
+  {
+    name: 'exclusive gateway (2 outgoing sequence flows, 1 default, 1 with condition)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:exclusiveGateway id="ExclusiveGateway_1" default="SequenceFlow_2">
+        <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+        <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
+      </bpmn:exclusiveGateway>
+      <bpmn:endEvent id="EndEvent_1">
+        <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="ExclusiveGateway_1" targetRef="EndEvent_1">
+        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=foo</bpmn:conditionExpression>
+      </bpmn:sequenceFlow>
+      <bpmn:endEvent id="EndEvent_2">
+        <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="ExclusiveGateway_1" targetRef="EndEvent_2" />
+    `))
+  },
+  {
+    name: 'end event',
+    moddleElement: createModdle(createProcess('<bpmn:endEvent id="EndEvent_1" />'))
+  },
+  {
+    name: 'task',
+    moddleElement: createModdle(createProcess('<bpmn:task id="Task_1" />'))
+  }
+];
+
+const invalid = [
+  {
+    name: 'inclusive gateway (2 outgoing sequence flows, one without condition)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:inclusiveGateway id="InclusiveGateway_1">
+        <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+        <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
+      </bpmn:inclusiveGateway>
+      <bpmn:endEvent id="EndEvent_1">
+        <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="InclusiveGateway_1" targetRef="EndEvent_1">
+        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=foo</bpmn:conditionExpression>
+      </bpmn:sequenceFlow>
+      <bpmn:endEvent id="EndEvent_2">
+        <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="InclusiveGateway_1" targetRef="EndEvent_2" />
+    `)),
+    report: {
+      id: 'SequenceFlow_2',
+      message: 'Element of type <bpmn:SequenceFlow> must have property <conditionExpression>',
+      path: [
+        'conditionExpression'
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'SequenceFlow_2',
+        parentNode: null,
+        requiredProperty: 'conditionExpression'
+      }
+    }
+  },
+  {
+    name: 'inclusive gateway (2 outgoing sequence flows, 2 without condition)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:inclusiveGateway id="InclusiveGateway_1">
+        <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+        <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
+      </bpmn:inclusiveGateway>
+      <bpmn:endEvent id="EndEvent_1">
+        <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="InclusiveGateway_1" targetRef="EndEvent_1" />
+      <bpmn:endEvent id="EndEvent_2">
+        <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="InclusiveGateway_1" targetRef="EndEvent_2" />
+    `)),
+    report: [
+      {
+        id: 'SequenceFlow_1',
+        message: 'Element of type <bpmn:SequenceFlow> must have property <conditionExpression>',
+        path: [
+          'conditionExpression'
+        ],
+        data: {
+          type: ERROR_TYPES.PROPERTY_REQUIRED,
+          node: 'SequenceFlow_1',
+          parentNode: null,
+          requiredProperty: 'conditionExpression'
+        }
+      },
+      {
+        id: 'SequenceFlow_2',
+        message: 'Element of type <bpmn:SequenceFlow> must have property <conditionExpression>',
+        path: [
+          'conditionExpression'
+        ],
+        data: {
+          type: ERROR_TYPES.PROPERTY_REQUIRED,
+          node: 'SequenceFlow_2',
+          parentNode: null,
+          requiredProperty: 'conditionExpression'
+        }
+      }
+    ]
+  },
+  {
+    name: 'exclusive gateway (2 outgoing sequence flows, one without condition)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:exclusiveGateway id="ExclusiveGateway_1">
+        <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+        <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
+      </bpmn:exclusiveGateway>
+      <bpmn:endEvent id="EndEvent_1">
+        <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="ExclusiveGateway_1" targetRef="EndEvent_1">
+        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=foo</bpmn:conditionExpression>
+      </bpmn:sequenceFlow>
+      <bpmn:endEvent id="EndEvent_2">
+        <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="ExclusiveGateway_1" targetRef="EndEvent_2" />
+    `)),
+    report: {
+      id: 'SequenceFlow_2',
+      message: 'Element of type <bpmn:SequenceFlow> must have property <conditionExpression>',
+      path: [
+        'conditionExpression'
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'SequenceFlow_2',
+        parentNode: null,
+        requiredProperty: 'conditionExpression'
+      }
+    }
+  },
+  {
+    name: 'exclusive gateway (2 outgoing sequence flows, 2 without condition)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:exclusiveGateway id="ExclusiveGateway_1">
+        <bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+        <bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
+      </bpmn:exclusiveGateway>
+      <bpmn:endEvent id="EndEvent_1">
+        <bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="ExclusiveGateway_1" targetRef="EndEvent_1" />
+      <bpmn:endEvent id="EndEvent_2">
+        <bpmn:incoming>SequenceFlow_2</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="ExclusiveGateway_1" targetRef="EndEvent_2" />
+    `)),
+    report: [
+      {
+        id: 'SequenceFlow_1',
+        message: 'Element of type <bpmn:SequenceFlow> must have property <conditionExpression>',
+        path: [
+          'conditionExpression'
+        ],
+        data: {
+          type: ERROR_TYPES.PROPERTY_REQUIRED,
+          node: 'SequenceFlow_1',
+          parentNode: null,
+          requiredProperty: 'conditionExpression'
+        }
+      },
+      {
+        id: 'SequenceFlow_2',
+        message: 'Element of type <bpmn:SequenceFlow> must have property <conditionExpression>',
+        path: [
+          'conditionExpression'
+        ],
+        data: {
+          type: ERROR_TYPES.PROPERTY_REQUIRED,
+          node: 'SequenceFlow_2',
+          parentNode: null,
+          requiredProperty: 'conditionExpression'
+        }
+      }
+    ]
+  }
+];
+
+RuleTester.verify('sequence-flow-condition', rule, {
+  valid,
+  invalid
+});

--- a/test/config/configs.spec.js
+++ b/test/config/configs.spec.js
@@ -17,6 +17,7 @@ describe('configs', function() {
     'message-reference': 'error',
     'no-template': 'error',
     'no-zeebe-properties': 'error',
+    'sequence-flow-condition': 'error',
     'subscription': 'error',
     'timer': [ 'error', { version: '1.0' } ],
     'user-task-form': 'error'
@@ -36,6 +37,7 @@ describe('configs', function() {
     'message-reference': 'error',
     'no-template': 'error',
     'no-zeebe-properties': 'error',
+    'sequence-flow-condition': 'error',
     'subscription': 'error',
     'timer': [ 'error', { version: '1.1' } ],
     'user-task-form': 'error'
@@ -55,6 +57,7 @@ describe('configs', function() {
     'message-reference': 'error',
     'no-template': 'error',
     'no-zeebe-properties': 'error',
+    'sequence-flow-condition': 'error',
     'subscription': 'error',
     'timer': [ 'error', { version: '1.2' } ],
     'user-task-form': 'error'
@@ -74,6 +77,7 @@ describe('configs', function() {
     'message-reference': 'error',
     'no-template': 'error',
     'no-zeebe-properties': 'error',
+    'sequence-flow-condition': 'error',
     'subscription': 'error',
     'timer': [ 'error', { version: '1.3' } ],
     'user-task-form': 'error'
@@ -92,6 +96,7 @@ describe('configs', function() {
     'loop-characteristics': 'error',
     'message-reference': 'error',
     'no-zeebe-properties': 'error',
+    'sequence-flow-condition': 'error',
     'subscription': 'error',
     'timer': [ 'error', { version: '8.0' } ],
     'user-task-form': 'error'
@@ -110,6 +115,7 @@ describe('configs', function() {
     'inclusive-gateway': 'error',
     'loop-characteristics': 'error',
     'message-reference': 'error',
+    'sequence-flow-condition': 'error',
     'subscription': 'error',
     'timer': [ 'error', { version: '8.1' } ],
     'user-task-form': 'error'


### PR DESCRIPTION
Conditions now checked for both exclusive and inclusive gateways.

![image](https://user-images.githubusercontent.com/7633572/200515455-27dd38ab-1f4d-4980-827b-7098a3a3c7fc.png)

* separate `inclusive-gateway` into 2 parts
* `inclusive-gateway` rule checks number of incoming sequence flows of inclusive gateway
* `sequence-flow-condition` rule checks condition of outgoing sequence flows of exclusive and inclusive gateway