### PR TITLE
feat: allow link events in camunda 8.2

### DIFF
--- a/rules/called-decision-or-task-definition/config.js
+++ b/rules/called-decision-or-task-definition/config.js
@@ -4,7 +4,9 @@ module.exports = {
   },
   taskDefinition: {
     'bpmn:BusinessRuleTask': '1.1',
-    'bpmn:IntermediateThrowEvent': '1.2',
+    'bpmn:IntermediateThrowEvent': {
+      'bpmn:MessageEventDefinition': '1.2',
+    },
     'bpmn:ScriptTask': '1.1',
     'bpmn:SendTask': '1.1',
     'bpmn:ServiceTask': '1.0'

--- a/rules/element-type/config.js
+++ b/rules/element-type/config.js
@@ -24,11 +24,13 @@ module.exports = {
   'bpmn:InclusiveGateway': '8.1',
   'bpmn:IntermediateCatchEvent': {
     'bpmn:MessageEventDefinition': '1.0',
-    'bpmn:TimerEventDefinition': '1.0'
+    'bpmn:TimerEventDefinition': '1.0',
+    'bpmn:LinkEventDefinition': '8.2'
   },
   'bpmn:IntermediateThrowEvent': {
     '_': '1.1',
-    'bpmn:MessageEventDefinition': '1.2'
+    'bpmn:MessageEventDefinition': '1.2',
+    'bpmn:LinkEventDefinition': '8.2'
   },
   'bpmn:ManualTask': '1.1',
   'bpmn:MessageFlow': '1.0',

--- a/test/camunda-cloud/called-decision-or-task-definition.spec.js
+++ b/test/camunda-cloud/called-decision-or-task-definition.spec.js
@@ -27,6 +27,15 @@ const valid = [
     moddleElement: createModdle(createProcess('<bpmn:task id="Task_1" />'))
   },
   {
+    name: 'intermediate link throw event (Camunda Cloud 1.0)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:intermediateThrowEvent id="IntermediateThrowEvent_1">
+        <bpmn:linkEventDefinition id="LinkEventDefinition_1kkrq09" name="Foobar" />
+      </bpmn:intermediateThrowEvent>
+    `))
+  },
+  {
     name: 'business rule task (Camunda Cloud 1.1)',
     config: { version: '1.1' },
     moddleElement: createModdle(createProcess(`
@@ -43,7 +52,7 @@ const valid = [
     moddleElement: createModdle(createProcess('<bpmn:task id="Task_1" />'))
   },
   {
-    name: 'intermediate throw event (Camunda Cloud 1.2)',
+    name: 'intermediate message throw event (Camunda Cloud 1.2)',
     config: { version: '1.2' },
     moddleElement: createModdle(createProcess(`
       <bpmn:intermediateThrowEvent id="IntermediateThrowEvent_1">

--- a/test/camunda-cloud/called-decision-or-task-definition.spec.js
+++ b/test/camunda-cloud/called-decision-or-task-definition.spec.js
@@ -27,11 +27,11 @@ const valid = [
     moddleElement: createModdle(createProcess('<bpmn:task id="Task_1" />'))
   },
   {
-    name: 'intermediate link throw event (Camunda Cloud 1.0)',
-    config: { version: '1.0' },
+    name: 'intermediate link throw event (Camunda Cloud 8.2)',
+    config: { version: '8.2' },
     moddleElement: createModdle(createProcess(`
       <bpmn:intermediateThrowEvent id="IntermediateThrowEvent_1">
-        <bpmn:linkEventDefinition id="LinkEventDefinition_1kkrq09" name="Foobar" />
+        <bpmn:linkEventDefinition id="LinkEventDefinition_1" name="foo" />
       </bpmn:intermediateThrowEvent>
     `))
   },

--- a/test/camunda-cloud/camunda-cloud-8-1-element-type.spec.js
+++ b/test/camunda-cloud/camunda-cloud-8-1-element-type.spec.js
@@ -93,6 +93,43 @@ const invalid = [
         allowedVersion: '8.2'
       }
     }
+  },
+  {
+    name: 'link events',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_1">
+        <bpmn:linkEventDefinition id="LinkEventDefinition_1" name="Foobar" />
+      </bpmn:intermediateCatchEvent>
+      <bpmn:intermediateThrowEvent id="IntermediateThrowEvent_1">
+        <bpmn:linkEventDefinition id="LinkEventDefinition_2" name="Foobar" />
+      </bpmn:intermediateThrowEvent>
+    `)),
+    report: [
+      {
+        id: 'IntermediateCatchEvent_1',
+        message: 'Element of type <bpmn:IntermediateCatchEvent> with event definition of type <bpmn:LinkEventDefinition> only allowed by Camunda Platform 8.2 or newer',
+        path: null,
+        data: {
+          type: ERROR_TYPES.ELEMENT_TYPE_NOT_ALLOWED,
+          node: 'IntermediateCatchEvent_1',
+          parentNode: null,
+          eventDefinition: 'LinkEventDefinition_1',
+          allowedVersion: '8.2'
+        }
+      },
+      {
+        id: 'IntermediateThrowEvent_1',
+        message: 'Element of type <bpmn:IntermediateThrowEvent> with event definition of type <bpmn:LinkEventDefinition> only allowed by Camunda Platform 8.2 or newer',
+        path: null,
+        data: {
+          type: ERROR_TYPES.ELEMENT_TYPE_NOT_ALLOWED,
+          node: 'IntermediateThrowEvent_1',
+          parentNode: null,
+          eventDefinition: 'LinkEventDefinition_2',
+          allowedVersion: '8.2'
+        }
+      }
+    ]
   }
 ];
 

--- a/test/camunda-cloud/camunda-cloud-8-2-element-type.spec.js
+++ b/test/camunda-cloud/camunda-cloud-8-2-element-type.spec.js
@@ -15,7 +15,23 @@ const valid = [
   {
     name: 'Task',
     moddleElement: createModdle(createProcess('<bpmn:task id="Task_1" />'))
-  }
+  },
+  {
+    name: 'Link Intermediate Catch Event',
+    moddleElement: createModdle(createProcess(`
+    <bpmn:intermediateCatchEvent id="Event_1ekxmj4">
+      <bpmn:linkEventDefinition id="LinkEventDefinition_1kkrq09" name="Foobar" />
+    </bpmn:intermediateCatchEvent>
+    `))
+  },
+  {
+    name: 'Link Intermediate Throw Event',
+    moddleElement: createModdle(createProcess(`
+    <bpmn:intermediateThrowEvent id="Event_1ekxmj4">
+      <bpmn:linkEventDefinition id="LinkEventDefinition_1kkrq09" name="Foobar" />
+    </bpmn:intermediateThrowEvent>
+    `))
+  },
 ];
 
 const invalid = [

--- a/test/camunda-cloud/camunda-cloud-8-2-element-type.spec.js
+++ b/test/camunda-cloud/camunda-cloud-8-2-element-type.spec.js
@@ -13,25 +13,25 @@ const { ERROR_TYPES } = require('../../rules/utils/element');
 const valid = [
   ...require('./camunda-cloud-8-1-element-type.spec').valid,
   {
-    name: 'Task',
+    name: 'task',
     moddleElement: createModdle(createProcess('<bpmn:task id="Task_1" />'))
   },
   {
-    name: 'Link Intermediate Catch Event',
+    name: 'link intermediate catch event',
     moddleElement: createModdle(createProcess(`
-    <bpmn:intermediateCatchEvent id="Event_1ekxmj4">
-      <bpmn:linkEventDefinition id="LinkEventDefinition_1kkrq09" name="Foobar" />
-    </bpmn:intermediateCatchEvent>
+      <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_1">
+        <bpmn:linkEventDefinition id="LinkEventDefinition_1" name="foo" />
+      </bpmn:intermediateCatchEvent>
     `))
   },
   {
-    name: 'Link Intermediate Throw Event',
+    name: 'link intermediate throw event',
     moddleElement: createModdle(createProcess(`
-    <bpmn:intermediateThrowEvent id="Event_1ekxmj4">
-      <bpmn:linkEventDefinition id="LinkEventDefinition_1kkrq09" name="Foobar" />
-    </bpmn:intermediateThrowEvent>
+      <bpmn:intermediateThrowEvent id="IntermediateCatchEvent_1">
+        <bpmn:linkEventDefinition id="LinkEventDefinition_1" name="foo" />
+      </bpmn:intermediateThrowEvent>
     `))
-  },
+  }
 ];
 
 const invalid = [

--- a/test/camunda-cloud/integration/camunda-cloud-8-2-called-decision-or-task-definition.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-8-2-called-decision-or-task-definition.bpmn
@@ -27,6 +27,9 @@
       </bpmn:extensionElements>
       <bpmn:messageEventDefinition id="MessageEventDefinition_1puphj5" />
     </bpmn:intermediateThrowEvent>
+    <bpmn:intermediateThrowEvent id="Event_0p6pl2i">
+      <bpmn:linkEventDefinition id="LinkEventDefinition_06pkhyc" name="" />
+    </bpmn:intermediateThrowEvent>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0h5hgi7">
@@ -44,6 +47,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_15elbnv_di" bpmnElement="Event_1hi96lx">
         <dc:Bounds x="192" y="232" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_04fdck5_di" bpmnElement="Event_0p6pl2i">
+        <dc:Bounds x="252" y="232" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/camunda-cloud/integration/camunda-cloud-8-2-element-type-errors.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-8-2-element-type-errors.bpmn
@@ -76,12 +76,6 @@
         <bpmn:condition xsi:type="bpmn:tFormalExpression" />
       </bpmn:conditionalEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:intermediateCatchEvent id="Event_0s96ilr">
-      <bpmn:linkEventDefinition id="LinkEventDefinition_1ppd3yy" name="" />
-    </bpmn:intermediateCatchEvent>
-    <bpmn:intermediateThrowEvent id="Event_058pikp">
-      <bpmn:linkEventDefinition id="LinkEventDefinition_0yv4tfh" name="" />
-    </bpmn:intermediateThrowEvent>
     <bpmn:intermediateThrowEvent id="Event_143034p">
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_19qzhq6" />
     </bpmn:intermediateThrowEvent>
@@ -285,12 +279,6 @@
       <bpmndi:BPMNShape id="Event_0b7z33f_di" bpmnElement="Event_1cdxynr">
         <dc:Bounds x="822" y="312" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0gxwsku_di" bpmnElement="Event_0s96ilr">
-        <dc:Bounds x="882" y="312" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_00ttebs_di" bpmnElement="Event_058pikp">
-        <dc:Bounds x="942" y="312" width="36" height="36" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1d7dyp1_di" bpmnElement="Event_143034p">
         <dc:Bounds x="1002" y="312" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -336,9 +324,6 @@
       <bpmndi:BPMNShape id="Activity_0u9hvk8_di" bpmnElement="Activity_0u9hvk8">
         <dc:Bounds x="2300" y="580" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="312" y="422" width="36" height="36" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0odp5sa_di" bpmnElement="Activity_18lrl5o">
         <dc:Bounds x="1720" y="400" width="100" height="80" />
       </bpmndi:BPMNShape>
@@ -374,6 +359,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1i575ke_di" bpmnElement="Event_0m5bm2q">
         <dc:Bounds x="872" y="622" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="312" y="422" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1pws5gv_di" bpmnElement="Event_06vp79f">
         <dc:Bounds x="2062" y="322" width="36" height="36" />

--- a/test/camunda-cloud/integration/camunda-cloud-8-2-element-type.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-8-2-element-type.bpmn
@@ -130,6 +130,12 @@
     <bpmn:sequenceFlow id="Flow_00w4v7n" sourceRef="Activity_0f2pmcw" targetRef="Activity_18lrl5o" />
     <bpmn:sequenceFlow id="Flow_0fcl9ds" sourceRef="Activity_05jt1pz" targetRef="Event_1kvsony" />
     <bpmn:sequenceFlow id="Flow_1ymtwgk" sourceRef="Activity_18lrl5o" targetRef="Activity_05jt1pz" />
+    <bpmn:intermediateCatchEvent id="Event_0s96ilr">
+      <bpmn:linkEventDefinition id="LinkEventDefinition_1ppd3yy" name="" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateThrowEvent id="Event_058pikp">
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0yv4tfh" name="" />
+    </bpmn:intermediateThrowEvent>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0hnpxxj">
@@ -299,6 +305,12 @@
         <di:waypoint x="429" y="220" />
         <di:waypoint x="429" y="280" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0gxwsku_di" bpmnElement="Event_0s96ilr">
+        <dc:Bounds x="882" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_00ttebs_di" bpmnElement="Event_058pikp">
+        <dc:Bounds x="942" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1lv689l">


### PR DESCRIPTION
This PR only covers modeling the elements, it does not add validation for the event itself. I created a follow-up issue for this: https://github.com/camunda/bpmnlint-plugin-camunda-compat/issues/62

\< 8.2
![image](https://user-images.githubusercontent.com/21984219/202480801-f459aba0-cb0b-4370-9c16-6e02a8dc86f6.png)

\>= 8.2
![image](https://user-images.githubusercontent.com/21984219/202480912-f1512764-75b7-4127-b481-68ca15516f44.png)

related to https://github.com/camunda/camunda-modeler/issues/3282