### PR TITLE
Add platform 'history time to live' required rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,10 @@ const camundaCloud82Rules = withConfig({
   'escalation-reference': 'error'
 }, { version: '8.2' });
 
+const camundaPlatform719Rules = withConfig({
+  'history-time-to-live': 'error'
+}, { version: '7.19' });
+
 module.exports = {
   configs: {
     'camunda-cloud-1-0': {
@@ -63,6 +67,9 @@ module.exports = {
     },
     'camunda-cloud-8-2': {
       rules: camundaCloud82Rules
+    },
+    'camunda-platform-7-19': {
+      rules: camundaPlatform719Rules
     }
   }
 };

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ const camundaCloud82Rules = withConfig({
 
 const camundaPlatform719Rules = withConfig({
   'history-time-to-live': 'error'
-}, { version: '7.19' });
+}, { platform: 'camunda-platform', version: '7.19' });
 
 module.exports = {
   configs: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@bpmn-io/feel-lint": "^0.1.1",
         "@bpmn-io/moddle-utils": "^0.1.0",
         "bpmnlint-utils": "^1.0.2",
+        "camunda-bpmn-moddle": "^7.0.1",
         "min-dash": "^3.8.1",
         "semver-compare": "^1.0.0"
       },
@@ -977,6 +978,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/camunda-bpmn-moddle": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-moddle/-/camunda-bpmn-moddle-7.0.1.tgz",
+      "integrity": "sha512-Br8Diu6roMpziHdpl66Dhnm0DTnCFMrSD9zwLV08LpD52QA0UsXxU87XfHf08HjuB7ly0Hd1bvajZRpf9hbmYQ=="
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001388",
@@ -4580,6 +4586,11 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true
+    },
+    "camunda-bpmn-moddle": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camunda-bpmn-moddle/-/camunda-bpmn-moddle-7.0.1.tgz",
+      "integrity": "sha512-Br8Diu6roMpziHdpl66Dhnm0DTnCFMrSD9zwLV08LpD52QA0UsXxU87XfHf08HjuB7ly0Hd1bvajZRpf9hbmYQ=="
     },
     "caniuse-lite": {
       "version": "1.0.30001388",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@bpmn-io/feel-lint": "^0.1.1",
     "@bpmn-io/moddle-utils": "^0.1.0",
     "bpmnlint-utils": "^1.0.2",
+    "camunda-bpmn-moddle": "^7.0.1",
     "min-dash": "^3.8.1",
     "semver-compare": "^1.0.0"
   },

--- a/rules/history-time-to-live.js
+++ b/rules/history-time-to-live.js
@@ -1,6 +1,9 @@
 const { is } = require('bpmnlint-utils');
+
 const { hasProperties } = require('./utils/element');
+
 const { reportErrors } = require('./utils/reporter');
+
 const { skipInNonExecutableProcess } = require('./utils/rule');
 
 module.exports = skipInNonExecutableProcess(function() {

--- a/rules/history-time-to-live.js
+++ b/rules/history-time-to-live.js
@@ -1,0 +1,28 @@
+const { is } = require('bpmnlint-utils');
+const { hasProperties } = require('./utils/element');
+const { reportErrors } = require('./utils/reporter');
+const { skipInNonExecutableProcess } = require('./utils/rule');
+
+module.exports = skipInNonExecutableProcess(function() {
+  function check(node, reporter) {
+
+    if (!is(node, 'bpmn:Process')) {
+      return;
+    }
+
+    let errors = hasProperties(node, {
+      'historyTimeToLive': {
+        required: true
+      }
+    }, node);
+
+    if (errors) {
+      reportErrors(node, reporter, errors);
+    }
+    return;
+  }
+
+  return {
+    check
+  };
+});

--- a/rules/utils/rule.js
+++ b/rules/utils/rule.js
@@ -6,10 +6,14 @@ function skipInNonExecutableProcess(ruleFactory) {
   return function(config = {}) {
     const rule = ruleFactory(config);
 
-    const { version } = config;
+    const { version, platform = 'zeebe' } = config;
 
     function check(node, reporter) {
-      if (version && greaterOrEqual(version, '8.2') && isNonExecutableProcess(node)) {
+      if (platform === 'zeebe' && version && greaterOrEqual(version, '8.2') && isNonExecutableProcess(node)) {
+        return false;
+      }
+
+      if (platform === 'platform' && isNonExecutableProcess(node)) {
         return false;
       }
 

--- a/rules/utils/rule.js
+++ b/rules/utils/rule.js
@@ -6,14 +6,14 @@ function skipInNonExecutableProcess(ruleFactory) {
   return function(config = {}) {
     const rule = ruleFactory(config);
 
-    const { version, platform = 'zeebe' } = config;
+    const { version, platform = 'camunda-cloud' } = config;
 
     function check(node, reporter) {
-      if (platform === 'zeebe' && version && greaterOrEqual(version, '8.2') && isNonExecutableProcess(node)) {
+      if (platform === 'camunda-cloud' && version && greaterOrEqual(version, '8.2') && isNonExecutableProcess(node)) {
         return false;
       }
 
-      if (platform === 'platform' && isNonExecutableProcess(node)) {
+      if (platform === 'camunda-platform' && isNonExecutableProcess(node)) {
         return false;
       }
 

--- a/test/camunda-platform/history-time-to-live.spec.js
+++ b/test/camunda-platform/history-time-to-live.spec.js
@@ -18,7 +18,7 @@ const valid = [
   },
   {
     name: 'non-executable process (history time to live)',
-    config: { platform: 'platform' },
+    config: { platform: 'camunda-platform' },
     moddleElement: createModdle(createDefinitions(`
       <bpmn:process id="Process_1" />
     `), 'platform'),

--- a/test/camunda-platform/history-time-to-live.spec.js
+++ b/test/camunda-platform/history-time-to-live.spec.js
@@ -1,0 +1,54 @@
+const RuleTester = require('bpmnlint/lib/testers/rule-tester');
+
+const rule = require('../../rules/history-time-to-live');
+
+const {
+  createDefinitions,
+  createModdle
+} = require('../helper');
+
+const { ERROR_TYPES } = require('../../rules/utils/element');
+
+const valid = [
+  {
+    name: 'process (history time to live)',
+    moddleElement: createModdle(createDefinitions(`
+      <bpmn:process id="Process_1" isExecutable="true" camunda:historyTimeToLive="123"/>
+    `), 'platform'),
+  },
+  {
+    name: 'non-executable process (history time to live)',
+    config: { platform: 'platform' },
+    moddleElement: createModdle(createDefinitions(`
+      <bpmn:process id="Process_1" />
+    `), 'platform'),
+  }
+];
+
+const invalid = [
+  {
+    name: 'process (no history time to live)',
+    moddleElement: createModdle(createDefinitions(`
+    <bpmn:process id="Process_1" isExecutable="true">
+    </bpmn:process>
+    `), 'platform'),
+    report: {
+      id: 'Process_1',
+      message: 'Element of type <bpmn:Process> must have property <historyTimeToLive>',
+      path: [
+        'historyTimeToLive'
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'Process_1',
+        parentNode: null,
+        requiredProperty: 'historyTimeToLive'
+      }
+    }
+  }
+];
+
+RuleTester.verify('history-time-to-live', rule, {
+  valid,
+  invalid
+});

--- a/test/camunda-platform/history-time-to-live.spec.js
+++ b/test/camunda-platform/history-time-to-live.spec.js
@@ -4,7 +4,7 @@ const rule = require('../../rules/history-time-to-live');
 
 const {
   createDefinitions,
-  createModdle
+  createModdleCamundaPlatform: createModdle
 } = require('../helper');
 
 const { ERROR_TYPES } = require('../../rules/utils/element');
@@ -14,14 +14,14 @@ const valid = [
     name: 'process (history time to live)',
     moddleElement: createModdle(createDefinitions(`
       <bpmn:process id="Process_1" isExecutable="true" camunda:historyTimeToLive="123" />
-    `), 'platform'),
+    `)),
   },
   {
     name: 'non-executable process (history time to live)',
     config: { platform: 'camunda-platform' },
     moddleElement: createModdle(createDefinitions(`
       <bpmn:process id="Process_1" />
-    `), 'platform'),
+    `)),
   }
 ];
 
@@ -30,7 +30,7 @@ const invalid = [
     name: 'process (no history time to live)',
     moddleElement: createModdle(createDefinitions(`
       <bpmn:process id="Process_1" isExecutable="true" />
-    `), 'platform'),
+    `)),
     report: {
       id: 'Process_1',
       message: 'Element of type <bpmn:Process> must have property <historyTimeToLive>',

--- a/test/camunda-platform/history-time-to-live.spec.js
+++ b/test/camunda-platform/history-time-to-live.spec.js
@@ -13,7 +13,7 @@ const valid = [
   {
     name: 'process (history time to live)',
     moddleElement: createModdle(createDefinitions(`
-      <bpmn:process id="Process_1" isExecutable="true" camunda:historyTimeToLive="123"/>
+      <bpmn:process id="Process_1" isExecutable="true" camunda:historyTimeToLive="123" />
     `), 'platform'),
   },
   {
@@ -29,8 +29,7 @@ const invalid = [
   {
     name: 'process (no history time to live)',
     moddleElement: createModdle(createDefinitions(`
-    <bpmn:process id="Process_1" isExecutable="true">
-    </bpmn:process>
+      <bpmn:process id="Process_1" isExecutable="true" />
     `), 'platform'),
     report: {
       id: 'Process_1',

--- a/test/camunda-platform/integration/history-time-to-live-errors.bpmn
+++ b/test/camunda-platform/integration/history-time-to-live-errors.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_19bxjpz" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.19.0">
+  <bpmn:process id="Process_0fdds93" isExecutable="true" >
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_06awcz8</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_09orc6r">
+      <bpmn:incoming>Flow_06awcz8</bpmn:incoming>
+      <bpmn:outgoing>Flow_1fx1veh</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_06awcz8" sourceRef="StartEvent_1" targetRef="Activity_09orc6r" />
+    <bpmn:endEvent id="Event_1lss22g">
+      <bpmn:incoming>Flow_1fx1veh</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1fx1veh" sourceRef="Activity_09orc6r" targetRef="Event_1lss22g" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0fdds93">
+      <bpmndi:BPMNEdge id="Flow_06awcz8_di" bpmnElement="Flow_06awcz8">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1fx1veh_di" bpmnElement="Flow_1fx1veh">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09orc6r_di" bpmnElement="Activity_09orc6r">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1lss22g_di" bpmnElement="Event_1lss22g">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/camunda-platform/integration/history-time-to-live-errors.bpmn
+++ b/test/camunda-platform/integration/history-time-to-live-errors.bpmn
@@ -1,37 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_19bxjpz" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.19.0">
-  <bpmn:process id="Process_0fdds93" isExecutable="true" >
-    <bpmn:startEvent id="StartEvent_1">
-      <bpmn:outgoing>Flow_06awcz8</bpmn:outgoing>
-    </bpmn:startEvent>
-    <bpmn:task id="Activity_09orc6r">
-      <bpmn:incoming>Flow_06awcz8</bpmn:incoming>
-      <bpmn:outgoing>Flow_1fx1veh</bpmn:outgoing>
-    </bpmn:task>
-    <bpmn:sequenceFlow id="Flow_06awcz8" sourceRef="StartEvent_1" targetRef="Activity_09orc6r" />
-    <bpmn:endEvent id="Event_1lss22g">
-      <bpmn:incoming>Flow_1fx1veh</bpmn:incoming>
-    </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_1fx1veh" sourceRef="Activity_09orc6r" targetRef="Event_1lss22g" />
-  </bpmn:process>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_19bxjpz" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.8.0-rc.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.19.0">
+  <bpmn:collaboration id="Collaboration_1">
+    <bpmn:participant id="Participant_1" name="Executable" processRef="Process_1" />
+    <bpmn:participant id="Participant_2" name="Not executable" processRef="Process_2" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="true" />
+  <bpmn:process id="Process_2" isExecutable="false" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0fdds93">
-      <bpmndi:BPMNEdge id="Flow_06awcz8_di" bpmnElement="Flow_06awcz8">
-        <di:waypoint x="215" y="117" />
-        <di:waypoint x="270" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1fx1veh_di" bpmnElement="Flow_1fx1veh">
-        <di:waypoint x="370" y="117" />
-        <di:waypoint x="432" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="99" width="36" height="36" />
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1">
+      <bpmndi:BPMNShape id="Participant_0nfvgvy_di" bpmnElement="Participant_1" isHorizontal="true">
+        <dc:Bounds x="160" y="82" width="600" height="250" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_09orc6r_di" bpmnElement="Activity_09orc6r">
-        <dc:Bounds x="270" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1lss22g_di" bpmnElement="Event_1lss22g">
-        <dc:Bounds x="432" y="99" width="36" height="36" />
+      <bpmndi:BPMNShape id="Participant_1w78ag3_di" bpmnElement="Participant_2" isHorizontal="true">
+        <dc:Bounds x="160" y="360" width="600" height="250" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/camunda-platform/integration/history-time-to-live.bpmn
+++ b/test/camunda-platform/integration/history-time-to-live.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_19bxjpz" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.19.0">
+  <bpmn:process id="Process_0fdds93" isExecutable="true" camunda:historyTimeToLive="123">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_06awcz8</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_09orc6r">
+      <bpmn:incoming>Flow_06awcz8</bpmn:incoming>
+      <bpmn:outgoing>Flow_1fx1veh</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_06awcz8" sourceRef="StartEvent_1" targetRef="Activity_09orc6r" />
+    <bpmn:endEvent id="Event_1lss22g">
+      <bpmn:incoming>Flow_1fx1veh</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1fx1veh" sourceRef="Activity_09orc6r" targetRef="Event_1lss22g" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0fdds93">
+      <bpmndi:BPMNEdge id="Flow_06awcz8_di" bpmnElement="Flow_06awcz8">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1fx1veh_di" bpmnElement="Flow_1fx1veh">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09orc6r_di" bpmnElement="Activity_09orc6r">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1lss22g_di" bpmnElement="Event_1lss22g">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/camunda-platform/integration/history-time-to-live.bpmn
+++ b/test/camunda-platform/integration/history-time-to-live.bpmn
@@ -1,37 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_19bxjpz" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.19.0">
-  <bpmn:process id="Process_0fdds93" isExecutable="true" camunda:historyTimeToLive="123">
-    <bpmn:startEvent id="StartEvent_1">
-      <bpmn:outgoing>Flow_06awcz8</bpmn:outgoing>
-    </bpmn:startEvent>
-    <bpmn:task id="Activity_09orc6r">
-      <bpmn:incoming>Flow_06awcz8</bpmn:incoming>
-      <bpmn:outgoing>Flow_1fx1veh</bpmn:outgoing>
-    </bpmn:task>
-    <bpmn:sequenceFlow id="Flow_06awcz8" sourceRef="StartEvent_1" targetRef="Activity_09orc6r" />
-    <bpmn:endEvent id="Event_1lss22g">
-      <bpmn:incoming>Flow_1fx1veh</bpmn:incoming>
-    </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_1fx1veh" sourceRef="Activity_09orc6r" targetRef="Event_1lss22g" />
-  </bpmn:process>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_19bxjpz" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.8.0-rc.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.19.0">
+  <bpmn:collaboration id="Collaboration_1">
+    <bpmn:participant id="Participant_1" name="Executable" processRef="Process_1" />
+    <bpmn:participant id="Participant_2" name="Not executable" processRef="Process_2" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="true" camunda:historyTimeToLive="123" />
+  <bpmn:process id="Process_2" isExecutable="false" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0fdds93">
-      <bpmndi:BPMNEdge id="Flow_06awcz8_di" bpmnElement="Flow_06awcz8">
-        <di:waypoint x="215" y="117" />
-        <di:waypoint x="270" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1fx1veh_di" bpmnElement="Flow_1fx1veh">
-        <di:waypoint x="370" y="117" />
-        <di:waypoint x="432" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="99" width="36" height="36" />
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1">
+      <bpmndi:BPMNShape id="Participant_0nfvgvy_di" bpmnElement="Participant_1" isHorizontal="true">
+        <dc:Bounds x="160" y="82" width="600" height="250" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_09orc6r_di" bpmnElement="Activity_09orc6r">
-        <dc:Bounds x="270" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1lss22g_di" bpmnElement="Event_1lss22g">
-        <dc:Bounds x="432" y="99" width="36" height="36" />
+      <bpmndi:BPMNShape id="Participant_1w78ag3_di" bpmnElement="Participant_2" isHorizontal="true">
+        <dc:Bounds x="160" y="360" width="600" height="250" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/camunda-platform/integration/history-time-to-live.spec.js
+++ b/test/camunda-platform/integration/history-time-to-live.spec.js
@@ -7,7 +7,7 @@ const NodeResolver = require('bpmnlint/lib/resolver/node-resolver');
 const { readModdle } = require('../../helper');
 
 const versions = [
-  '7.19',
+  '7.19'
 ];
 
 describe('integration - history-time-to-live', function() {

--- a/test/camunda-platform/integration/history-time-to-live.spec.js
+++ b/test/camunda-platform/integration/history-time-to-live.spec.js
@@ -1,0 +1,68 @@
+const { expect } = require('chai');
+
+const Linter = require('bpmnlint/lib/linter');
+
+const NodeResolver = require('bpmnlint/lib/resolver/node-resolver');
+
+const { readModdle } = require('../../helper');
+
+const versions = [
+  '7.19',
+];
+
+describe('integration - history-time-to-live', function() {
+
+  versions.forEach(function(version) {
+
+    let linter;
+
+    beforeEach(function() {
+      linter = new Linter({
+        config: {
+          extends: `plugin:camunda-compat/camunda-platform-${ version.replace('.', '-') }`
+        },
+        resolver: new NodeResolver()
+      });
+    });
+
+
+    describe(`Camunda Platform ${ version }`, function() {
+
+      describe('no errors', function() {
+
+        it('should not have errors', async function() {
+
+          // given
+          const { root } = await readModdle('test/camunda-platform/integration/history-time-to-live.bpmn');
+
+          // when
+          const reports = await linter.lint(root);
+
+          // then
+          expect(reports[ 'camunda-compat/history-time-to-live' ]).not.to.exist;
+        });
+
+      });
+
+
+      describe('errors', function() {
+
+        it('should have errors', async function() {
+
+          // given
+          const { root } = await readModdle('test/camunda-platform/integration/history-time-to-live-errors.bpmn');
+
+          // when
+          const reports = await linter.lint(root);
+
+          // then
+          expect(reports[ 'camunda-compat/history-time-to-live' ]).to.exist;
+        });
+
+      });
+
+    });
+
+  });
+
+});

--- a/test/config/configs.spec.js
+++ b/test/config/configs.spec.js
@@ -154,6 +154,11 @@ describe('configs', function() {
     'user-task-form': [ 'error', { version: '8.2' } ]
   }));
 
+
+  it('camunda-platform-7-19', expectRules(configs, 'camunda-platform-7-19', {
+    'history-time-to-live': [ 'error', { platform: 'camunda-platform', version: '7.19' } ]
+  }));
+
 });
 
 function expectRules(configs, name, rules) {

--- a/test/helper.js
+++ b/test/helper.js
@@ -2,9 +2,9 @@ const BpmnModdle = require('bpmn-moddle');
 
 const { isArray } = require('min-dash');
 
-const modelerModdleSchema = require('modeler-moddle/resources/modeler.json'),
-      zeebeModdleSchema = require('zeebe-bpmn-moddle/resources/zeebe.json'),
-      camundaModdleSchema = require('camunda-bpmn-moddle/resources/camunda.json');
+const camundaModdleSchema = require('camunda-bpmn-moddle/resources/camunda.json'),
+      modelerModdleSchema = require('modeler-moddle/resources/modeler.json'),
+      zeebeModdleSchema = require('zeebe-bpmn-moddle/resources/zeebe.json');
 
 const { readFileSync } = require('fs');
 
@@ -48,14 +48,15 @@ module.exports.createProcess = function(bpmn = '', bpmndi = '') {
 
 module.exports.readModdle = function(filePath) {
   const contents = readFileSync(filePath, 'utf8');
-  const platformSchema = filePath.includes('camunda-cloud') ? 'zeebe' : 'platform';
 
-  return createModdle(contents, platformSchema);
+  const executionPlatform = filePath.includes('camunda-cloud') ? 'camunda-cloud' : 'camunda-platform';
+
+  return createModdle(contents, executionPlatform);
 };
 
-async function createModdle(xml, platformSchema = 'zeebe') {
-  const moddleSchema = (platformSchema === 'zeebe') ?
-    { zeebe: zeebeModdleSchema }
+async function createModdle(xml, executionPlatform = 'camunda-cloud') {
+  const moddleSchema = executionPlatform === 'camunda-cloud'
+    ? { zeebe: zeebeModdleSchema }
     : { camunda: camundaModdleSchema };
 
   const moddle = new BpmnModdle({

--- a/test/helper.js
+++ b/test/helper.js
@@ -3,7 +3,8 @@ const BpmnModdle = require('bpmn-moddle');
 const { isArray } = require('min-dash');
 
 const modelerModdleSchema = require('modeler-moddle/resources/modeler.json'),
-      zeebeModdleSchema = require('zeebe-bpmn-moddle/resources/zeebe.json');
+      zeebeModdleSchema = require('zeebe-bpmn-moddle/resources/zeebe.json'),
+      camundaModdleSchema = require('camunda-bpmn-moddle/resources/camunda.json');
 
 const { readFileSync } = require('fs');
 
@@ -47,14 +48,19 @@ module.exports.createProcess = function(bpmn = '', bpmndi = '') {
 
 module.exports.readModdle = function(filePath) {
   const contents = readFileSync(filePath, 'utf8');
+  const platformSchema = filePath.includes('camunda-cloud') ? 'zeebe' : 'platform';
 
-  return createModdle(contents);
+  return createModdle(contents, platformSchema);
 };
 
-async function createModdle(xml) {
+async function createModdle(xml, platformSchema = 'zeebe') {
+  const moddleSchema = (platformSchema === 'zeebe') ?
+    { zeebe: zeebeModdleSchema }
+    : { camunda: camundaModdleSchema };
+
   const moddle = new BpmnModdle({
     modeler: modelerModdleSchema,
-    zeebe: zeebeModdleSchema
+    ...moddleSchema
   });
 
   let root, warnings;

--- a/test/helper.js
+++ b/test/helper.js
@@ -87,6 +87,14 @@ async function createModdle(xml, executionPlatform = 'camunda-cloud') {
 
 module.exports.createModdle = createModdle;
 
+module.exports.createModdleCamundaCloud = function(xml) {
+  return createModdle(xml, 'camunda-cloud');
+};
+
+module.exports.createModdleCamundaPlatform = function(xml) {
+  return createModdle(xml, 'camunda-platform');
+};
+
 function createElement(type, properties) {
   const moddle = new BpmnModdle({
     modeler: modelerModdleSchema,


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/3369

Since we can't fully separate the rules in nested folders (because of `bpmnlint`), it's mixed in with the other rules. I also tried to accommodate for it (in tests and helpers) without making too many changes - feel free to propose a better structure