### PR TITLE
fix: report missing `errorCode` in Camunda 8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [bpmnlint-plugin-camunda-compat](https://github.com/camun
 
 ___Note:__ Yet to be released changes appear here._
 
+# 1.0.1
+
+* `FIX`: report missing errorCode in Camunda 8.2 ([#91](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/91))
+
 # 1.0.0
 
 * `FIX`: fix typo in error type `PROPERTY_DEPENDENT_REQUIRED` ([#90](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/90))

--- a/test/camunda-cloud/error-reference.spec.js
+++ b/test/camunda-cloud/error-reference.spec.js
@@ -92,10 +92,37 @@ const invalid = [
     }
   },
   {
-    name: 'error end event (no error code)',
+    name: 'error end event (no error code) (Camunda 8.1)',
     config: { version: '8.1' },
     moddleElement: createModdle(createDefinitions(`
-      <bpmn:process id="Process_1">
+      <bpmn:process id="Process_1" isExecutable="true">
+        <bpmn:endEvent id="EndEvent_1">
+          <bpmn:errorEventDefinition id="ErrorEventDefinition_1" errorRef="Error_1" />
+        </bpmn:endEvent>
+      </bpmn:process>
+      <bpmn:error id="Error_1" />
+    `)),
+    report: {
+      id: 'EndEvent_1',
+      message: 'Element of type <bpmn:Error> must have property <errorCode>',
+      path: [
+        'rootElements',
+        1,
+        'errorCode'
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'Error_1',
+        parentNode: 'EndEvent_1',
+        requiredProperty: 'errorCode'
+      }
+    }
+  },
+  {
+    name: 'error end event (no error code) (Camunda 8.2)',
+    config: { version: '8.2' },
+    moddleElement: createModdle(createDefinitions(`
+      <bpmn:process id="Process_1" isExecutable="true">
         <bpmn:endEvent id="EndEvent_1">
           <bpmn:errorEventDefinition id="ErrorEventDefinition_1" errorRef="Error_1" />
         </bpmn:endEvent>


### PR DESCRIPTION
Missing `errorCode` wouldn't get reported due to early return. 🤦🏻‍♂️ `v1.0.1`, here we go! 🔥 