### PR TITLE
Support Signal Intermediate Throw and End Event in Camunda 8.3

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,10 @@ const camundaCloud82Rules = withConfig({
   'task-schedule': 'error'
 }, { version: '8.2' });
 
-const camundaCloud83Rules = withConfig(camundaCloud82Rules, { version: '8.3' });
+const camundaCloud83Rules = withConfig({
+  ...camundaCloud82Rules,
+  'signal-reference': 'error'
+}, { version: '8.3' });
 
 const camundaPlatform719Rules = withConfig({
   'history-time-to-live': 'error'

--- a/index.js
+++ b/index.js
@@ -47,6 +47,8 @@ const camundaCloud82Rules = withConfig({
   'task-schedule': 'error'
 }, { version: '8.2' });
 
+const camundaCloud83Rules = withConfig(camundaCloud82Rules, { version: '8.3' });
+
 const camundaPlatform719Rules = withConfig({
   'history-time-to-live': 'error'
 }, { platform: 'camunda-platform', version: '7.19' });
@@ -73,6 +75,9 @@ module.exports = {
     },
     'camunda-cloud-8-2': {
       rules: camundaCloud82Rules
+    },
+    'camunda-cloud-8-3': {
+      rules: camundaCloud83Rules
     },
     'camunda-platform-7-19': {
       rules: camundaPlatform719Rules

--- a/rules/element-type/config.js
+++ b/rules/element-type/config.js
@@ -26,14 +26,14 @@ module.exports = {
   'bpmn:InclusiveGateway': '8.1',
   'bpmn:IntermediateCatchEvent': {
     'bpmn:MessageEventDefinition': '1.0',
-    'bpmn:TimerEventDefinition': '1.0',
-    'bpmn:LinkEventDefinition': '8.2'
+    'bpmn:LinkEventDefinition': '8.2',
+    'bpmn:TimerEventDefinition': '1.0'
   },
   'bpmn:IntermediateThrowEvent': {
     '_': '1.1',
     'bpmn:EscalationEventDefinition': '8.2',
-    'bpmn:MessageEventDefinition': '1.2',
-    'bpmn:LinkEventDefinition': '8.2'
+    'bpmn:LinkEventDefinition': '8.2',
+    'bpmn:MessageEventDefinition': '1.2'
   },
   'bpmn:ManualTask': '1.1',
   'bpmn:MessageFlow': '1.0',

--- a/rules/element-type/config.js
+++ b/rules/element-type/config.js
@@ -18,6 +18,7 @@ module.exports = {
     'bpmn:ErrorEventDefinition': '1.0',
     'bpmn:EscalationEventDefinition': '8.2',
     'bpmn:MessageEventDefinition': '1.2',
+    'bpmn:SignalEventDefinition': '8.3',
     'bpmn:TerminateEventDefinition': '8.1'
   },
   'bpmn:EventBasedGateway': '1.0',
@@ -33,7 +34,8 @@ module.exports = {
     '_': '1.1',
     'bpmn:EscalationEventDefinition': '8.2',
     'bpmn:LinkEventDefinition': '8.2',
-    'bpmn:MessageEventDefinition': '1.2'
+    'bpmn:MessageEventDefinition': '1.2',
+    'bpmn:SignalEventDefinition': '8.3'
   },
   'bpmn:ManualTask': '1.1',
   'bpmn:MessageFlow': '1.0',

--- a/rules/no-expression.js
+++ b/rules/no-expression.js
@@ -65,6 +65,10 @@ function noExpressionRule({ version }) {
 function checkForVersion(node, version) {
   const handlers = handlersMap[version];
 
+  if (!handlers) {
+    return [];
+  }
+
   return handlers.reduce((errors, handler) => {
     const handlerErrors = handler(node) || [];
     return errors.concat(handlerErrors);

--- a/rules/no-expression.js
+++ b/rules/no-expression.js
@@ -35,6 +35,10 @@ const handlersMap = {
   '8.2': [
     checkErrorCatchEvent,
     checkEscalationCatchEvent
+  ],
+  '8.3': [
+    checkErrorCatchEvent,
+    checkEscalationCatchEvent
   ]
 };
 

--- a/rules/signal-reference.js
+++ b/rules/signal-reference.js
@@ -1,0 +1,59 @@
+const {
+  is,
+  isAny
+} = require('bpmnlint-utils');
+
+const {
+  getEventDefinition,
+  hasProperties
+} = require('./utils/element');
+
+const { reportErrors } = require('./utils/reporter');
+
+const { skipInNonExecutableProcess } = require('./utils/rule');
+
+module.exports = skipInNonExecutableProcess(function() {
+  function check(node, reporter) {
+    if (!isAny(node, [ 'bpmn:StartEvent', 'bpmn:IntermediateThrowEvent', 'bpmn:EndEvent' ])) {
+      return;
+    }
+
+    const eventDefinition = getEventDefinition(node);
+
+    if (!eventDefinition || !is(eventDefinition, 'bpmn:SignalEventDefinition')) {
+      return;
+    }
+
+    let errors = hasProperties(eventDefinition, {
+      signalRef: {
+        required: true
+      }
+    }, node);
+
+    if (errors.length) {
+      reportErrors(node, reporter, errors);
+
+      return;
+    }
+
+    const signalRef = eventDefinition.get('signalRef');
+
+    if (!signalRef) {
+      return;
+    }
+
+    errors = hasProperties(signalRef, {
+      name: {
+        required: true
+      }
+    }, node);
+
+    if (errors.length) {
+      reportErrors(node, reporter, errors);
+    }
+  }
+
+  return {
+    check
+  };
+});

--- a/test/camunda-cloud/camunda-cloud-1-0-element-type.spec.js
+++ b/test/camunda-cloud/camunda-cloud-1-0-element-type.spec.js
@@ -333,6 +333,46 @@ const invalid = [
         allowedVersion: '8.0'
       }
     }
+  },
+  {
+    name: 'signal intermediate throw event',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:intermediateThrowEvent id="IntermediateThrowEvent_1">
+        <bpmn:signalEventDefinition id="SignalEventDefinition_1" />
+      </bpmn:intermediateThrowEvent>
+    `)),
+    report: {
+      id: 'IntermediateThrowEvent_1',
+      message: 'Element of type <bpmn:IntermediateThrowEvent> with event definition of type <bpmn:SignalEventDefinition> only allowed by Camunda Platform 8.3 or newer',
+      path: null,
+      data: {
+        type: ERROR_TYPES.ELEMENT_TYPE_NOT_ALLOWED,
+        node: 'IntermediateThrowEvent_1',
+        parentNode: null,
+        eventDefinition: 'SignalEventDefinition_1',
+        allowedVersion: '8.3'
+      }
+    }
+  },
+  {
+    name: 'signal end event',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:endEvent id="EndEvent_1">
+        <bpmn:signalEventDefinition id="SignalEventDefinition_1" />
+      </bpmn:endEvent>
+    `)),
+    report: {
+      id: 'EndEvent_1',
+      message: 'Element of type <bpmn:EndEvent> with event definition of type <bpmn:SignalEventDefinition> only allowed by Camunda Platform 8.3 or newer',
+      path: null,
+      data: {
+        type: ERROR_TYPES.ELEMENT_TYPE_NOT_ALLOWED,
+        node: 'EndEvent_1',
+        parentNode: null,
+        eventDefinition: 'SignalEventDefinition_1',
+        allowedVersion: '8.3'
+      }
+    }
   }
 ];
 

--- a/test/camunda-cloud/camunda-cloud-1-0-element-type.spec.js
+++ b/test/camunda-cloud/camunda-cloud-1-0-element-type.spec.js
@@ -303,7 +303,7 @@ const invalid = [
   {
     name: 'data store',
     moddleElement: createModdle(createProcess(`
-    <bpmn:dataStoreReference id="DataStoreReference_1" />
+      <bpmn:dataStoreReference id="DataStoreReference_1" />
     `)),
     report: {
       id: 'DataStoreReference_1',
@@ -320,7 +320,7 @@ const invalid = [
   {
     name: 'data object',
     moddleElement: createModdle(createProcess(`
-    <bpmn:dataObjectReference id="DataObjectReference_1" />
+      <bpmn:dataObjectReference id="DataObjectReference_1" />
     `)),
     report: {
       id: 'DataObjectReference_1',

--- a/test/camunda-cloud/camunda-cloud-1-1-element-type.spec.js
+++ b/test/camunda-cloud/camunda-cloud-1-1-element-type.spec.js
@@ -149,6 +149,46 @@ const invalid = [
         allowedVersion: '8.0'
       }
     }
+  },
+  {
+    name: 'signal intermediate throw event',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:intermediateThrowEvent id="IntermediateThrowEvent_1">
+        <bpmn:signalEventDefinition id="SignalEventDefinition_1" />
+      </bpmn:intermediateThrowEvent>
+    `)),
+    report: {
+      id: 'IntermediateThrowEvent_1',
+      message: 'Element of type <bpmn:IntermediateThrowEvent> with event definition of type <bpmn:SignalEventDefinition> only allowed by Camunda Platform 8.3 or newer',
+      path: null,
+      data: {
+        type: ERROR_TYPES.ELEMENT_TYPE_NOT_ALLOWED,
+        node: 'IntermediateThrowEvent_1',
+        parentNode: null,
+        eventDefinition: 'SignalEventDefinition_1',
+        allowedVersion: '8.3'
+      }
+    }
+  },
+  {
+    name: 'signal end event',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:endEvent id="EndEvent_1">
+        <bpmn:signalEventDefinition id="SignalEventDefinition_1" />
+      </bpmn:endEvent>
+    `)),
+    report: {
+      id: 'EndEvent_1',
+      message: 'Element of type <bpmn:EndEvent> with event definition of type <bpmn:SignalEventDefinition> only allowed by Camunda Platform 8.3 or newer',
+      path: null,
+      data: {
+        type: ERROR_TYPES.ELEMENT_TYPE_NOT_ALLOWED,
+        node: 'EndEvent_1',
+        parentNode: null,
+        eventDefinition: 'SignalEventDefinition_1',
+        allowedVersion: '8.3'
+      }
+    }
   }
 ];
 

--- a/test/camunda-cloud/camunda-cloud-1-1-element-type.spec.js
+++ b/test/camunda-cloud/camunda-cloud-1-1-element-type.spec.js
@@ -119,7 +119,7 @@ const invalid = [
   {
     name: 'data store',
     moddleElement: createModdle(createProcess(`
-    <bpmn:dataStoreReference id="DataStoreReference_1" />
+      <bpmn:dataStoreReference id="DataStoreReference_1" />
     `)),
     report: {
       id: 'DataStoreReference_1',
@@ -136,7 +136,7 @@ const invalid = [
   {
     name: 'data object',
     moddleElement: createModdle(createProcess(`
-    <bpmn:dataObjectReference id="DataObjectReference_1" />
+      <bpmn:dataObjectReference id="DataObjectReference_1" />
     `)),
     report: {
       id: 'DataObjectReference_1',

--- a/test/camunda-cloud/camunda-cloud-1-2-element-type.spec.js
+++ b/test/camunda-cloud/camunda-cloud-1-2-element-type.spec.js
@@ -161,6 +161,46 @@ const invalid = [
         allowedVersion: '8.0'
       }
     }
+  },
+  {
+    name: 'signal intermediate throw event',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:intermediateThrowEvent id="IntermediateThrowEvent_1">
+        <bpmn:signalEventDefinition id="SignalEventDefinition_1" />
+      </bpmn:intermediateThrowEvent>
+    `)),
+    report: {
+      id: 'IntermediateThrowEvent_1',
+      message: 'Element of type <bpmn:IntermediateThrowEvent> with event definition of type <bpmn:SignalEventDefinition> only allowed by Camunda Platform 8.3 or newer',
+      path: null,
+      data: {
+        type: ERROR_TYPES.ELEMENT_TYPE_NOT_ALLOWED,
+        node: 'IntermediateThrowEvent_1',
+        parentNode: null,
+        eventDefinition: 'SignalEventDefinition_1',
+        allowedVersion: '8.3'
+      }
+    }
+  },
+  {
+    name: 'signal end event',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:endEvent id="EndEvent_1">
+        <bpmn:signalEventDefinition id="SignalEventDefinition_1" />
+      </bpmn:endEvent>
+    `)),
+    report: {
+      id: 'EndEvent_1',
+      message: 'Element of type <bpmn:EndEvent> with event definition of type <bpmn:SignalEventDefinition> only allowed by Camunda Platform 8.3 or newer',
+      path: null,
+      data: {
+        type: ERROR_TYPES.ELEMENT_TYPE_NOT_ALLOWED,
+        node: 'EndEvent_1',
+        parentNode: null,
+        eventDefinition: 'SignalEventDefinition_1',
+        allowedVersion: '8.3'
+      }
+    }
   }
 ];
 

--- a/test/camunda-cloud/camunda-cloud-1-2-element-type.spec.js
+++ b/test/camunda-cloud/camunda-cloud-1-2-element-type.spec.js
@@ -131,7 +131,7 @@ const invalid = [
   {
     name: 'data store',
     moddleElement: createModdle(createProcess(`
-    <bpmn:dataStoreReference id="DataStoreReference_1" />
+      <bpmn:dataStoreReference id="DataStoreReference_1" />
     `)),
     report: {
       id: 'DataStoreReference_1',
@@ -148,7 +148,7 @@ const invalid = [
   {
     name: 'data object',
     moddleElement: createModdle(createProcess(`
-    <bpmn:dataObjectReference id="DataObjectReference_1" />
+      <bpmn:dataObjectReference id="DataObjectReference_1" />
     `)),
     report: {
       id: 'DataObjectReference_1',

--- a/test/camunda-cloud/camunda-cloud-8-0-element-type.spec.js
+++ b/test/camunda-cloud/camunda-cloud-8-0-element-type.spec.js
@@ -15,13 +15,13 @@ const valid = [
   {
     name: 'data store',
     moddleElement: createModdle(createProcess(`
-    <bpmn:dataStoreReference id="DataStoreReference_1" />
+      <bpmn:dataStoreReference id="DataStoreReference_1" />
     `))
   },
   {
     name: 'data object',
     moddleElement: createModdle(createProcess(`
-    <bpmn:dataObjectReference id="DataObjectReference_1" />
+      <bpmn:dataObjectReference id="DataObjectReference_1" />
     `))
   }
 ];

--- a/test/camunda-cloud/camunda-cloud-8-0-element-type.spec.js
+++ b/test/camunda-cloud/camunda-cloud-8-0-element-type.spec.js
@@ -88,6 +88,46 @@ const invalid = [
         allowedVersion: '8.2'
       }
     }
+  },
+  {
+    name: 'signal intermediate throw event',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:intermediateThrowEvent id="IntermediateThrowEvent_1">
+        <bpmn:signalEventDefinition id="SignalEventDefinition_1" />
+      </bpmn:intermediateThrowEvent>
+    `)),
+    report: {
+      id: 'IntermediateThrowEvent_1',
+      message: 'Element of type <bpmn:IntermediateThrowEvent> with event definition of type <bpmn:SignalEventDefinition> only allowed by Camunda Platform 8.3 or newer',
+      path: null,
+      data: {
+        type: ERROR_TYPES.ELEMENT_TYPE_NOT_ALLOWED,
+        node: 'IntermediateThrowEvent_1',
+        parentNode: null,
+        eventDefinition: 'SignalEventDefinition_1',
+        allowedVersion: '8.3'
+      }
+    }
+  },
+  {
+    name: 'signal end event',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:endEvent id="EndEvent_1">
+        <bpmn:signalEventDefinition id="SignalEventDefinition_1" />
+      </bpmn:endEvent>
+    `)),
+    report: {
+      id: 'EndEvent_1',
+      message: 'Element of type <bpmn:EndEvent> with event definition of type <bpmn:SignalEventDefinition> only allowed by Camunda Platform 8.3 or newer',
+      path: null,
+      data: {
+        type: ERROR_TYPES.ELEMENT_TYPE_NOT_ALLOWED,
+        node: 'EndEvent_1',
+        parentNode: null,
+        eventDefinition: 'SignalEventDefinition_1',
+        allowedVersion: '8.3'
+      }
+    }
   }
 ];
 

--- a/test/camunda-cloud/camunda-cloud-8-1-element-type.spec.js
+++ b/test/camunda-cloud/camunda-cloud-8-1-element-type.spec.js
@@ -127,6 +127,46 @@ const invalid = [
         }
       }
     ]
+  },
+  {
+    name: 'signal intermediate throw event',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:intermediateThrowEvent id="IntermediateThrowEvent_1">
+        <bpmn:signalEventDefinition id="SignalEventDefinition_1" />
+      </bpmn:intermediateThrowEvent>
+    `)),
+    report: {
+      id: 'IntermediateThrowEvent_1',
+      message: 'Element of type <bpmn:IntermediateThrowEvent> with event definition of type <bpmn:SignalEventDefinition> only allowed by Camunda Platform 8.3 or newer',
+      path: null,
+      data: {
+        type: ERROR_TYPES.ELEMENT_TYPE_NOT_ALLOWED,
+        node: 'IntermediateThrowEvent_1',
+        parentNode: null,
+        eventDefinition: 'SignalEventDefinition_1',
+        allowedVersion: '8.3'
+      }
+    }
+  },
+  {
+    name: 'signal end event',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:endEvent id="EndEvent_1">
+        <bpmn:signalEventDefinition id="SignalEventDefinition_1" />
+      </bpmn:endEvent>
+    `)),
+    report: {
+      id: 'EndEvent_1',
+      message: 'Element of type <bpmn:EndEvent> with event definition of type <bpmn:SignalEventDefinition> only allowed by Camunda Platform 8.3 or newer',
+      path: null,
+      data: {
+        type: ERROR_TYPES.ELEMENT_TYPE_NOT_ALLOWED,
+        node: 'EndEvent_1',
+        parentNode: null,
+        eventDefinition: 'SignalEventDefinition_1',
+        allowedVersion: '8.3'
+      }
+    }
   }
 ];
 

--- a/test/camunda-cloud/camunda-cloud-8-1-element-type.spec.js
+++ b/test/camunda-cloud/camunda-cloud-8-1-element-type.spec.js
@@ -21,9 +21,9 @@ const valid = [
   {
     name: 'Terminate end event',
     moddleElement: createModdle(createProcess(`
-    <bpmn:endEvent id="Event_1qpo2zy">
-      <bpmn:terminateEventDefinition id="TerminateEventDefinition_0c6uql1" />
-    </bpmn:endEvent>
+      <bpmn:endEvent id="Event_1qpo2zy">
+        <bpmn:terminateEventDefinition id="TerminateEventDefinition_0c6uql1" />
+      </bpmn:endEvent>
     `))
   }
 ];

--- a/test/camunda-cloud/camunda-cloud-8-2-element-type.spec.js
+++ b/test/camunda-cloud/camunda-cloud-8-2-element-type.spec.js
@@ -79,9 +79,9 @@ const valid = [
   {
     name: 'intermediate catch event (non-executable process)',
     moddleElement: createModdle(createDefinitions(`
-    <bpmn:process id="Process_1">
-      <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_1" />
-    </bpmn:process>
+      <bpmn:process id="Process_1">
+        <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_1" />
+      </bpmn:process>
     `))
   }
 ];

--- a/test/camunda-cloud/camunda-cloud-8-3-element-type.spec.js
+++ b/test/camunda-cloud/camunda-cloud-8-3-element-type.spec.js
@@ -12,7 +12,7 @@ const {
 const { ERROR_TYPES } = require('../../rules/utils/element');
 
 const valid = [
-  ...require('./camunda-cloud-8-1-element-type.spec').valid,
+  ...require('./camunda-cloud-8-2-element-type.spec').valid,
   {
     name: 'task',
     moddleElement: createModdle(createProcess('<bpmn:task id="Task_1" />'))
@@ -83,10 +83,24 @@ const valid = [
         <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_1" />
       </bpmn:process>
     `))
+  },
+  {
+    name: 'signal intermediate throw event',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:intermediateThrowEvent id="IntermediateThrowEvent_1">
+        <bpmn:signalEventDefinition id="SignalEventDefinition_1" />
+      </bpmn:intermediateThrowEvent>
+    `))
+  },
+  {
+    name: 'signal end event',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:endEvent id="EndEvent_1">
+        <bpmn:signalEventDefinition id="SignalEventDefinition_1" />
+      </bpmn:endEvent>
+    `))
   }
 ];
-
-module.exports.valid = valid;
 
 const invalid = [
   {
@@ -133,50 +147,10 @@ const invalid = [
         parentNode: null
       }
     }
-  },
-  {
-    name: 'signal intermediate throw event',
-    moddleElement: createModdle(createProcess(`
-      <bpmn:intermediateThrowEvent id="IntermediateThrowEvent_1">
-        <bpmn:signalEventDefinition id="SignalEventDefinition_1" />
-      </bpmn:intermediateThrowEvent>
-    `)),
-    report: {
-      id: 'IntermediateThrowEvent_1',
-      message: 'Element of type <bpmn:IntermediateThrowEvent> with event definition of type <bpmn:SignalEventDefinition> only allowed by Camunda Platform 8.3 or newer',
-      path: null,
-      data: {
-        type: ERROR_TYPES.ELEMENT_TYPE_NOT_ALLOWED,
-        node: 'IntermediateThrowEvent_1',
-        parentNode: null,
-        eventDefinition: 'SignalEventDefinition_1',
-        allowedVersion: '8.3'
-      }
-    }
-  },
-  {
-    name: 'signal end event',
-    moddleElement: createModdle(createProcess(`
-      <bpmn:endEvent id="EndEvent_1">
-        <bpmn:signalEventDefinition id="SignalEventDefinition_1" />
-      </bpmn:endEvent>
-    `)),
-    report: {
-      id: 'EndEvent_1',
-      message: 'Element of type <bpmn:EndEvent> with event definition of type <bpmn:SignalEventDefinition> only allowed by Camunda Platform 8.3 or newer',
-      path: null,
-      data: {
-        type: ERROR_TYPES.ELEMENT_TYPE_NOT_ALLOWED,
-        node: 'EndEvent_1',
-        parentNode: null,
-        eventDefinition: 'SignalEventDefinition_1',
-        allowedVersion: '8.3'
-      }
-    }
   }
 ];
 
-RuleTester.verify('camunda-cloud-8-2-element-type', rule, {
-  valid: withConfig(valid, { version: '8.2' }),
-  invalid: withConfig(invalid, { version: '8.2' })
+RuleTester.verify('camunda-cloud-8-3-element-type', rule, {
+  valid: withConfig(valid, { version: '8.3' }),
+  invalid: withConfig(invalid, { version: '8.3' })
 });

--- a/test/camunda-cloud/error-reference.spec.js
+++ b/test/camunda-cloud/error-reference.spec.js
@@ -198,7 +198,7 @@ const invalid = [
         requiredProperty: 'errorCode'
       }
     }
-  },
+  }
 ];
 
 RuleTester.verify('error-reference', rule, {

--- a/test/camunda-cloud/implementation.spec.js
+++ b/test/camunda-cloud/implementation.spec.js
@@ -596,7 +596,7 @@ const invalid = [
         requiredProperty: 'resultVariable'
       }
     }
-  },
+  }
 ];
 
 RuleTester.verify('implementation', rule, {

--- a/test/camunda-cloud/integration/camunda-cloud-8-3-element-type-errors.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-8-3-element-type-errors.bpmn
@@ -1,0 +1,494 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0pbksug" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.5.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.3.0">
+  <bpmn:collaboration id="Collaboration_0hnpxxj">
+    <bpmn:participant id="Participant_1d3u7q6" processRef="Process_0vsq5kz" />
+    <bpmn:participant id="Participant_1urnon6" />
+    <bpmn:messageFlow id="Flow_0z4inc6" sourceRef="Participant_1urnon6" targetRef="Participant_1d3u7q6" />
+    <bpmn:group id="Group_0ma761l" />
+    <bpmn:textAnnotation id="TextAnnotation_0yyvgv8" />
+    <bpmn:association id="Association_1andiqd" sourceRef="Participant_1urnon6" targetRef="TextAnnotation_0yyvgv8" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_0vsq5kz" isExecutable="true">
+    <bpmn:sendTask id="Activity_0hifi7a">
+      <bpmn:incoming>Flow_0zrg42j</bpmn:incoming>
+      <bpmn:outgoing>Flow_1q7z4jd</bpmn:outgoing>
+    </bpmn:sendTask>
+    <bpmn:receiveTask id="Activity_1vno0ey">
+      <bpmn:incoming>Flow_1q7z4jd</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ktumbe</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:userTask id="Activity_1kwbjs8">
+      <bpmn:incoming>Flow_1ktumbe</bpmn:incoming>
+      <bpmn:outgoing>Flow_15iu8ql</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:manualTask id="Activity_1bp6c09">
+      <bpmn:incoming>Flow_15iu8ql</bpmn:incoming>
+      <bpmn:outgoing>Flow_0f0cw0k</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:businessRuleTask id="Activity_1pvu3g5">
+      <bpmn:incoming>Flow_0f0cw0k</bpmn:incoming>
+      <bpmn:outgoing>Flow_1vgf7tg</bpmn:outgoing>
+    </bpmn:businessRuleTask>
+    <bpmn:serviceTask id="Activity_0zp5887">
+      <bpmn:incoming>Flow_1vgf7tg</bpmn:incoming>
+      <bpmn:outgoing>Flow_0bejje3</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:scriptTask id="Activity_1j3irvn">
+      <bpmn:incoming>Flow_0bejje3</bpmn:incoming>
+      <bpmn:outgoing>Flow_1s28mu2</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:callActivity id="Activity_0f2pmcw">
+      <bpmn:incoming>Flow_1s28mu2</bpmn:incoming>
+      <bpmn:outgoing>Flow_00w4v7n</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="Event_1kvsony">
+      <bpmn:incoming>Flow_0fcl9ds</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:startEvent id="Event_1sik4ir">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1dqeihq" />
+    </bpmn:startEvent>
+    <bpmn:startEvent id="Event_0sug9c8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_09iembn" />
+    </bpmn:startEvent>
+    <bpmn:startEvent id="Event_1mlyq56">
+      <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_0y1o8w9">
+        <bpmn:condition xsi:type="bpmn:tFormalExpression" />
+      </bpmn:conditionalEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:startEvent id="Event_08y7buv">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_1g1ahc8" />
+    </bpmn:startEvent>
+    <bpmn:intermediateThrowEvent id="Event_13sqei3" />
+    <bpmn:intermediateCatchEvent id="Event_1yebdzz">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_03inc7e" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateThrowEvent id="Event_1tl88e7">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1fifzss" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:intermediateCatchEvent id="Event_1qhglqg">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1vbhrzi" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateThrowEvent id="Event_1fb2uyx">
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_1r8c2bd" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:intermediateCatchEvent id="Event_1cdxynr">
+      <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_0016c3a">
+        <bpmn:condition xsi:type="bpmn:tFormalExpression" />
+      </bpmn:conditionalEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateThrowEvent id="Event_143034p">
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_19qzhq6" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:intermediateCatchEvent id="Event_1inzg0a">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_1hbtft5" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateThrowEvent id="Event_0mdb56m">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_1awhs8b" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:endEvent id="Event_00km32j">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0s0a93g" />
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_09tepzu">
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_1lfe75d" />
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_1nig1bg">
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0c3ll4b" />
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_0vvvebn">
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_16lxpyp" />
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_0kd0oqx">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_04dcslm" />
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_1ju6z4u">
+      <bpmn:terminateEventDefinition id="TerminateEventDefinition_0exip3l" />
+    </bpmn:endEvent>
+    <bpmn:exclusiveGateway id="Gateway_1cux9or" />
+    <bpmn:parallelGateway id="Gateway_0d8i5nb" />
+    <bpmn:inclusiveGateway id="Gateway_0m8jsue" />
+    <bpmn:complexGateway id="Gateway_1lxsbxz" />
+    <bpmn:eventBasedGateway id="Gateway_0ucgat5" />
+    <bpmn:task id="Activity_0u9hvk8" isForCompensation="true" />
+    <bpmn:subProcess id="Activity_18lrl5o">
+      <bpmn:incoming>Flow_00w4v7n</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ymtwgk</bpmn:outgoing>
+      <bpmn:startEvent id="Event_1woqh9b">
+        <bpmn:outgoing>Flow_01mxrfh</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:task id="Activity_1j5vlu2">
+        <bpmn:incoming>Flow_01mxrfh</bpmn:incoming>
+        <bpmn:outgoing>Flow_10m6o1a</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:sequenceFlow id="Flow_01mxrfh" sourceRef="Event_1woqh9b" targetRef="Activity_1j5vlu2" />
+      <bpmn:endEvent id="Event_0p9vdz4">
+        <bpmn:incoming>Flow_10m6o1a</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_10m6o1a" sourceRef="Activity_1j5vlu2" targetRef="Event_0p9vdz4" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="Activity_05jt1pz">
+      <bpmn:incoming>Flow_1ymtwgk</bpmn:incoming>
+      <bpmn:outgoing>Flow_0fcl9ds</bpmn:outgoing>
+    </bpmn:subProcess>
+    <bpmn:transaction id="Activity_0lvrtc3" />
+    <bpmn:subProcess id="Activity_10ml8f5" triggeredByEvent="true">
+      <bpmn:startEvent id="Event_0e5fobq">
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_0ntzcza" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="Event_04vjlly">
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_1tz13oy" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="Event_1n4h052">
+        <bpmn:compensateEventDefinition id="CompensateEventDefinition_0h0toxw" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="Event_1icr23y" isInterrupting="false">
+        <bpmn:messageEventDefinition id="MessageEventDefinition_03xjf10" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="Event_1gh3swq" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_12rfa0p" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="Event_1f4hda7" isInterrupting="false">
+        <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_00rrqi2">
+          <bpmn:condition xsi:type="bpmn:tFormalExpression" />
+        </bpmn:conditionalEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="Event_15xo5kw" isInterrupting="false">
+        <bpmn:signalEventDefinition id="SignalEventDefinition_1ux385d" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="Event_0m5bm2q" isInterrupting="false">
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_139c8rm" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="Event_0soqabs" attachedToRef="Activity_05jt1pz" />
+    <bpmn:boundaryEvent id="Event_0v6xk6w" attachedToRef="Activity_05jt1pz">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0xd75mh" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_15ztmj6" attachedToRef="Activity_05jt1pz">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_06rc1eo" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_040kzqb" attachedToRef="Activity_05jt1pz">
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_19o4ttm" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_1ki32zr" attachedToRef="Activity_05jt1pz">
+      <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_0t2jyfm">
+        <bpmn:condition xsi:type="bpmn:tFormalExpression" />
+      </bpmn:conditionalEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_0qbl3tj" attachedToRef="Activity_05jt1pz">
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_00rink1" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_0a2uqrs" attachedToRef="Activity_05jt1pz">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_10zsnh7" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_19cgonn" attachedToRef="Activity_05jt1pz">
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_03vqd4j" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_02q3kpk" cancelActivity="false" attachedToRef="Activity_05jt1pz">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0vfg04n" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_02iufst" cancelActivity="false" attachedToRef="Activity_05jt1pz">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1jtcfpb" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_1qpecs5" cancelActivity="false" attachedToRef="Activity_05jt1pz">
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_1eyz075" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_0lgm1da" cancelActivity="false" attachedToRef="Activity_05jt1pz">
+      <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_1iiw5jk">
+        <bpmn:condition xsi:type="bpmn:tFormalExpression" />
+      </bpmn:conditionalEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_06vp79f" cancelActivity="false" attachedToRef="Activity_05jt1pz">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_0e2vn9j" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_0zrg42j" sourceRef="StartEvent_1" targetRef="Activity_0hifi7a" />
+    <bpmn:sequenceFlow id="Flow_1q7z4jd" sourceRef="Activity_0hifi7a" targetRef="Activity_1vno0ey">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" />
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1ktumbe" sourceRef="Activity_1vno0ey" targetRef="Activity_1kwbjs8" />
+    <bpmn:sequenceFlow id="Flow_15iu8ql" sourceRef="Activity_1kwbjs8" targetRef="Activity_1bp6c09" />
+    <bpmn:sequenceFlow id="Flow_0f0cw0k" sourceRef="Activity_1bp6c09" targetRef="Activity_1pvu3g5" />
+    <bpmn:sequenceFlow id="Flow_1vgf7tg" sourceRef="Activity_1pvu3g5" targetRef="Activity_0zp5887" />
+    <bpmn:sequenceFlow id="Flow_0bejje3" sourceRef="Activity_0zp5887" targetRef="Activity_1j3irvn" />
+    <bpmn:sequenceFlow id="Flow_1s28mu2" sourceRef="Activity_1j3irvn" targetRef="Activity_0f2pmcw" />
+    <bpmn:sequenceFlow id="Flow_00w4v7n" sourceRef="Activity_0f2pmcw" targetRef="Activity_18lrl5o" />
+    <bpmn:sequenceFlow id="Flow_0fcl9ds" sourceRef="Activity_05jt1pz" targetRef="Event_1kvsony" />
+    <bpmn:sequenceFlow id="Flow_1ymtwgk" sourceRef="Activity_18lrl5o" targetRef="Activity_05jt1pz" />
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0zrg42j</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:association id="Association_1rwtg6e" associationDirection="One" sourceRef="Event_19cgonn" targetRef="Activity_0u9hvk8" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0hnpxxj">
+      <bpmndi:BPMNShape id="Participant_1d3u7q6_di" bpmnElement="Participant_1d3u7q6" isHorizontal="true">
+        <dc:Bounds x="129" y="280" width="2299" height="520" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0njnmpx_di" bpmnElement="Activity_0hifi7a">
+        <dc:Bounds x="440" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_127xhfq_di" bpmnElement="Activity_1vno0ey">
+        <dc:Bounds x="600" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0c57bs0_di" bpmnElement="Activity_1kwbjs8">
+        <dc:Bounds x="760" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0vr5k1p_di" bpmnElement="Activity_1bp6c09">
+        <dc:Bounds x="920" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1pquogt_di" bpmnElement="Activity_1pvu3g5">
+        <dc:Bounds x="1080" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1xin9vy_di" bpmnElement="Activity_0zp5887">
+        <dc:Bounds x="1240" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_079krpl_di" bpmnElement="Activity_1j3irvn">
+        <dc:Bounds x="1400" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0x54xxd_di" bpmnElement="Activity_0f2pmcw">
+        <dc:Bounds x="1560" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1kvsony_di" bpmnElement="Event_1kvsony">
+        <dc:Bounds x="2292" y="422" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1jcfc1d_di" bpmnElement="Event_1sik4ir">
+        <dc:Bounds x="192" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0v61cjv_di" bpmnElement="Event_0sug9c8">
+        <dc:Bounds x="252" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1wvkyvu_di" bpmnElement="Event_1mlyq56">
+        <dc:Bounds x="312" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1s32msm_di" bpmnElement="Event_08y7buv">
+        <dc:Bounds x="372" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13sqei3_di" bpmnElement="Event_13sqei3">
+        <dc:Bounds x="522" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gh09tu_di" bpmnElement="Event_1yebdzz">
+        <dc:Bounds x="582" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0dcfqnf_di" bpmnElement="Event_1tl88e7">
+        <dc:Bounds x="642" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1w32ogi_di" bpmnElement="Event_1qhglqg">
+        <dc:Bounds x="702" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1p7msmc_di" bpmnElement="Event_1fb2uyx">
+        <dc:Bounds x="762" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0b7z33f_di" bpmnElement="Event_1cdxynr">
+        <dc:Bounds x="822" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1d7dyp1_di" bpmnElement="Event_143034p">
+        <dc:Bounds x="1002" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1snfiak_di" bpmnElement="Event_1inzg0a">
+        <dc:Bounds x="1062" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0lirroz_di" bpmnElement="Event_0mdb56m">
+        <dc:Bounds x="1122" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1i7un43_di" bpmnElement="Event_00km32j">
+        <dc:Bounds x="1242" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hgm5w2_di" bpmnElement="Event_09tepzu">
+        <dc:Bounds x="1302" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0pvuyjl_di" bpmnElement="Event_1nig1bg">
+        <dc:Bounds x="1362" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0i5saq7_di" bpmnElement="Event_0vvvebn">
+        <dc:Bounds x="1422" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_07fo05t_di" bpmnElement="Event_0kd0oqx">
+        <dc:Bounds x="1482" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_00u2spk_di" bpmnElement="Event_1ju6z4u">
+        <dc:Bounds x="1542" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1cux9or_di" bpmnElement="Gateway_1cux9or" isMarkerVisible="true">
+        <dc:Bounds x="1005" y="615" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1jd0npw_di" bpmnElement="Gateway_0d8i5nb">
+        <dc:Bounds x="1075" y="615" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1nm08d5_di" bpmnElement="Gateway_0m8jsue">
+        <dc:Bounds x="1145" y="615" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0zexgtr_di" bpmnElement="Gateway_1lxsbxz">
+        <dc:Bounds x="1215" y="615" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0klbdgi_di" bpmnElement="Gateway_0ucgat5">
+        <dc:Bounds x="1285" y="615" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0u9hvk8_di" bpmnElement="Activity_0u9hvk8">
+        <dc:Bounds x="2300" y="580" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0odp5sa_di" bpmnElement="Activity_18lrl5o">
+        <dc:Bounds x="1720" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1w2xr6i_di" bpmnElement="Activity_05jt1pz" isExpanded="true">
+        <dc:Bounds x="1880" y="340" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1kllks5_di" bpmnElement="Activity_0lvrtc3" isExpanded="true">
+        <dc:Bounds x="190" y="540" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1q75iod_di" bpmnElement="Activity_10ml8f5" isExpanded="true">
+        <dc:Bounds x="610" y="540" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_02151f8_di" bpmnElement="Event_0e5fobq">
+        <dc:Bounds x="632" y="562" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1dukiyh_di" bpmnElement="Event_04vjlly">
+        <dc:Bounds x="692" y="562" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_096fdwl_di" bpmnElement="Event_1n4h052">
+        <dc:Bounds x="752" y="562" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0wf6dy6_di" bpmnElement="Event_1icr23y">
+        <dc:Bounds x="632" y="622" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0how8az_di" bpmnElement="Event_1gh3swq">
+        <dc:Bounds x="692" y="622" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_10szys8_di" bpmnElement="Event_1f4hda7">
+        <dc:Bounds x="752" y="622" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0la355u_di" bpmnElement="Event_15xo5kw">
+        <dc:Bounds x="812" y="622" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1i575ke_di" bpmnElement="Event_0m5bm2q">
+        <dc:Bounds x="872" y="622" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="312" y="422" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1pws5gv_di" bpmnElement="Event_06vp79f">
+        <dc:Bounds x="2062" y="322" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_00f052p_di" bpmnElement="Event_0lgm1da">
+        <dc:Bounds x="2012" y="322" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0vtj419_di" bpmnElement="Event_1qpecs5">
+        <dc:Bounds x="1962" y="322" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0vfmeds_di" bpmnElement="Event_02iufst">
+        <dc:Bounds x="1912" y="322" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ohsva6_di" bpmnElement="Event_02q3kpk">
+        <dc:Bounds x="1862" y="322" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_18uhr5s_di" bpmnElement="Event_19cgonn">
+        <dc:Bounds x="2212" y="522" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_00agtjp_di" bpmnElement="Event_0a2uqrs">
+        <dc:Bounds x="2162" y="522" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_03nyf2s_di" bpmnElement="Event_0qbl3tj">
+        <dc:Bounds x="2112" y="522" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0kvwx1q_di" bpmnElement="Event_1ki32zr">
+        <dc:Bounds x="2062" y="522" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_15mqu3x_di" bpmnElement="Event_040kzqb">
+        <dc:Bounds x="2012" y="522" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_01av6tw_di" bpmnElement="Event_15ztmj6">
+        <dc:Bounds x="1962" y="522" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1tec5eh_di" bpmnElement="Event_0v6xk6w">
+        <dc:Bounds x="1912" y="522" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1fvgbdm_di" bpmnElement="Event_0soqabs">
+        <dc:Bounds x="1862" y="522" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0zrg42j_di" bpmnElement="Flow_0zrg42j">
+        <di:waypoint x="348" y="440" />
+        <di:waypoint x="440" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1q7z4jd_di" bpmnElement="Flow_1q7z4jd">
+        <di:waypoint x="540" y="440" />
+        <di:waypoint x="600" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ktumbe_di" bpmnElement="Flow_1ktumbe">
+        <di:waypoint x="700" y="440" />
+        <di:waypoint x="760" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15iu8ql_di" bpmnElement="Flow_15iu8ql">
+        <di:waypoint x="860" y="440" />
+        <di:waypoint x="920" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0f0cw0k_di" bpmnElement="Flow_0f0cw0k">
+        <di:waypoint x="1020" y="440" />
+        <di:waypoint x="1080" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vgf7tg_di" bpmnElement="Flow_1vgf7tg">
+        <di:waypoint x="1180" y="440" />
+        <di:waypoint x="1240" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bejje3_di" bpmnElement="Flow_0bejje3">
+        <di:waypoint x="1340" y="440" />
+        <di:waypoint x="1400" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1s28mu2_di" bpmnElement="Flow_1s28mu2">
+        <di:waypoint x="1500" y="440" />
+        <di:waypoint x="1560" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00w4v7n_di" bpmnElement="Flow_00w4v7n">
+        <di:waypoint x="1660" y="440" />
+        <di:waypoint x="1720" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0fcl9ds_di" bpmnElement="Flow_0fcl9ds">
+        <di:waypoint x="2230" y="440" />
+        <di:waypoint x="2292" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ymtwgk_di" bpmnElement="Flow_1ymtwgk">
+        <di:waypoint x="1820" y="440" />
+        <di:waypoint x="1880" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1rwtg6e_di" bpmnElement="Association_1rwtg6e">
+        <di:waypoint x="2230" y="558" />
+        <di:waypoint x="2230" y="620" />
+        <di:waypoint x="2300" y="620" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_1eb58xy_di" bpmnElement="Participant_1urnon6" isHorizontal="true">
+        <dc:Bounds x="129" y="160" width="600" height="60" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0ma761l_di" bpmnElement="Group_0ma761l">
+        <dc:Bounds x="1380" y="380" width="300" height="300" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_0yyvgv8_di" bpmnElement="TextAnnotation_0yyvgv8">
+        <dc:Bounds x="730" y="80" width="99.99274099883856" height="29.997822299651567" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1andiqd_di" bpmnElement="Association_1andiqd">
+        <di:waypoint x="540" y="160" />
+        <di:waypoint x="730" y="109" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0z4inc6_di" bpmnElement="Flow_0z4inc6">
+        <di:waypoint x="429" y="220" />
+        <di:waypoint x="429" y="280" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1lv689l">
+    <bpmndi:BPMNPlane id="BPMNPlane_1vzt7pi" bpmnElement="Activity_18lrl5o">
+      <bpmndi:BPMNShape id="Event_1woqh9b_di" bpmnElement="Event_1woqh9b">
+        <dc:Bounds x="292" y="282" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1j5vlu2_di" bpmnElement="Activity_1j5vlu2">
+        <dc:Bounds x="380" y="260" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0p9vdz4_di" bpmnElement="Event_0p9vdz4">
+        <dc:Bounds x="532" y="282" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_01mxrfh_di" bpmnElement="Flow_01mxrfh">
+        <di:waypoint x="328" y="300" />
+        <di:waypoint x="380" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10m6o1a_di" bpmnElement="Flow_10m6o1a">
+        <di:waypoint x="480" y="300" />
+        <di:waypoint x="532" y="300" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/camunda-cloud/integration/camunda-cloud-8-3-element-type.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-8-3-element-type.bpmn
@@ -1,0 +1,372 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0pbksug" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.10.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.3.0">
+  <bpmn:collaboration id="Collaboration_0hnpxxj">
+    <bpmn:participant id="Participant_1d3u7q6" processRef="Process_0vsq5kz" />
+    <bpmn:participant id="Participant_1urnon6" />
+    <bpmn:messageFlow id="Flow_0z4inc6" sourceRef="Participant_1urnon6" targetRef="Participant_1d3u7q6" />
+    <bpmn:group id="Group_0ma761l" />
+    <bpmn:textAnnotation id="TextAnnotation_0yyvgv8" />
+    <bpmn:association id="Association_1andiqd" sourceRef="Participant_1urnon6" targetRef="TextAnnotation_0yyvgv8" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_0vsq5kz" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0zrg42j</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sendTask id="Activity_0hifi7a">
+      <bpmn:incoming>Flow_0zrg42j</bpmn:incoming>
+      <bpmn:outgoing>Flow_1q7z4jd</bpmn:outgoing>
+    </bpmn:sendTask>
+    <bpmn:receiveTask id="Activity_1vno0ey">
+      <bpmn:incoming>Flow_1q7z4jd</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ktumbe</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:userTask id="Activity_1kwbjs8">
+      <bpmn:incoming>Flow_1ktumbe</bpmn:incoming>
+      <bpmn:outgoing>Flow_15iu8ql</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:manualTask id="Activity_1bp6c09">
+      <bpmn:incoming>Flow_15iu8ql</bpmn:incoming>
+      <bpmn:outgoing>Flow_0f0cw0k</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:businessRuleTask id="Activity_1pvu3g5">
+      <bpmn:incoming>Flow_0f0cw0k</bpmn:incoming>
+      <bpmn:outgoing>Flow_1vgf7tg</bpmn:outgoing>
+    </bpmn:businessRuleTask>
+    <bpmn:serviceTask id="Activity_0zp5887">
+      <bpmn:incoming>Flow_1vgf7tg</bpmn:incoming>
+      <bpmn:outgoing>Flow_0bejje3</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:scriptTask id="Activity_1j3irvn">
+      <bpmn:incoming>Flow_0bejje3</bpmn:incoming>
+      <bpmn:outgoing>Flow_1s28mu2</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:callActivity id="Activity_0f2pmcw">
+      <bpmn:incoming>Flow_1s28mu2</bpmn:incoming>
+      <bpmn:outgoing>Flow_00w4v7n</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="Event_1kvsony">
+      <bpmn:incoming>Flow_0fcl9ds</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:startEvent id="Event_1sik4ir">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1dqeihq" />
+    </bpmn:startEvent>
+    <bpmn:startEvent id="Event_0sug9c8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_09iembn" />
+    </bpmn:startEvent>
+    <bpmn:intermediateThrowEvent id="Event_13sqei3" />
+    <bpmn:intermediateCatchEvent id="Event_1yebdzz">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_03inc7e" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateThrowEvent id="Event_1tl88e7">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1fifzss" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:intermediateCatchEvent id="Event_1qhglqg">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1vbhrzi" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:endEvent id="Event_00km32j">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0s0a93g" />
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_1nig1bg">
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0c3ll4b" />
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_1ju6z4u">
+      <bpmn:terminateEventDefinition id="TerminateEventDefinition_0exip3l" />
+    </bpmn:endEvent>
+    <bpmn:exclusiveGateway id="Gateway_1cux9or" />
+    <bpmn:parallelGateway id="Gateway_0d8i5nb" />
+    <bpmn:inclusiveGateway id="Gateway_0m8jsue" />
+    <bpmn:eventBasedGateway id="Gateway_0ucgat5" />
+    <bpmn:subProcess id="Activity_18lrl5o">
+      <bpmn:incoming>Flow_00w4v7n</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ymtwgk</bpmn:outgoing>
+      <bpmn:startEvent id="Event_1woqh9b">
+        <bpmn:outgoing>Flow_01mxrfh</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_01mxrfh" sourceRef="Event_1woqh9b" targetRef="Event_0p9vdz4" />
+      <bpmn:endEvent id="Event_0p9vdz4">
+        <bpmn:incoming>Flow_01mxrfh</bpmn:incoming>
+      </bpmn:endEvent>
+    </bpmn:subProcess>
+    <bpmn:subProcess id="Activity_05jt1pz">
+      <bpmn:incoming>Flow_1ymtwgk</bpmn:incoming>
+      <bpmn:outgoing>Flow_0fcl9ds</bpmn:outgoing>
+    </bpmn:subProcess>
+    <bpmn:subProcess id="Activity_10ml8f5" triggeredByEvent="true">
+      <bpmn:startEvent id="Event_0e5fobq">
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_0ntzcza" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="Event_1icr23y" isInterrupting="false">
+        <bpmn:messageEventDefinition id="MessageEventDefinition_03xjf10" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="Event_1gh3swq" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_12rfa0p" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="Event_13c0n9u">
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0198cou" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="Event_0v6xk6w" attachedToRef="Activity_05jt1pz">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0xd75mh" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_15ztmj6" attachedToRef="Activity_05jt1pz">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_06rc1eo" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_0qbl3tj" attachedToRef="Activity_05jt1pz">
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_00rink1" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_02q3kpk" cancelActivity="false" attachedToRef="Activity_05jt1pz">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0vfg04n" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_02iufst" cancelActivity="false" attachedToRef="Activity_05jt1pz">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1jtcfpb" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_0zrg42j" sourceRef="StartEvent_1" targetRef="Activity_0hifi7a" />
+    <bpmn:sequenceFlow id="Flow_1q7z4jd" sourceRef="Activity_0hifi7a" targetRef="Activity_1vno0ey">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" />
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1ktumbe" sourceRef="Activity_1vno0ey" targetRef="Activity_1kwbjs8" />
+    <bpmn:sequenceFlow id="Flow_15iu8ql" sourceRef="Activity_1kwbjs8" targetRef="Activity_1bp6c09" />
+    <bpmn:sequenceFlow id="Flow_0f0cw0k" sourceRef="Activity_1bp6c09" targetRef="Activity_1pvu3g5" />
+    <bpmn:sequenceFlow id="Flow_1vgf7tg" sourceRef="Activity_1pvu3g5" targetRef="Activity_0zp5887" />
+    <bpmn:sequenceFlow id="Flow_0bejje3" sourceRef="Activity_0zp5887" targetRef="Activity_1j3irvn" />
+    <bpmn:sequenceFlow id="Flow_1s28mu2" sourceRef="Activity_1j3irvn" targetRef="Activity_0f2pmcw" />
+    <bpmn:sequenceFlow id="Flow_00w4v7n" sourceRef="Activity_0f2pmcw" targetRef="Activity_18lrl5o" />
+    <bpmn:sequenceFlow id="Flow_0fcl9ds" sourceRef="Activity_05jt1pz" targetRef="Event_1kvsony" />
+    <bpmn:sequenceFlow id="Flow_1ymtwgk" sourceRef="Activity_18lrl5o" targetRef="Activity_05jt1pz" />
+    <bpmn:intermediateCatchEvent id="Event_0s96ilr">
+      <bpmn:linkEventDefinition id="LinkEventDefinition_1ppd3yy" name="" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateThrowEvent id="Event_058pikp">
+      <bpmn:linkEventDefinition id="LinkEventDefinition_0yv4tfh" name="" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:boundaryEvent id="Event_0yz69is" attachedToRef="Activity_05jt1pz">
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_06rsztn" />
+    </bpmn:boundaryEvent>
+    <bpmn:endEvent id="Event_1v0g6mh">
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_0eo3dmf" />
+    </bpmn:endEvent>
+    <bpmn:intermediateThrowEvent id="Event_0ulfy29">
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_1axhot4" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:startEvent id="Event_1px08dy">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_0xnpz4y" />
+    </bpmn:startEvent>
+    <bpmn:intermediateThrowEvent id="Event_0mdb56m">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_1awhs8b" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:endEvent id="Event_0kd0oqx">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_04dcslm" />
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0hnpxxj">
+      <bpmndi:BPMNShape id="Participant_1d3u7q6_di" bpmnElement="Participant_1d3u7q6" isHorizontal="true">
+        <dc:Bounds x="129" y="280" width="2299" height="520" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="192" y="422" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0njnmpx_di" bpmnElement="Activity_0hifi7a">
+        <dc:Bounds x="440" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_127xhfq_di" bpmnElement="Activity_1vno0ey">
+        <dc:Bounds x="600" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0c57bs0_di" bpmnElement="Activity_1kwbjs8">
+        <dc:Bounds x="760" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0vr5k1p_di" bpmnElement="Activity_1bp6c09">
+        <dc:Bounds x="920" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1pquogt_di" bpmnElement="Activity_1pvu3g5">
+        <dc:Bounds x="1080" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1xin9vy_di" bpmnElement="Activity_0zp5887">
+        <dc:Bounds x="1240" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_079krpl_di" bpmnElement="Activity_1j3irvn">
+        <dc:Bounds x="1400" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0x54xxd_di" bpmnElement="Activity_0f2pmcw">
+        <dc:Bounds x="1560" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1kvsony_di" bpmnElement="Event_1kvsony">
+        <dc:Bounds x="2292" y="422" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1jcfc1d_di" bpmnElement="Event_1sik4ir">
+        <dc:Bounds x="192" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0v61cjv_di" bpmnElement="Event_0sug9c8">
+        <dc:Bounds x="252" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13sqei3_di" bpmnElement="Event_13sqei3">
+        <dc:Bounds x="522" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gh09tu_di" bpmnElement="Event_1yebdzz">
+        <dc:Bounds x="582" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0dcfqnf_di" bpmnElement="Event_1tl88e7">
+        <dc:Bounds x="642" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1w32ogi_di" bpmnElement="Event_1qhglqg">
+        <dc:Bounds x="702" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1i7un43_di" bpmnElement="Event_00km32j">
+        <dc:Bounds x="1242" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0pvuyjl_di" bpmnElement="Event_1nig1bg">
+        <dc:Bounds x="1362" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_00u2spk_di" bpmnElement="Event_1ju6z4u">
+        <dc:Bounds x="1542" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1cux9or_di" bpmnElement="Gateway_1cux9or" isMarkerVisible="true">
+        <dc:Bounds x="1005" y="615" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1jd0npw_di" bpmnElement="Gateway_0d8i5nb">
+        <dc:Bounds x="1075" y="615" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1nm08d5_di" bpmnElement="Gateway_0m8jsue">
+        <dc:Bounds x="1145" y="615" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0klbdgi_di" bpmnElement="Gateway_0ucgat5">
+        <dc:Bounds x="1285" y="615" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0lirroz_di" bpmnElement="Event_0mdb56m">
+        <dc:Bounds x="1122" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_07fo05t_di" bpmnElement="Event_0kd0oqx">
+        <dc:Bounds x="1482" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0odp5sa_di" bpmnElement="Activity_18lrl5o">
+        <dc:Bounds x="1720" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1w2xr6i_di" bpmnElement="Activity_05jt1pz" isExpanded="true">
+        <dc:Bounds x="1880" y="340" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1q75iod_di" bpmnElement="Activity_10ml8f5" isExpanded="true">
+        <dc:Bounds x="610" y="540" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_02151f8_di" bpmnElement="Event_0e5fobq">
+        <dc:Bounds x="632" y="562" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0wf6dy6_di" bpmnElement="Event_1icr23y">
+        <dc:Bounds x="632" y="622" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0how8az_di" bpmnElement="Event_1gh3swq">
+        <dc:Bounds x="692" y="622" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0b7w7t0_di" bpmnElement="Event_13c0n9u">
+        <dc:Bounds x="692" y="562" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0gxwsku_di" bpmnElement="Event_0s96ilr">
+        <dc:Bounds x="882" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_00ttebs_di" bpmnElement="Event_058pikp">
+        <dc:Bounds x="942" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_095u95r_di" bpmnElement="Event_1v0g6mh">
+        <dc:Bounds x="1302" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1fu33v8_di" bpmnElement="Event_0ulfy29">
+        <dc:Bounds x="1002" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_16jkm7a_di" bpmnElement="Event_1px08dy">
+        <dc:Bounds x="372" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_07szt4n_di" bpmnElement="Event_0yz69is">
+        <dc:Bounds x="2022" y="522" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0vfmeds_di" bpmnElement="Event_02iufst">
+        <dc:Bounds x="1912" y="322" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ohsva6_di" bpmnElement="Event_02q3kpk">
+        <dc:Bounds x="1862" y="322" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_03nyf2s_di" bpmnElement="Event_0qbl3tj">
+        <dc:Bounds x="2112" y="522" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_01av6tw_di" bpmnElement="Event_15ztmj6">
+        <dc:Bounds x="1962" y="522" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1tec5eh_di" bpmnElement="Event_0v6xk6w">
+        <dc:Bounds x="1912" y="522" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0zrg42j_di" bpmnElement="Flow_0zrg42j">
+        <di:waypoint x="228" y="440" />
+        <di:waypoint x="440" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1q7z4jd_di" bpmnElement="Flow_1q7z4jd">
+        <di:waypoint x="540" y="440" />
+        <di:waypoint x="600" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ktumbe_di" bpmnElement="Flow_1ktumbe">
+        <di:waypoint x="700" y="440" />
+        <di:waypoint x="760" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15iu8ql_di" bpmnElement="Flow_15iu8ql">
+        <di:waypoint x="860" y="440" />
+        <di:waypoint x="920" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0f0cw0k_di" bpmnElement="Flow_0f0cw0k">
+        <di:waypoint x="1020" y="440" />
+        <di:waypoint x="1080" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vgf7tg_di" bpmnElement="Flow_1vgf7tg">
+        <di:waypoint x="1180" y="440" />
+        <di:waypoint x="1240" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bejje3_di" bpmnElement="Flow_0bejje3">
+        <di:waypoint x="1340" y="440" />
+        <di:waypoint x="1400" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1s28mu2_di" bpmnElement="Flow_1s28mu2">
+        <di:waypoint x="1500" y="440" />
+        <di:waypoint x="1560" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00w4v7n_di" bpmnElement="Flow_00w4v7n">
+        <di:waypoint x="1660" y="440" />
+        <di:waypoint x="1720" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0fcl9ds_di" bpmnElement="Flow_0fcl9ds">
+        <di:waypoint x="2230" y="440" />
+        <di:waypoint x="2292" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ymtwgk_di" bpmnElement="Flow_1ymtwgk">
+        <di:waypoint x="1820" y="440" />
+        <di:waypoint x="1880" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_1eb58xy_di" bpmnElement="Participant_1urnon6" isHorizontal="true">
+        <dc:Bounds x="129" y="160" width="600" height="60" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0ma761l_di" bpmnElement="Group_0ma761l">
+        <dc:Bounds x="1380" y="380" width="300" height="300" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_0yyvgv8_di" bpmnElement="TextAnnotation_0yyvgv8">
+        <dc:Bounds x="730" y="80" width="99.99274099883856" height="29.997822299651567" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1andiqd_di" bpmnElement="Association_1andiqd">
+        <di:waypoint x="540" y="160" />
+        <di:waypoint x="730" y="109" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0z4inc6_di" bpmnElement="Flow_0z4inc6">
+        <di:waypoint x="429" y="220" />
+        <di:waypoint x="429" y="280" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1lv689l">
+    <bpmndi:BPMNPlane id="BPMNPlane_1vzt7pi" bpmnElement="Activity_18lrl5o">
+      <bpmndi:BPMNShape id="Event_1woqh9b_di" bpmnElement="Event_1woqh9b">
+        <dc:Bounds x="152" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0p9vdz4_di" bpmnElement="Event_0p9vdz4">
+        <dc:Bounds x="392" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_01mxrfh_di" bpmnElement="Flow_01mxrfh">
+        <di:waypoint x="188" y="100" />
+        <di:waypoint x="392" y="100" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/camunda-cloud/integration/element-type.spec.js
+++ b/test/camunda-cloud/integration/element-type.spec.js
@@ -13,7 +13,8 @@ const versions = [
   '1.3',
   '8.0',
   '8.1',
-  '8.2'
+  '8.2',
+  '8.3'
 ];
 
 describe('integration - element-type', function() {

--- a/test/camunda-cloud/integration/signal-reference-errors.bpmn
+++ b/test/camunda-cloud/integration/signal-reference-errors.bpmn
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0essyw9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0-rc.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="StartEvent_1">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_11sxzpt" />
+    </bpmn:startEvent>
+    <bpmn:intermediateThrowEvent id="IntermediateThrowEvent_1" name="IntermediateThrowEvent_1">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_0xoda87" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:endEvent id="EndEvent_1" name="EndEvent_1">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_19odikl" />
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:signal id="Signal_3pc76da" name="Signal_1" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_12k8vvh_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="165" y="122" width="64" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0zjbi47_di" bpmnElement="IntermediateThrowEvent_1">
+        <dc:Bounds x="272" y="79" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="251" y="122" width="79" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_00qcrpe_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="362" y="79" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="350" y="122" width="60" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/camunda-cloud/integration/signal-reference.bpmn
+++ b/test/camunda-cloud/integration/signal-reference.bpmn
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0essyw9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0-rc.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="StartEvent_1">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_11sxzpt" signalRef="Signal_3pc76da" />
+    </bpmn:startEvent>
+    <bpmn:intermediateThrowEvent id="IntermediateThrowEvent_1" name="IntermediateThrowEvent_1">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_0xoda87" signalRef="Signal_3pc76da" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:endEvent id="EndEvent_1" name="EndEvent_1">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_19odikl" signalRef="Signal_3pc76da" />
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:signal id="Signal_3pc76da" name="Signal_1" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_12k8vvh_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="165" y="122" width="64" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0zjbi47_di" bpmnElement="IntermediateThrowEvent_1">
+        <dc:Bounds x="272" y="79" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="251" y="122" width="79" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_00qcrpe_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="362" y="79" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="350" y="122" width="60" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/camunda-cloud/integration/signal-reference.spec.js
+++ b/test/camunda-cloud/integration/signal-reference.spec.js
@@ -1,0 +1,66 @@
+const { expect } = require('chai');
+
+const Linter = require('bpmnlint/lib/linter');
+
+const NodeResolver = require('bpmnlint/lib/resolver/node-resolver');
+
+const { readModdle } = require('../../helper');
+
+describe('integration - signal-reference', function() {
+
+  [
+    '8.3'
+  ].forEach(function(version) {
+
+    let linter;
+
+    beforeEach(function() {
+      linter = new Linter({
+        config: {
+          extends: `plugin:camunda-compat/camunda-cloud-${ version.replace('.', '-') }`
+        },
+        resolver: new NodeResolver()
+      });
+    });
+
+
+    describe(`Camunda Cloud ${ version }`, function() {
+
+      describe('no errors', function() {
+
+        it('should not have errors', async function() {
+
+          // given
+          const { root } = await readModdle('test/camunda-cloud/integration/signal-reference.bpmn');
+
+          // when
+          const reports = await linter.lint(root);
+
+          // then
+          expect(reports[ 'camunda-compat/signal-reference' ]).not.to.exist;
+        });
+
+      });
+
+
+      describe('errors', function() {
+
+        it('should have errors', async function() {
+
+          // given
+          const { root } = await readModdle('test/camunda-cloud/integration/signal-reference-errors.bpmn');
+
+          // when
+          const reports = await linter.lint(root);
+
+          // then
+          expect(reports[ 'camunda-compat/signal-reference' ]).to.exist;
+        });
+
+      });
+
+    });
+
+  });
+
+});

--- a/test/camunda-cloud/no-expression.spec.js
+++ b/test/camunda-cloud/no-expression.spec.js
@@ -71,7 +71,19 @@ const valid = [
       </bpmn:process>
       <bpmn:error id="Error_1" name="Error_1" errorCode="=myCode" />
     `))
-  }
+  },
+  {
+    name: 'error throw event (unknown version)',
+    config: { version: '0.0' },
+    moddleElement: createModdle(createDefinitions(`
+      <bpmn:process id="Process_1" isExecutable="true">
+        <bpmn:endEvent id="Event">
+          <bpmn:errorEventDefinition id="ErrorEventDefinition" errorRef="Error" />
+        </bpmn:endEvent>
+      </bpmn:process>
+      <bpmn:error id="Error" name="Error" errorCode="=myCode" />
+    `))
+  },
 ];
 
 const invalid = [

--- a/test/camunda-cloud/signal-reference.spec.js
+++ b/test/camunda-cloud/signal-reference.spec.js
@@ -1,0 +1,217 @@
+const RuleTester = require('bpmnlint/lib/testers/rule-tester');
+
+const rule = require('../../rules/signal-reference');
+
+const {
+  createDefinitions,
+  createModdle,
+  createProcess
+} = require('../helper');
+
+const { ERROR_TYPES } = require('../../rules/utils/element');
+
+const valid = [
+  {
+    name: 'start event (signal)',
+    moddleElement: createModdle(createDefinitions(`
+      <bpmn:process id="Process_1" isExecutable="true">
+        <bpmn:startEvent id="StartEvent_1">
+          <bpmn:signalEventDefinition id="SignalEventDefinition_1" signalRef="Signal_1" />
+        </bpmn:startEvent>
+      </bpmn:process>
+      <bpmn:signal id="Signal_1" name="foo" />
+    `))
+  },
+  {
+    name: 'intermediate throw event (signal)',
+    moddleElement: createModdle(createDefinitions(`
+      <bpmn:process id="Process_1" isExecutable="true">
+        <bpmn:intermediateThrowEvent id="IntermediateThrowEvent_1">
+          <bpmn:signalEventDefinition id="SignalEventDefinition_1" signalRef="Signal_1" />
+        </bpmn:intermediateThrowEvent>
+      </bpmn:process>
+      <bpmn:signal id="Signal_1" name="foo" />
+    `))
+  },
+  {
+    name: 'end event (signal)',
+    moddleElement: createModdle(createDefinitions(`
+      <bpmn:process id="Process_1" isExecutable="true">
+        <bpmn:endEvent id="EndEvent_1">
+          <bpmn:signalEventDefinition id="SignalEventDefinition_1" signalRef="Signal_1" />
+        </bpmn:endEvent>
+      </bpmn:process>
+      <bpmn:signal id="Signal_1" name="foo" />
+    `))
+  },
+  {
+    name: 'task',
+    moddleElement: createModdle(createProcess('<bpmn:task id="Task_1" />'))
+  },
+  {
+    name: 'intermediate throw event (no signal reference) (non-executable process)',
+    config: { version: '8.2' },
+    moddleElement: createModdle(createDefinitions(`
+      <bpmn:process id="Process_1">
+        <bpmn:intermediateThrowEvent id="IntermediateThrowEvent_1">
+          <bpmn:signalEventDefinition id="SignalEventDefinition_1" />
+        </bpmn:intermediateThrowEvent>
+      </bpmn:process>
+    `))
+  }
+];
+
+const invalid = [
+  {
+    name: 'start event (no signal reference)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:startEvent id="StartEvent_1">
+        <bpmn:signalEventDefinition id="SignalEventDefinition_1" />
+      </bpmn:startEvent>
+    `)),
+    report: {
+      id: 'StartEvent_1',
+      message: 'Element of type <bpmn:SignalEventDefinition> must have property <signalRef>',
+      path: [
+        'eventDefinitions',
+        0,
+        'signalRef'
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'SignalEventDefinition_1',
+        parentNode: 'StartEvent_1',
+        requiredProperty: 'signalRef'
+      }
+    }
+  },
+  {
+    name: 'start event (no signal name)',
+    moddleElement: createModdle(createDefinitions(`
+      <bpmn:process id="Process_1">
+        <bpmn:startEvent id="StartEvent_1">
+          <bpmn:signalEventDefinition id="SignalEventDefinition_1" signalRef="Signal_1" />
+        </bpmn:startEvent>
+      </bpmn:process>
+      <bpmn:signal id="Signal_1" />
+    `)),
+    report: {
+      id: 'StartEvent_1',
+      message: 'Element of type <bpmn:Signal> must have property <name>',
+      path: [
+        'rootElements',
+        1,
+        'name'
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'Signal_1',
+        parentNode: 'StartEvent_1',
+        requiredProperty: 'name'
+      }
+    }
+  },
+  {
+    name: 'intermediate throw event (no signal reference)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:intermediateThrowEvent id="IntermediateThrowEvent_1">
+        <bpmn:signalEventDefinition id="SignalEventDefinition_1" />
+      </bpmn:intermediateThrowEvent>
+    `)),
+    report: {
+      id: 'IntermediateThrowEvent_1',
+      message: 'Element of type <bpmn:SignalEventDefinition> must have property <signalRef>',
+      path: [
+        'eventDefinitions',
+        0,
+        'signalRef'
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'SignalEventDefinition_1',
+        parentNode: 'IntermediateThrowEvent_1',
+        requiredProperty: 'signalRef'
+      }
+    }
+  },
+  {
+    name: 'intermediate throw event (no signal name)',
+    moddleElement: createModdle(createDefinitions(`
+      <bpmn:process id="Process_1">
+        <bpmn:intermediateThrowEvent id="IntermediateThrowEvent_1">
+          <bpmn:signalEventDefinition id="SignalEventDefinition_1" signalRef="Signal_1" />
+        </bpmn:intermediateThrowEvent>
+      </bpmn:process>
+      <bpmn:signal id="Signal_1" />
+    `)),
+    report: {
+      id: 'IntermediateThrowEvent_1',
+      message: 'Element of type <bpmn:Signal> must have property <name>',
+      path: [
+        'rootElements',
+        1,
+        'name'
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'Signal_1',
+        parentNode: 'IntermediateThrowEvent_1',
+        requiredProperty: 'name'
+      }
+    }
+  },
+  {
+    name: 'end event (no signal reference)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:endEvent id="EndEvent_1">
+        <bpmn:signalEventDefinition id="SignalEventDefinition_1" />
+      </bpmn:endEvent>
+    `)),
+    report: {
+      id: 'EndEvent_1',
+      message: 'Element of type <bpmn:SignalEventDefinition> must have property <signalRef>',
+      path: [
+        'eventDefinitions',
+        0,
+        'signalRef'
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'SignalEventDefinition_1',
+        parentNode: 'EndEvent_1',
+        requiredProperty: 'signalRef'
+      }
+    }
+  },
+  {
+    name: 'end event (no signal name)',
+    moddleElement: createModdle(createDefinitions(`
+      <bpmn:process id="Process_1">
+        <bpmn:endEvent id="EndEvent_1">
+          <bpmn:signalEventDefinition id="SignalEventDefinition_1" signalRef="Signal_1" />
+        </bpmn:endEvent>
+      </bpmn:process>
+      <bpmn:signal id="Signal_1" />
+    `)),
+    report: {
+      id: 'EndEvent_1',
+      message: 'Element of type <bpmn:Signal> must have property <name>',
+      path: [
+        'rootElements',
+        1,
+        'name'
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'Signal_1',
+        parentNode: 'EndEvent_1',
+        requiredProperty: 'name'
+      }
+    }
+  }
+];
+
+RuleTester.verify('error-reference', rule, {
+  valid,
+  invalid
+});

--- a/test/config/configs.spec.js
+++ b/test/config/configs.spec.js
@@ -163,6 +163,29 @@ describe('configs', function() {
   }));
 
 
+  it('camunda-cloud-8-3', expectRules(configs, 'camunda-cloud-8-3', {
+    'implementation': [ 'error', { version: '8.3' } ],
+    'called-element': [ 'error', { version: '8.3' } ],
+    'collapsed-subprocess': [ 'error', { version: '8.3' } ],
+    'duplicate-task-headers': [ 'error', { version: '8.3' } ],
+    'element-type': [ 'error', { version: '8.3' } ],
+    'error-reference': [ 'error', { version: '8.3' } ],
+    'escalation-reference': [ 'error', { version: '8.3' } ],
+    'executable-process': [ 'error', { version: '8.3' } ],
+    'feel': [ 'error', { version: '8.3' } ],
+    'inclusive-gateway': [ 'error', { version: '8.3' } ],
+    'loop-characteristics': [ 'error', { version: '8.3' } ],
+    'message-reference': [ 'error', { version: '8.3' } ],
+    'no-expression': [ 'error', { version: '8.3' } ],
+    'no-signal-event-sub-process': [ 'error', { version: '8.3' } ],
+    'sequence-flow-condition': [ 'error', { version: '8.3' } ],
+    'subscription': [ 'error', { version: '8.3' } ],
+    'task-schedule': [ 'error', { version: '8.3' } ],
+    'timer': [ 'error', { version: '8.3' } ],
+    'user-task-form': [ 'error', { version: '8.3' } ]
+  }));
+
+
   it('camunda-platform-7-19', expectRules(configs, 'camunda-platform-7-19', {
     'history-time-to-live': [ 'error', { platform: 'camunda-platform', version: '7.19' } ]
   }));

--- a/test/config/configs.spec.js
+++ b/test/config/configs.spec.js
@@ -179,6 +179,7 @@ describe('configs', function() {
     'no-expression': [ 'error', { version: '8.3' } ],
     'no-signal-event-sub-process': [ 'error', { version: '8.3' } ],
     'sequence-flow-condition': [ 'error', { version: '8.3' } ],
+    'signal-reference': [ 'error', { version: '8.3' } ],
     'subscription': [ 'error', { version: '8.3' } ],
     'task-schedule': [ 'error', { version: '8.3' } ],
     'timer': [ 'error', { version: '8.3' } ],


### PR DESCRIPTION
* add Camunda 8.3 config
* adjust `element-type` configuration to support signal intermediaate throw and end events in Camunda 8.3
* add `signal-reference` rule to lint signal reference and name
---

Closes https://github.com/camunda/bpmnlint-plugin-camunda-compat/issues/93