### PR TITLE
Support `bpmn:timeDate` for Timer Boundary and Intermediate Catch Events

### DIFF
--- a/rules/timer/config.js
+++ b/rules/timer/config.js
@@ -31,12 +31,12 @@ module.exports = {
 
         return null;
       },
-      'timeDate': () => null,
+      'timeDate': () => '8.3',
       'timeDuration': () => '1.0'
     },
     'bpmn:IntermediateCatchEvent': {
       'timeCycle': () => null,
-      'timeDate': () => null,
+      'timeDate': () => '8.3',
       'timeDuration': () => '1.0'
     }
   }

--- a/rules/timer/config.js
+++ b/rules/timer/config.js
@@ -1,4 +1,47 @@
+const { is } = require('bpmnlint-utils');
+
 module.exports = {
-  'cron': '8.1',
-  'iso8601': '1.0'
+  expressionType: {
+    'cron': '8.1',
+    'iso8601': '1.0'
+  },
+  elementType: {
+    'bpmn:StartEvent': {
+      'timeCycle': (isInterrupting, parent) => {
+        if (!isInterrupting || !isEventSubProcess(parent)) {
+          return '1.0';
+        }
+
+        return null;
+      },
+      'timeDate': () => '1.0',
+      'timeDuration': (_, parent) => {
+        if (isEventSubProcess(parent)) {
+          return '1.0';
+        }
+
+        return null;
+      }
+    },
+    'bpmn:BoundaryEvent': {
+      'timeCycle': (cancelActivity) => {
+        if (!cancelActivity) {
+          return '1.0';
+        }
+
+        return null;
+      },
+      'timeDate': () => null,
+      'timeDuration': () => '1.0'
+    },
+    'bpmn:IntermediateCatchEvent': {
+      'timeCycle': () => null,
+      'timeDate': () => null,
+      'timeDuration': () => '1.0'
+    }
+  }
 };
+
+function isEventSubProcess(element) {
+  return is(element, 'bpmn:SubProcess') && element.get('triggeredByEvent') === true;
+}

--- a/rules/utils/element.js
+++ b/rules/utils/element.js
@@ -68,24 +68,24 @@ function findExtensionElement(node, types) {
 
 module.exports.findExtensionElement = findExtensionElement;
 
-function formatTypes(types, exclusive = false) {
-  return types.reduce((string, type, index) => {
+function formatNames(names, exclusive = false) {
+  return names.reduce((string, name, index) => {
 
     // first
     if (index === 0) {
-      return `<${ type }>`;
+      return `<${ name }>`;
     }
 
     // last
-    if (index === types.length - 1) {
-      return `${ string } ${ exclusive ? 'or' : 'and' } <${ type }>`;
+    if (index === names.length - 1) {
+      return `${ string } ${ exclusive ? 'or' : 'and' } <${ name }>`;
     }
 
-    return `${ string }, <${ type }>`;
+    return `${ string }, <${ name }>`;
   }, '');
 }
 
-module.exports.formatTypes = formatTypes;
+module.exports.formatNames = formatNames;
 
 module.exports.hasDuplicatedPropertyValues = function(node, propertiesName, propertyName, parentNode = null) {
   const properties = node.get(propertiesName);
@@ -276,21 +276,21 @@ module.exports.hasProperties = function(node, properties, parentNode = null) {
   }, []);
 };
 
-module.exports.hasProperty = function(node, types, parentNode = null) {
-  const typesArray = isArray(types) ? types : [ types ];
+module.exports.hasProperty = function(node, propertyNames, parentNode = null) {
+  propertyNames = isArray(propertyNames) ? propertyNames : [ propertyNames ];
 
-  const properties = findProperties(node, typesArray);
+  const properties = findProperties(node, propertyNames);
 
   if (properties.length !== 1) {
     return [
       {
-        message: `Element of type <${ node.$type }> must have one property of type ${ formatTypes(typesArray, true) }`,
+        message: `Element of type <${ node.$type }> must have property ${ formatNames(propertyNames, true) }`,
         path: getPath(node, parentNode),
         data: {
           type: ERROR_TYPES.PROPERTY_REQUIRED,
           node,
           parentNode: parentNode == node ? null : parentNode,
-          requiredProperty: types
+          requiredProperty: propertyNames
         }
       }
     ];
@@ -299,11 +299,12 @@ module.exports.hasProperty = function(node, types, parentNode = null) {
   return [];
 };
 
-function findProperties(node, types) {
+function findProperties(node, propertyNames) {
   const properties = [];
-  for (const type of types) {
-    if (isDefined(node.get(type))) {
-      properties.push(node.get(type));
+
+  for (const propertyName of propertyNames) {
+    if (isDefined(node.get(propertyName))) {
+      properties.push(node.get(propertyName));
     }
   }
 
@@ -318,7 +319,7 @@ module.exports.hasExtensionElement = function(node, types, parentNode = null) {
   if (!extensionElements || extensionElements.length !== 1) {
     return [
       {
-        message: `Element of type <${ node.$type }> must have one extension element of type ${ formatTypes(typesArray, true) }`,
+        message: `Element of type <${ node.$type }> must have one extension element of type ${ formatNames(typesArray, true) }`,
         path: getPath(node, parentNode),
         data: {
           type: ERROR_TYPES.EXTENSION_ELEMENT_REQUIRED,

--- a/test/camunda-cloud/integration/camunda-cloud-1-0-timer-errors.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-1-0-timer-errors.bpmn
@@ -1,78 +1,376 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ot6ika" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.4.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
-  <bpmn:process id="Process_0jflbl3" isExecutable="true">
-    <bpmn:task id="Activity_0kcb5kw">
-      <bpmn:incoming>Flow_1xwctp0</bpmn:incoming>
-    </bpmn:task>
-    <bpmn:startEvent id="StartEvent_1" name="Date">
-      <bpmn:outgoing>Flow_0b6nadt</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1fxm0mf">
-        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDate>
-      </bpmn:timerEventDefinition>
-    </bpmn:startEvent>
-    <bpmn:intermediateCatchEvent id="Event_0sbvzs9" name="Duration">
-      <bpmn:incoming>Flow_0b6nadt</bpmn:incoming>
-      <bpmn:outgoing>Flow_1xwctp0</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1rxh4l4">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDuration>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1w3xyk9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Cycle" name="IntermediateCatchEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:boundaryEvent id="Event_0hn049s" name="Duration" attachedToRef="Activity_0kcb5kw">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0bg6y33">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDuration>
-      </bpmn:timerEventDefinition>
-    </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_0b6nadt" sourceRef="StartEvent_1" targetRef="Event_0sbvzs9" />
-    <bpmn:sequenceFlow id="Flow_1xwctp0" sourceRef="Event_0sbvzs9" targetRef="Activity_0kcb5kw" />
-    <bpmn:startEvent id="Event_1jtin5z" name="Cycle">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0sm5q3w">
-        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">@daily</bpmn:timeCycle>
+    <bpmn:startEvent id="StartEvent_Cycle" name="StartEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
-    <bpmn:boundaryEvent id="Event_1metpe7" attachedToRef="Activity_0kcb5kw">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0n56omv" />
+    <bpmn:task id="Task_1" />
+    <bpmn:boundaryEvent id="BoundaryEvent_Cycle" name="BoundaryEvent_Cycle" attachedToRef="Task_1">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
+    <bpmn:task id="Task_2" />
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Cycle" name="NonInterruptingBoundaryEvent_Cycle" cancelActivity="false" attachedToRef="Task_2">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:subProcess id="SubProcess_Cycle" name="SubProcess_Cycle" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Cycle" name="EventSubProcess_StartEvent_Cycle">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Cycle" name="EventSubProcess_NonInterruptingStartEvent_Cycle" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Date" name="IntermediateCatchEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_Date" name="StartEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_5" />
+    <bpmn:task id="Task_6" />
+    <bpmn:subProcess id="SubProcess_Date" name="SubProcess_Date" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Date" name="EventSubProcess_StartEvent_Date">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Date" name="EventSubProcess_NonInterruptingStartEvent_Date" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Date" name="BoundaryEvent_Date" attachedToRef="Task_5">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Date" name="NonInterruptingBoundaryEvent_Date" cancelActivity="false" attachedToRef="Task_6">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Duration" name="IntermediateCatchEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_Duration" name="StartEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_7" />
+    <bpmn:task id="Task_8" />
+    <bpmn:subProcess id="SubProcess_Duration" name="SubProcess_Duration" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Duration" name="EventSubProcess_StartEvent_Duration">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Duration" name="EventSubProcess_NonInterruptingStartEvent_Duration" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Duration" name="BoundaryEvent_Duration" attachedToRef="Task_7">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Duration" name="NonInterruptingBoundaryEvent_Duration" cancelActivity="false" attachedToRef="Task_8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_CycleCron" name="IntermediateCatchEvent_CycleCron">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_CycleCron" name="StartEvent_CycleCron">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_3" />
+    <bpmn:task id="Task_4" />
+    <bpmn:subProcess id="SubProcess_CycleCron" name="SubProcess_CycleCron" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_CycleCron" name="EventSubProcess_StartEvent_CycleCron">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_CycleCron">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_CycleCron" name="EventSubProcess_NonInterruptingStartEvent_CycleCron" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_CycleCron">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_CycleCron" name="BoundaryEvent_CycleCron" attachedToRef="Task_3">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_CycleCron" name="NonInterruptingBoundaryEvent_CycleCron" cancelActivity="false" attachedToRef="Task_4">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:group id="Group_Cycle" categoryValueRef="CategoryValue_Cycle" />
+    <bpmn:group id="Group_Date" categoryValueRef="CategoryValue_Date" />
+    <bpmn:group id="Group_Duration" categoryValueRef="CategoryValue_Duration" />
+    <bpmn:group id="Group_CycleCron" categoryValueRef="CategoryValue_CycleCron" />
+    <bpmn:textAnnotation id="TextAnnotation_1">
+      <bpmn:text>Camunda 8 (Zeebe 1.0)</bpmn:text>
+    </bpmn:textAnnotation>
   </bpmn:process>
+  <bpmn:category id="Category_Cycle">
+    <bpmn:categoryValue id="CategoryValue_Cycle" value="Cycle" />
+  </bpmn:category>
+  <bpmn:category id="Category_Date">
+    <bpmn:categoryValue id="CategoryValue_Date" value="Date" />
+  </bpmn:category>
+  <bpmn:category id="Category_Duration">
+    <bpmn:categoryValue id="CategoryValue_Duration" value="Duration" />
+  </bpmn:category>
+  <bpmn:category id="Category_CycleCron">
+    <bpmn:categoryValue id="CategoryValue_CycleCron" value="Cycle (CRON)" />
+  </bpmn:category>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0jflbl3">
-      <bpmndi:BPMNShape id="Activity_0kcb5kw_di" bpmnElement="Activity_0kcb5kw">
-        <dc:Bounds x="370" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1socevm_di" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="99" width="36" height="36" />
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_1ih3qg9_di" bpmnElement="IntermediateCatchEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="292" y="262" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="186" y="142" width="24" height="14" />
+          <dc:Bounds x="268" y="305" width="85" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0d5th2l_di" bpmnElement="Event_0sbvzs9">
-        <dc:Bounds x="272" y="99" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1a2aqqq_di" bpmnElement="StartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="262" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="269" y="142" width="42" height="14" />
+          <dc:Bounds x="178" y="305" width="86" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1r9zfi8_di" bpmnElement="Event_1jtin5z">
-        <dc:Bounds x="179" y="212" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_158bxus_di" bpmnElement="Task_1">
+        <dc:Bounds x="440" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1c7yu62_di" bpmnElement="Task_2">
+        <dc:Bounds x="620" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0si6fbo_di" bpmnElement="SubProcess_Cycle" isExpanded="true">
+        <dc:Bounds x="810" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0emjtwi_di" bpmnElement="EventSubProcess_StartEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="922" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="183" y="255" width="29" height="14" />
+          <dc:Bounds x="901" y="315" width="88" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1qiyw8j_di" bpmnElement="Event_0hn049s">
-        <dc:Bounds x="352" y="139" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1hvn2kh_di" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="349" y="182" width="42" height="14" />
+          <dc:Bounds x="990" y="315" width="85" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1jdcr1y_di" bpmnElement="Event_1metpe7">
-        <dc:Bounds x="452" y="139" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_1noobtj" bpmnElement="IntermediateCatchEvent_Date" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="292" y="582" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="272" y="625" width="80" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0b6nadt_di" bpmnElement="Flow_0b6nadt">
-        <di:waypoint x="215" y="117" />
-        <di:waypoint x="272" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1xwctp0_di" bpmnElement="Flow_1xwctp0">
-        <di:waypoint x="308" y="117" />
-        <di:waypoint x="370" y="117" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_1daj4e0" bpmnElement="StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="582" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="180" y="625" width="82" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1godq1i" bpmnElement="Task_5">
+        <dc:Bounds x="440" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1cqtk6t" bpmnElement="Task_6">
+        <dc:Bounds x="620" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nhun69" bpmnElement="SubProcess_Date" isExpanded="true">
+        <dc:Bounds x="810" y="510" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1679ksi" bpmnElement="EventSubProcess_StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="635" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n27xdi" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="988" y="635" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0b7rl6t" bpmnElement="IntermediateCatchEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="292" y="902" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="268" y="945" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nvr3f7" bpmnElement="StartEvent_Duration" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="202" y="902" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="178" y="945" width="86" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_09h1dj0" bpmnElement="Task_7">
+        <dc:Bounds x="440" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_13qr05v" bpmnElement="Task_8">
+        <dc:Bounds x="620" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sopxbu" bpmnElement="SubProcess_Duration" isExpanded="true">
+        <dc:Bounds x="810" y="830" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n0geh0" bpmnElement="EventSubProcess_StartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="955" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_01typqg" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="987" y="955" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0tc8we8" bpmnElement="IntermediateCatchEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1362" y="262" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1337" y="305" width="87" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_114olyo" bpmnElement="StartEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1272" y="262" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1249" y="305" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sp4b5v" bpmnElement="Task_3">
+        <dc:Bounds x="1510" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0j20tgx" bpmnElement="Task_4">
+        <dc:Bounds x="1690" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0gooim1" bpmnElement="SubProcess_CycleCron" isExpanded="true">
+        <dc:Bounds x="1880" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ph0d9f" bpmnElement="EventSubProcess_StartEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1992" y="272" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1971" y="315" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_11c780k" bpmnElement="EventSubProcess_NonInterruptingStartEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="2082" y="272" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2059" y="315" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0oqi537_di" bpmnElement="Group_Cycle">
+        <dc:Bounds x="160" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="671" y="137" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1lmj4kq" bpmnElement="Group_Date">
+        <dc:Bounds x="160" y="450" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="675" y="457" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_100yato" bpmnElement="Group_Duration">
+        <dc:Bounds x="160" y="770" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="664" y="777" width="42" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0m8h7pu" bpmnElement="Group_CycleCron">
+        <dc:Bounds x="1230" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1721" y="137" width="71" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1_di" bpmnElement="TextAnnotation_1">
+        <dc:Bounds x="160" y="80" width="1050" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0lzenly" bpmnElement="NonInterruptingBoundaryEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1772" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1746" y="345" width="90" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0v29o08" bpmnElement="BoundaryEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1592" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1566" y="345" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0nwveo1" bpmnElement="NonInterruptingBoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="702" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="985" width="89" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1q4qstq" bpmnElement="BoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="522" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="985" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_02pg78j" bpmnElement="NonInterruptingBoundaryEvent_Date" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="702" y="622" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="681" y="665" width="83" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ktlobl" bpmnElement="BoundaryEvent_Date" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="522" y="622" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="500" y="665" width="83" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hdiole_di" bpmnElement="NonInterruptingBoundaryEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="702" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="677" y="345" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1iy8313_di" bpmnElement="BoundaryEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="522" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="345" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/camunda-cloud/integration/camunda-cloud-1-0-timer.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-1-0-timer.bpmn
@@ -1,61 +1,221 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ot6ika" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.4.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
-  <bpmn:process id="Process_0jflbl3" isExecutable="true">
-    <bpmn:task id="Activity_0kcb5kw">
-      <bpmn:incoming>Flow_1xwctp0</bpmn:incoming>
-    </bpmn:task>
-    <bpmn:startEvent id="StartEvent_1" name="Date">
-      <bpmn:outgoing>Flow_0b6nadt</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1fxm0mf">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1w3xyk9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_Cycle" name="StartEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_1" />
+    <bpmn:task id="Task_2" />
+    <bpmn:subProcess id="SubProcess_Cycle" name="SubProcess_Cycle" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Cycle" name="EventSubProcess_NonInterruptingStartEvent_Cycle" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:startEvent id="StartEvent_Date" name="StartEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Date">
         <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
-    <bpmn:intermediateCatchEvent id="Event_0sbvzs9" name="Duration">
-      <bpmn:incoming>Flow_0b6nadt</bpmn:incoming>
-      <bpmn:outgoing>Flow_1xwctp0</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1rxh4l4">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT15S</bpmn:timeDuration>
+    <bpmn:task id="Task_5" />
+    <bpmn:task id="Task_6" />
+    <bpmn:subProcess id="SubProcess_Date" name="SubProcess_Date" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Date" name="EventSubProcess_StartEvent_Date">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Date" name="EventSubProcess_NonInterruptingStartEvent_Date" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Duration" name="IntermediateCatchEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:boundaryEvent id="Event_0hn049s" name="Duration" attachedToRef="Activity_0kcb5kw">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0bg6y33">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT15S</bpmn:timeDuration>
+    <bpmn:task id="Task_7" />
+    <bpmn:task id="Task_8" />
+    <bpmn:subProcess id="SubProcess_Duration" name="SubProcess_Duration" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Duration" name="EventSubProcess_StartEvent_Duration">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Duration" name="EventSubProcess_NonInterruptingStartEvent_Duration" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Duration" name="BoundaryEvent_Duration" attachedToRef="Task_7">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_0b6nadt" sourceRef="StartEvent_1" targetRef="Event_0sbvzs9" />
-    <bpmn:sequenceFlow id="Flow_1xwctp0" sourceRef="Event_0sbvzs9" targetRef="Activity_0kcb5kw" />
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Duration" name="NonInterruptingBoundaryEvent_Duration" cancelActivity="false" attachedToRef="Task_8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:task id="Task_3" />
+    <bpmn:task id="Task_4" />
+    <bpmn:subProcess id="SubProcess_CycleCron" name="SubProcess_CycleCron" triggeredByEvent="true" />
+    <bpmn:group id="Group_Cycle" categoryValueRef="CategoryValue_Cycle" />
+    <bpmn:group id="Group_Date" categoryValueRef="CategoryValue_Date" />
+    <bpmn:group id="Group_Duration" categoryValueRef="CategoryValue_Duration" />
+    <bpmn:group id="Group_CycleCron" categoryValueRef="CategoryValue_CycleCron" />
+    <bpmn:textAnnotation id="TextAnnotation_1">
+      <bpmn:text>Camunda 8 (Zeebe 1.0)</bpmn:text>
+    </bpmn:textAnnotation>
   </bpmn:process>
+  <bpmn:category id="Category_Cycle">
+    <bpmn:categoryValue id="CategoryValue_Cycle" value="Cycle" />
+  </bpmn:category>
+  <bpmn:category id="Category_Date">
+    <bpmn:categoryValue id="CategoryValue_Date" value="Date" />
+  </bpmn:category>
+  <bpmn:category id="Category_Duration">
+    <bpmn:categoryValue id="CategoryValue_Duration" value="Duration" />
+  </bpmn:category>
+  <bpmn:category id="Category_CycleCron">
+    <bpmn:categoryValue id="CategoryValue_CycleCron" value="Cycle (CRON)" />
+  </bpmn:category>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0jflbl3">
-      <bpmndi:BPMNShape id="Activity_0kcb5kw_di" bpmnElement="Activity_0kcb5kw">
-        <dc:Bounds x="370" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1socevm_di" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="99" width="36" height="36" />
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_1a2aqqq_di" bpmnElement="StartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="262" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="186" y="142" width="24" height="14" />
+          <dc:Bounds x="178" y="305" width="86" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0d5th2l_di" bpmnElement="Event_0sbvzs9">
-        <dc:Bounds x="272" y="99" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_158bxus_di" bpmnElement="Task_1">
+        <dc:Bounds x="440" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1c7yu62_di" bpmnElement="Task_2">
+        <dc:Bounds x="620" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0si6fbo_di" bpmnElement="SubProcess_Cycle" isExpanded="true">
+        <dc:Bounds x="810" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1hvn2kh_di" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="269" y="142" width="42" height="14" />
+          <dc:Bounds x="990" y="315" width="85" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1qiyw8j_di" bpmnElement="Event_0hn049s">
-        <dc:Bounds x="352" y="139" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_1daj4e0" bpmnElement="StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="582" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="349" y="182" width="42" height="14" />
+          <dc:Bounds x="180" y="625" width="82" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0b6nadt_di" bpmnElement="Flow_0b6nadt">
-        <di:waypoint x="215" y="117" />
-        <di:waypoint x="272" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1xwctp0_di" bpmnElement="Flow_1xwctp0">
-        <di:waypoint x="308" y="117" />
-        <di:waypoint x="370" y="117" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_1godq1i" bpmnElement="Task_5">
+        <dc:Bounds x="440" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1cqtk6t" bpmnElement="Task_6">
+        <dc:Bounds x="620" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nhun69" bpmnElement="SubProcess_Date" isExpanded="true">
+        <dc:Bounds x="810" y="510" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1679ksi" bpmnElement="EventSubProcess_StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="635" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n27xdi" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="988" y="635" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0b7rl6t" bpmnElement="IntermediateCatchEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="292" y="902" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="268" y="945" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_09h1dj0" bpmnElement="Task_7">
+        <dc:Bounds x="440" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_13qr05v" bpmnElement="Task_8">
+        <dc:Bounds x="620" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sopxbu" bpmnElement="SubProcess_Duration" isExpanded="true">
+        <dc:Bounds x="810" y="830" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n0geh0" bpmnElement="EventSubProcess_StartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="955" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_01typqg" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="987" y="955" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sp4b5v" bpmnElement="Task_3">
+        <dc:Bounds x="1510" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0j20tgx" bpmnElement="Task_4">
+        <dc:Bounds x="1690" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0gooim1" bpmnElement="SubProcess_CycleCron" isExpanded="true">
+        <dc:Bounds x="1880" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0oqi537_di" bpmnElement="Group_Cycle">
+        <dc:Bounds x="160" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="671" y="137" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1lmj4kq" bpmnElement="Group_Date">
+        <dc:Bounds x="160" y="450" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="675" y="457" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_100yato" bpmnElement="Group_Duration">
+        <dc:Bounds x="160" y="770" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="664" y="777" width="42" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0m8h7pu" bpmnElement="Group_CycleCron">
+        <dc:Bounds x="1230" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1721" y="137" width="71" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1_di" bpmnElement="TextAnnotation_1">
+        <dc:Bounds x="160" y="80" width="1050" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0nwveo1" bpmnElement="NonInterruptingBoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="702" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="985" width="89" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1q4qstq" bpmnElement="BoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="522" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="985" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/camunda-cloud/integration/camunda-cloud-1-1-timer-errors.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-1-1-timer-errors.bpmn
@@ -1,78 +1,352 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ot6ika" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.4.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.1.0">
-  <bpmn:process id="Process_0jflbl3" isExecutable="true">
-    <bpmn:task id="Activity_0kcb5kw">
-      <bpmn:incoming>Flow_1xwctp0</bpmn:incoming>
-    </bpmn:task>
-    <bpmn:startEvent id="StartEvent_1" name="Date">
-      <bpmn:outgoing>Flow_0b6nadt</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1fxm0mf">
-        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDate>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1w3xyk9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.1.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Cycle" name="IntermediateCatchEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Cycle" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_Cycle" name="StartEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
-    <bpmn:intermediateCatchEvent id="Event_0sbvzs9" name="Duration">
-      <bpmn:incoming>Flow_0b6nadt</bpmn:incoming>
-      <bpmn:outgoing>Flow_1xwctp0</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1rxh4l4">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDuration>
+    <bpmn:task id="Task_1" />
+    <bpmn:boundaryEvent id="BoundaryEvent_Cycle" name="BoundaryEvent_Cycle" attachedToRef="Task_1">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Cycle" />
+    </bpmn:boundaryEvent>
+    <bpmn:task id="Task_2" />
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Cycle" name="NonInterruptingBoundaryEvent_Cycle" cancelActivity="false" attachedToRef="Task_2">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:subProcess id="SubProcess_Cycle" name="SubProcess_Cycle" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Cycle" name="EventSubProcess_StartEvent_Cycle">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Cycle" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Cycle" name="EventSubProcess_NonInterruptingStartEvent_Cycle" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Date" name="IntermediateCatchEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Date" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_Date" name="StartEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_5" />
+    <bpmn:task id="Task_6" />
+    <bpmn:subProcess id="SubProcess_Date" name="SubProcess_Date" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Date" name="EventSubProcess_StartEvent_Date">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Date" name="EventSubProcess_NonInterruptingStartEvent_Date" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Date" name="BoundaryEvent_Date" attachedToRef="Task_5">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Date" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Date" name="NonInterruptingBoundaryEvent_Date" cancelActivity="false" attachedToRef="Task_6">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Date" />
+    </bpmn:boundaryEvent>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Duration" name="IntermediateCatchEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:boundaryEvent id="Event_0hn049s" name="Duration" attachedToRef="Activity_0kcb5kw">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0bg6y33">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDuration>
+    <bpmn:startEvent id="StartEvent_Duration" name="StartEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Duration" />
+    </bpmn:startEvent>
+    <bpmn:task id="Task_7" />
+    <bpmn:task id="Task_8" />
+    <bpmn:subProcess id="SubProcess_Duration" name="SubProcess_Duration" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Duration" name="EventSubProcess_StartEvent_Duration">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Duration" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Duration" name="EventSubProcess_NonInterruptingStartEvent_Duration" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Duration" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Duration" name="BoundaryEvent_Duration" attachedToRef="Task_7">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_0b6nadt" sourceRef="StartEvent_1" targetRef="Event_0sbvzs9" />
-    <bpmn:sequenceFlow id="Flow_1xwctp0" sourceRef="Event_0sbvzs9" targetRef="Activity_0kcb5kw" />
-    <bpmn:startEvent id="Event_1jtin5z" name="Cycle">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0sm5q3w">
-        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">@daily</bpmn:timeCycle>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Duration" name="NonInterruptingBoundaryEvent_Duration" cancelActivity="false" attachedToRef="Task_8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_CycleCron" name="IntermediateCatchEvent_CycleCron">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_CycleCron" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_CycleCron" name="StartEvent_CycleCron">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
-    <bpmn:boundaryEvent id="Event_1metpe7" attachedToRef="Activity_0kcb5kw">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0n56omv" />
+    <bpmn:task id="Task_3" />
+    <bpmn:task id="Task_4" />
+    <bpmn:subProcess id="SubProcess_CycleCron" name="SubProcess_CycleCron" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_CycleCron" name="EventSubProcess_StartEvent_CycleCron">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_CycleCron" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_CycleCron" name="EventSubProcess_NonInterruptingStartEvent_CycleCron" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_CycleCron">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_CycleCron" name="BoundaryEvent_CycleCron" attachedToRef="Task_3">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_CycleCron" />
     </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_CycleCron" name="NonInterruptingBoundaryEvent_CycleCron" cancelActivity="false" attachedToRef="Task_4">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:group id="Group_Cycle" categoryValueRef="CategoryValue_Cycle" />
+    <bpmn:group id="Group_Date" categoryValueRef="CategoryValue_Date" />
+    <bpmn:group id="Group_Duration" categoryValueRef="CategoryValue_Duration" />
+    <bpmn:group id="Group_CycleCron" categoryValueRef="CategoryValue_CycleCron" />
+    <bpmn:textAnnotation id="TextAnnotation_1">
+      <bpmn:text>Camunda 8 (Zeebe 1.1)</bpmn:text>
+    </bpmn:textAnnotation>
   </bpmn:process>
+  <bpmn:category id="Category_Cycle">
+    <bpmn:categoryValue id="CategoryValue_Cycle" value="Cycle" />
+  </bpmn:category>
+  <bpmn:category id="Category_Date">
+    <bpmn:categoryValue id="CategoryValue_Date" value="Date" />
+  </bpmn:category>
+  <bpmn:category id="Category_Duration">
+    <bpmn:categoryValue id="CategoryValue_Duration" value="Duration" />
+  </bpmn:category>
+  <bpmn:category id="Category_CycleCron">
+    <bpmn:categoryValue id="CategoryValue_CycleCron" value="Cycle (CRON)" />
+  </bpmn:category>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0jflbl3">
-      <bpmndi:BPMNShape id="Activity_0kcb5kw_di" bpmnElement="Activity_0kcb5kw">
-        <dc:Bounds x="370" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1socevm_di" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="99" width="36" height="36" />
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_1ih3qg9_di" bpmnElement="IntermediateCatchEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="292" y="212" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="186" y="142" width="24" height="14" />
+          <dc:Bounds x="268" y="255" width="85" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0d5th2l_di" bpmnElement="Event_0sbvzs9">
-        <dc:Bounds x="272" y="99" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1a2aqqq_di" bpmnElement="StartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="212" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="269" y="142" width="42" height="14" />
+          <dc:Bounds x="179" y="255" width="85" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1r9zfi8_di" bpmnElement="Event_1jtin5z">
-        <dc:Bounds x="179" y="212" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_158bxus_di" bpmnElement="Task_1">
+        <dc:Bounds x="440" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1c7yu62_di" bpmnElement="Task_2">
+        <dc:Bounds x="620" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0si6fbo_di" bpmnElement="SubProcess_Cycle" isExpanded="true">
+        <dc:Bounds x="810" y="140" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0emjtwi_di" bpmnElement="EventSubProcess_StartEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="922" y="222" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="183" y="255" width="29" height="14" />
+          <dc:Bounds x="901" y="265" width="88" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1qiyw8j_di" bpmnElement="Event_0hn049s">
-        <dc:Bounds x="352" y="139" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1hvn2kh_di" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="222" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="349" y="182" width="42" height="14" />
+          <dc:Bounds x="990" y="265" width="86" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1jdcr1y_di" bpmnElement="Event_1metpe7">
-        <dc:Bounds x="452" y="139" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_1noobtj" bpmnElement="IntermediateCatchEvent_Date" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="292" y="532" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="272" y="575" width="80" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0b6nadt_di" bpmnElement="Flow_0b6nadt">
-        <di:waypoint x="215" y="117" />
-        <di:waypoint x="272" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1xwctp0_di" bpmnElement="Flow_1xwctp0">
-        <di:waypoint x="308" y="117" />
-        <di:waypoint x="370" y="117" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_1daj4e0" bpmnElement="StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="532" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="181" y="575" width="81" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1godq1i" bpmnElement="Task_5">
+        <dc:Bounds x="440" y="510" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1cqtk6t" bpmnElement="Task_6">
+        <dc:Bounds x="620" y="510" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nhun69" bpmnElement="SubProcess_Date" isExpanded="true">
+        <dc:Bounds x="810" y="460" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1679ksi" bpmnElement="EventSubProcess_StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="542" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="585" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n27xdi" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="542" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="989" y="585" width="87" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0b7rl6t" bpmnElement="IntermediateCatchEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="292" y="852" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="268" y="895" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nvr3f7" bpmnElement="StartEvent_Duration" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="202" y="852" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="178" y="895" width="86" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_09h1dj0" bpmnElement="Task_7">
+        <dc:Bounds x="440" y="830" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_13qr05v" bpmnElement="Task_8">
+        <dc:Bounds x="620" y="830" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sopxbu" bpmnElement="SubProcess_Duration" isExpanded="true">
+        <dc:Bounds x="810" y="780" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n0geh0" bpmnElement="EventSubProcess_StartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="862" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="905" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_01typqg" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="862" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="987" y="905" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0tc8we8" bpmnElement="IntermediateCatchEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1362" y="212" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1337" y="255" width="87" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_114olyo" bpmnElement="StartEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1272" y="212" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1249" y="255" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sp4b5v" bpmnElement="Task_3">
+        <dc:Bounds x="1510" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0j20tgx" bpmnElement="Task_4">
+        <dc:Bounds x="1690" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0gooim1" bpmnElement="SubProcess_CycleCron" isExpanded="true">
+        <dc:Bounds x="1880" y="140" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ph0d9f" bpmnElement="EventSubProcess_StartEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1992" y="222" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1971" y="265" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_11c780k" bpmnElement="EventSubProcess_NonInterruptingStartEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="2082" y="222" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2059" y="265" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0oqi537_di" bpmnElement="Group_Cycle">
+        <dc:Bounds x="160" y="80" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="672" y="87" width="28" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1lmj4kq" bpmnElement="Group_Date">
+        <dc:Bounds x="160" y="400" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="675" y="407" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_100yato" bpmnElement="Group_Duration">
+        <dc:Bounds x="160" y="720" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="664" y="727" width="42" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0m8h7pu" bpmnElement="Group_CycleCron">
+        <dc:Bounds x="1230" y="80" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1721" y="87" width="71" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1_di" bpmnElement="TextAnnotation_1">
+        <dc:Bounds x="160" y="30" width="1050" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0lzenly" bpmnElement="NonInterruptingBoundaryEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1772" y="252" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1746" y="295" width="90" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0v29o08" bpmnElement="BoundaryEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1592" y="252" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1566" y="295" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0nwveo1" bpmnElement="NonInterruptingBoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="702" y="892" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="935" width="89" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1q4qstq" bpmnElement="BoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="522" y="892" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="935" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_02pg78j" bpmnElement="NonInterruptingBoundaryEvent_Date" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="702" y="572" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="681" y="615" width="83" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ktlobl" bpmnElement="BoundaryEvent_Date" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="522" y="572" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="500" y="615" width="83" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hdiole_di" bpmnElement="NonInterruptingBoundaryEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="702" y="252" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="677" y="295" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1iy8313_di" bpmnElement="BoundaryEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="522" y="252" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="295" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/camunda-cloud/integration/camunda-cloud-1-1-timer.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-1-1-timer.bpmn
@@ -1,61 +1,221 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ot6ika" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.4.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.1.0">
-  <bpmn:process id="Process_0jflbl3" isExecutable="true">
-    <bpmn:task id="Activity_0kcb5kw">
-      <bpmn:incoming>Flow_1xwctp0</bpmn:incoming>
-    </bpmn:task>
-    <bpmn:startEvent id="StartEvent_1" name="Date">
-      <bpmn:outgoing>Flow_0b6nadt</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1fxm0mf">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1w3xyk9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.1.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_Cycle" name="StartEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_1" />
+    <bpmn:task id="Task_2" />
+    <bpmn:subProcess id="SubProcess_Cycle" name="SubProcess_Cycle" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Cycle" name="EventSubProcess_NonInterruptingStartEvent_Cycle" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:startEvent id="StartEvent_Date" name="StartEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Date">
         <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
-    <bpmn:intermediateCatchEvent id="Event_0sbvzs9" name="Duration">
-      <bpmn:incoming>Flow_0b6nadt</bpmn:incoming>
-      <bpmn:outgoing>Flow_1xwctp0</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1rxh4l4">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT15S</bpmn:timeDuration>
+    <bpmn:task id="Task_5" />
+    <bpmn:task id="Task_6" />
+    <bpmn:subProcess id="SubProcess_Date" name="SubProcess_Date" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Date" name="EventSubProcess_StartEvent_Date">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Date" name="EventSubProcess_NonInterruptingStartEvent_Date" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Duration" name="IntermediateCatchEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:boundaryEvent id="Event_0hn049s" name="Duration" attachedToRef="Activity_0kcb5kw">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0bg6y33">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT15S</bpmn:timeDuration>
+    <bpmn:task id="Task_7" />
+    <bpmn:task id="Task_8" />
+    <bpmn:subProcess id="SubProcess_Duration" name="SubProcess_Duration" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Duration" name="EventSubProcess_StartEvent_Duration">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Duration" name="EventSubProcess_NonInterruptingStartEvent_Duration" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Duration" name="BoundaryEvent_Duration" attachedToRef="Task_7">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_0b6nadt" sourceRef="StartEvent_1" targetRef="Event_0sbvzs9" />
-    <bpmn:sequenceFlow id="Flow_1xwctp0" sourceRef="Event_0sbvzs9" targetRef="Activity_0kcb5kw" />
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Duration" name="NonInterruptingBoundaryEvent_Duration" cancelActivity="false" attachedToRef="Task_8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:task id="Task_3" />
+    <bpmn:task id="Task_4" />
+    <bpmn:subProcess id="SubProcess_CycleCron" name="SubProcess_CycleCron" triggeredByEvent="true" />
+    <bpmn:group id="Group_Cycle" categoryValueRef="CategoryValue_Cycle" />
+    <bpmn:group id="Group_Date" categoryValueRef="CategoryValue_Date" />
+    <bpmn:group id="Group_Duration" categoryValueRef="CategoryValue_Duration" />
+    <bpmn:group id="Group_CycleCron" categoryValueRef="CategoryValue_CycleCron" />
+    <bpmn:textAnnotation id="TextAnnotation_1">
+      <bpmn:text>Camunda 8 (Zeebe 1.1)</bpmn:text>
+    </bpmn:textAnnotation>
   </bpmn:process>
+  <bpmn:category id="Category_Cycle">
+    <bpmn:categoryValue id="CategoryValue_Cycle" value="Cycle" />
+  </bpmn:category>
+  <bpmn:category id="Category_Date">
+    <bpmn:categoryValue id="CategoryValue_Date" value="Date" />
+  </bpmn:category>
+  <bpmn:category id="Category_Duration">
+    <bpmn:categoryValue id="CategoryValue_Duration" value="Duration" />
+  </bpmn:category>
+  <bpmn:category id="Category_CycleCron">
+    <bpmn:categoryValue id="CategoryValue_CycleCron" value="Cycle (CRON)" />
+  </bpmn:category>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0jflbl3">
-      <bpmndi:BPMNShape id="Activity_0kcb5kw_di" bpmnElement="Activity_0kcb5kw">
-        <dc:Bounds x="370" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1socevm_di" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="99" width="36" height="36" />
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_1a2aqqq_di" bpmnElement="StartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="262" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="186" y="142" width="24" height="14" />
+          <dc:Bounds x="178" y="305" width="86" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0d5th2l_di" bpmnElement="Event_0sbvzs9">
-        <dc:Bounds x="272" y="99" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_158bxus_di" bpmnElement="Task_1">
+        <dc:Bounds x="440" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1c7yu62_di" bpmnElement="Task_2">
+        <dc:Bounds x="620" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0si6fbo_di" bpmnElement="SubProcess_Cycle" isExpanded="true">
+        <dc:Bounds x="810" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1hvn2kh_di" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="269" y="142" width="42" height="14" />
+          <dc:Bounds x="990" y="315" width="85" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1qiyw8j_di" bpmnElement="Event_0hn049s">
-        <dc:Bounds x="352" y="139" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_1daj4e0" bpmnElement="StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="582" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="349" y="182" width="42" height="14" />
+          <dc:Bounds x="180" y="625" width="82" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0b6nadt_di" bpmnElement="Flow_0b6nadt">
-        <di:waypoint x="215" y="117" />
-        <di:waypoint x="272" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1xwctp0_di" bpmnElement="Flow_1xwctp0">
-        <di:waypoint x="308" y="117" />
-        <di:waypoint x="370" y="117" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_1godq1i" bpmnElement="Task_5">
+        <dc:Bounds x="440" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1cqtk6t" bpmnElement="Task_6">
+        <dc:Bounds x="620" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nhun69" bpmnElement="SubProcess_Date" isExpanded="true">
+        <dc:Bounds x="810" y="510" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1679ksi" bpmnElement="EventSubProcess_StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="635" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n27xdi" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="988" y="635" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0b7rl6t" bpmnElement="IntermediateCatchEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="292" y="902" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="268" y="945" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_09h1dj0" bpmnElement="Task_7">
+        <dc:Bounds x="440" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_13qr05v" bpmnElement="Task_8">
+        <dc:Bounds x="620" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sopxbu" bpmnElement="SubProcess_Duration" isExpanded="true">
+        <dc:Bounds x="810" y="830" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n0geh0" bpmnElement="EventSubProcess_StartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="955" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_01typqg" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="987" y="955" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sp4b5v" bpmnElement="Task_3">
+        <dc:Bounds x="1510" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0j20tgx" bpmnElement="Task_4">
+        <dc:Bounds x="1690" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0gooim1" bpmnElement="SubProcess_CycleCron" isExpanded="true">
+        <dc:Bounds x="1880" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0oqi537_di" bpmnElement="Group_Cycle">
+        <dc:Bounds x="160" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="671" y="137" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1lmj4kq" bpmnElement="Group_Date">
+        <dc:Bounds x="160" y="450" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="675" y="457" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_100yato" bpmnElement="Group_Duration">
+        <dc:Bounds x="160" y="770" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="664" y="777" width="42" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0m8h7pu" bpmnElement="Group_CycleCron">
+        <dc:Bounds x="1230" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1721" y="137" width="71" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1_di" bpmnElement="TextAnnotation_1">
+        <dc:Bounds x="160" y="80" width="1050" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0nwveo1" bpmnElement="NonInterruptingBoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="702" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="985" width="89" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1q4qstq" bpmnElement="BoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="522" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="985" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/camunda-cloud/integration/camunda-cloud-1-2-timer-errors.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-1-2-timer-errors.bpmn
@@ -1,78 +1,352 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ot6ika" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.4.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.2.0">
-  <bpmn:process id="Process_0jflbl3" isExecutable="true">
-    <bpmn:task id="Activity_0kcb5kw">
-      <bpmn:incoming>Flow_1xwctp0</bpmn:incoming>
-    </bpmn:task>
-    <bpmn:startEvent id="StartEvent_1" name="Date">
-      <bpmn:outgoing>Flow_0b6nadt</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1fxm0mf">
-        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDate>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1w3xyk9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.2.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Cycle" name="IntermediateCatchEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Cycle" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_Cycle" name="StartEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
-    <bpmn:intermediateCatchEvent id="Event_0sbvzs9" name="Duration">
-      <bpmn:incoming>Flow_0b6nadt</bpmn:incoming>
-      <bpmn:outgoing>Flow_1xwctp0</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1rxh4l4">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDuration>
+    <bpmn:task id="Task_1" />
+    <bpmn:boundaryEvent id="BoundaryEvent_Cycle" name="BoundaryEvent_Cycle" attachedToRef="Task_1">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Cycle" />
+    </bpmn:boundaryEvent>
+    <bpmn:task id="Task_2" />
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Cycle" name="NonInterruptingBoundaryEvent_Cycle" cancelActivity="false" attachedToRef="Task_2">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:subProcess id="SubProcess_Cycle" name="SubProcess_Cycle" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Cycle" name="EventSubProcess_StartEvent_Cycle">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Cycle" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Cycle" name="EventSubProcess_NonInterruptingStartEvent_Cycle" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Date" name="IntermediateCatchEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Date" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_Date" name="StartEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_5" />
+    <bpmn:task id="Task_6" />
+    <bpmn:subProcess id="SubProcess_Date" name="SubProcess_Date" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Date" name="EventSubProcess_StartEvent_Date">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Date" name="EventSubProcess_NonInterruptingStartEvent_Date" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Date" name="BoundaryEvent_Date" attachedToRef="Task_5">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Date" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Date" name="NonInterruptingBoundaryEvent_Date" cancelActivity="false" attachedToRef="Task_6">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Date" />
+    </bpmn:boundaryEvent>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Duration" name="IntermediateCatchEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:boundaryEvent id="Event_0hn049s" name="Duration" attachedToRef="Activity_0kcb5kw">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0bg6y33">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDuration>
+    <bpmn:startEvent id="StartEvent_Duration" name="StartEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Duration" />
+    </bpmn:startEvent>
+    <bpmn:task id="Task_7" />
+    <bpmn:task id="Task_8" />
+    <bpmn:subProcess id="SubProcess_Duration" name="SubProcess_Duration" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Duration" name="EventSubProcess_StartEvent_Duration">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Duration" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Duration" name="EventSubProcess_NonInterruptingStartEvent_Duration" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Duration" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Duration" name="BoundaryEvent_Duration" attachedToRef="Task_7">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_0b6nadt" sourceRef="StartEvent_1" targetRef="Event_0sbvzs9" />
-    <bpmn:sequenceFlow id="Flow_1xwctp0" sourceRef="Event_0sbvzs9" targetRef="Activity_0kcb5kw" />
-    <bpmn:startEvent id="Event_1jtin5z" name="Cycle">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0sm5q3w">
-        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">@daily</bpmn:timeCycle>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Duration" name="NonInterruptingBoundaryEvent_Duration" cancelActivity="false" attachedToRef="Task_8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_CycleCron" name="IntermediateCatchEvent_CycleCron">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_CycleCron" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_CycleCron" name="StartEvent_CycleCron">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
-    <bpmn:boundaryEvent id="Event_1metpe7" attachedToRef="Activity_0kcb5kw">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0n56omv" />
+    <bpmn:task id="Task_3" />
+    <bpmn:task id="Task_4" />
+    <bpmn:subProcess id="SubProcess_CycleCron" name="SubProcess_CycleCron" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_CycleCron" name="EventSubProcess_StartEvent_CycleCron">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_CycleCron" />
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_CycleCron" name="EventSubProcess_NonInterruptingStartEvent_CycleCron" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_CycleCron">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_CycleCron" name="BoundaryEvent_CycleCron" attachedToRef="Task_3">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_CycleCron" />
     </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_CycleCron" name="NonInterruptingBoundaryEvent_CycleCron" cancelActivity="false" attachedToRef="Task_4">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:group id="Group_Cycle" categoryValueRef="CategoryValue_Cycle" />
+    <bpmn:group id="Group_Date" categoryValueRef="CategoryValue_Date" />
+    <bpmn:group id="Group_Duration" categoryValueRef="CategoryValue_Duration" />
+    <bpmn:group id="Group_CycleCron" categoryValueRef="CategoryValue_CycleCron" />
+    <bpmn:textAnnotation id="TextAnnotation_1">
+      <bpmn:text>Camunda 8 (Zeebe 1.2)</bpmn:text>
+    </bpmn:textAnnotation>
   </bpmn:process>
+  <bpmn:category id="Category_Cycle">
+    <bpmn:categoryValue id="CategoryValue_Cycle" value="Cycle" />
+  </bpmn:category>
+  <bpmn:category id="Category_Date">
+    <bpmn:categoryValue id="CategoryValue_Date" value="Date" />
+  </bpmn:category>
+  <bpmn:category id="Category_Duration">
+    <bpmn:categoryValue id="CategoryValue_Duration" value="Duration" />
+  </bpmn:category>
+  <bpmn:category id="Category_CycleCron">
+    <bpmn:categoryValue id="CategoryValue_CycleCron" value="Cycle (CRON)" />
+  </bpmn:category>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0jflbl3">
-      <bpmndi:BPMNShape id="Activity_0kcb5kw_di" bpmnElement="Activity_0kcb5kw">
-        <dc:Bounds x="370" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1socevm_di" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="99" width="36" height="36" />
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_1ih3qg9_di" bpmnElement="IntermediateCatchEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="292" y="212" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="186" y="142" width="24" height="14" />
+          <dc:Bounds x="268" y="255" width="85" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0d5th2l_di" bpmnElement="Event_0sbvzs9">
-        <dc:Bounds x="272" y="99" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1a2aqqq_di" bpmnElement="StartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="212" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="269" y="142" width="42" height="14" />
+          <dc:Bounds x="179" y="255" width="85" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1r9zfi8_di" bpmnElement="Event_1jtin5z">
-        <dc:Bounds x="179" y="212" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_158bxus_di" bpmnElement="Task_1">
+        <dc:Bounds x="440" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1c7yu62_di" bpmnElement="Task_2">
+        <dc:Bounds x="620" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0si6fbo_di" bpmnElement="SubProcess_Cycle" isExpanded="true">
+        <dc:Bounds x="810" y="140" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0emjtwi_di" bpmnElement="EventSubProcess_StartEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="922" y="222" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="183" y="255" width="29" height="14" />
+          <dc:Bounds x="901" y="265" width="88" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1qiyw8j_di" bpmnElement="Event_0hn049s">
-        <dc:Bounds x="352" y="139" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1hvn2kh_di" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="222" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="349" y="182" width="42" height="14" />
+          <dc:Bounds x="990" y="265" width="86" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1jdcr1y_di" bpmnElement="Event_1metpe7">
-        <dc:Bounds x="452" y="139" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_1noobtj" bpmnElement="IntermediateCatchEvent_Date" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="292" y="532" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="272" y="575" width="80" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0b6nadt_di" bpmnElement="Flow_0b6nadt">
-        <di:waypoint x="215" y="117" />
-        <di:waypoint x="272" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1xwctp0_di" bpmnElement="Flow_1xwctp0">
-        <di:waypoint x="308" y="117" />
-        <di:waypoint x="370" y="117" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_1daj4e0" bpmnElement="StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="532" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="181" y="575" width="81" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1godq1i" bpmnElement="Task_5">
+        <dc:Bounds x="440" y="510" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1cqtk6t" bpmnElement="Task_6">
+        <dc:Bounds x="620" y="510" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nhun69" bpmnElement="SubProcess_Date" isExpanded="true">
+        <dc:Bounds x="810" y="460" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1679ksi" bpmnElement="EventSubProcess_StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="542" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="585" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n27xdi" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="542" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="989" y="585" width="87" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0b7rl6t" bpmnElement="IntermediateCatchEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="292" y="852" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="268" y="895" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nvr3f7" bpmnElement="StartEvent_Duration" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="202" y="852" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="178" y="895" width="86" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_09h1dj0" bpmnElement="Task_7">
+        <dc:Bounds x="440" y="830" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_13qr05v" bpmnElement="Task_8">
+        <dc:Bounds x="620" y="830" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sopxbu" bpmnElement="SubProcess_Duration" isExpanded="true">
+        <dc:Bounds x="810" y="780" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n0geh0" bpmnElement="EventSubProcess_StartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="862" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="905" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_01typqg" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="862" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="987" y="905" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0tc8we8" bpmnElement="IntermediateCatchEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1362" y="212" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1337" y="255" width="87" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_114olyo" bpmnElement="StartEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1272" y="212" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1249" y="255" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sp4b5v" bpmnElement="Task_3">
+        <dc:Bounds x="1510" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0j20tgx" bpmnElement="Task_4">
+        <dc:Bounds x="1690" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0gooim1" bpmnElement="SubProcess_CycleCron" isExpanded="true">
+        <dc:Bounds x="1880" y="140" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ph0d9f" bpmnElement="EventSubProcess_StartEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1992" y="222" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1971" y="265" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_11c780k" bpmnElement="EventSubProcess_NonInterruptingStartEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="2082" y="222" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2059" y="265" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0oqi537_di" bpmnElement="Group_Cycle">
+        <dc:Bounds x="160" y="80" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="672" y="87" width="28" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1lmj4kq" bpmnElement="Group_Date">
+        <dc:Bounds x="160" y="400" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="675" y="407" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_100yato" bpmnElement="Group_Duration">
+        <dc:Bounds x="160" y="720" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="664" y="727" width="42" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0m8h7pu" bpmnElement="Group_CycleCron">
+        <dc:Bounds x="1230" y="80" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1721" y="87" width="71" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1_di" bpmnElement="TextAnnotation_1">
+        <dc:Bounds x="160" y="30" width="1050" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0lzenly" bpmnElement="NonInterruptingBoundaryEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1772" y="252" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1746" y="295" width="90" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0v29o08" bpmnElement="BoundaryEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1592" y="252" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1566" y="295" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0nwveo1" bpmnElement="NonInterruptingBoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="702" y="892" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="935" width="89" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1q4qstq" bpmnElement="BoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="522" y="892" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="935" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_02pg78j" bpmnElement="NonInterruptingBoundaryEvent_Date" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="702" y="572" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="681" y="615" width="83" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ktlobl" bpmnElement="BoundaryEvent_Date" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="522" y="572" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="500" y="615" width="83" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hdiole_di" bpmnElement="NonInterruptingBoundaryEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="702" y="252" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="677" y="295" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1iy8313_di" bpmnElement="BoundaryEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="522" y="252" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="295" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/camunda-cloud/integration/camunda-cloud-1-2-timer.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-1-2-timer.bpmn
@@ -1,61 +1,221 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ot6ika" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.4.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.2.0">
-  <bpmn:process id="Process_0jflbl3" isExecutable="true">
-    <bpmn:task id="Activity_0kcb5kw">
-      <bpmn:incoming>Flow_1xwctp0</bpmn:incoming>
-    </bpmn:task>
-    <bpmn:startEvent id="StartEvent_1" name="Date">
-      <bpmn:outgoing>Flow_0b6nadt</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1fxm0mf">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1w3xyk9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.2.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_Cycle" name="StartEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_1" />
+    <bpmn:task id="Task_2" />
+    <bpmn:subProcess id="SubProcess_Cycle" name="SubProcess_Cycle" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Cycle" name="EventSubProcess_NonInterruptingStartEvent_Cycle" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:startEvent id="StartEvent_Date" name="StartEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Date">
         <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
-    <bpmn:intermediateCatchEvent id="Event_0sbvzs9" name="Duration">
-      <bpmn:incoming>Flow_0b6nadt</bpmn:incoming>
-      <bpmn:outgoing>Flow_1xwctp0</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1rxh4l4">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT15S</bpmn:timeDuration>
+    <bpmn:task id="Task_5" />
+    <bpmn:task id="Task_6" />
+    <bpmn:subProcess id="SubProcess_Date" name="SubProcess_Date" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Date" name="EventSubProcess_StartEvent_Date">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Date" name="EventSubProcess_NonInterruptingStartEvent_Date" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Duration" name="IntermediateCatchEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:boundaryEvent id="Event_0hn049s" name="Duration" attachedToRef="Activity_0kcb5kw">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0bg6y33">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT15S</bpmn:timeDuration>
+    <bpmn:task id="Task_7" />
+    <bpmn:task id="Task_8" />
+    <bpmn:subProcess id="SubProcess_Duration" name="SubProcess_Duration" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Duration" name="EventSubProcess_StartEvent_Duration">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Duration" name="EventSubProcess_NonInterruptingStartEvent_Duration" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Duration" name="BoundaryEvent_Duration" attachedToRef="Task_7">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_0b6nadt" sourceRef="StartEvent_1" targetRef="Event_0sbvzs9" />
-    <bpmn:sequenceFlow id="Flow_1xwctp0" sourceRef="Event_0sbvzs9" targetRef="Activity_0kcb5kw" />
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Duration" name="NonInterruptingBoundaryEvent_Duration" cancelActivity="false" attachedToRef="Task_8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:task id="Task_3" />
+    <bpmn:task id="Task_4" />
+    <bpmn:subProcess id="SubProcess_CycleCron" name="SubProcess_CycleCron" triggeredByEvent="true" />
+    <bpmn:group id="Group_Cycle" categoryValueRef="CategoryValue_Cycle" />
+    <bpmn:group id="Group_Date" categoryValueRef="CategoryValue_Date" />
+    <bpmn:group id="Group_Duration" categoryValueRef="CategoryValue_Duration" />
+    <bpmn:group id="Group_CycleCron" categoryValueRef="CategoryValue_CycleCron" />
+    <bpmn:textAnnotation id="TextAnnotation_1">
+      <bpmn:text>Camunda 8 (Zeebe 1.2)</bpmn:text>
+    </bpmn:textAnnotation>
   </bpmn:process>
+  <bpmn:category id="Category_Cycle">
+    <bpmn:categoryValue id="CategoryValue_Cycle" value="Cycle" />
+  </bpmn:category>
+  <bpmn:category id="Category_Date">
+    <bpmn:categoryValue id="CategoryValue_Date" value="Date" />
+  </bpmn:category>
+  <bpmn:category id="Category_Duration">
+    <bpmn:categoryValue id="CategoryValue_Duration" value="Duration" />
+  </bpmn:category>
+  <bpmn:category id="Category_CycleCron">
+    <bpmn:categoryValue id="CategoryValue_CycleCron" value="Cycle (CRON)" />
+  </bpmn:category>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0jflbl3">
-      <bpmndi:BPMNShape id="Activity_0kcb5kw_di" bpmnElement="Activity_0kcb5kw">
-        <dc:Bounds x="370" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1socevm_di" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="99" width="36" height="36" />
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_1a2aqqq_di" bpmnElement="StartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="262" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="186" y="142" width="24" height="14" />
+          <dc:Bounds x="178" y="305" width="86" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0d5th2l_di" bpmnElement="Event_0sbvzs9">
-        <dc:Bounds x="272" y="99" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_158bxus_di" bpmnElement="Task_1">
+        <dc:Bounds x="440" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1c7yu62_di" bpmnElement="Task_2">
+        <dc:Bounds x="620" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0si6fbo_di" bpmnElement="SubProcess_Cycle" isExpanded="true">
+        <dc:Bounds x="810" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1hvn2kh_di" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="269" y="142" width="42" height="14" />
+          <dc:Bounds x="990" y="315" width="85" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1qiyw8j_di" bpmnElement="Event_0hn049s">
-        <dc:Bounds x="352" y="139" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_1daj4e0" bpmnElement="StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="582" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="349" y="182" width="42" height="14" />
+          <dc:Bounds x="180" y="625" width="82" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0b6nadt_di" bpmnElement="Flow_0b6nadt">
-        <di:waypoint x="215" y="117" />
-        <di:waypoint x="272" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1xwctp0_di" bpmnElement="Flow_1xwctp0">
-        <di:waypoint x="308" y="117" />
-        <di:waypoint x="370" y="117" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_1godq1i" bpmnElement="Task_5">
+        <dc:Bounds x="440" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1cqtk6t" bpmnElement="Task_6">
+        <dc:Bounds x="620" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nhun69" bpmnElement="SubProcess_Date" isExpanded="true">
+        <dc:Bounds x="810" y="510" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1679ksi" bpmnElement="EventSubProcess_StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="635" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n27xdi" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="988" y="635" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0b7rl6t" bpmnElement="IntermediateCatchEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="292" y="902" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="268" y="945" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_09h1dj0" bpmnElement="Task_7">
+        <dc:Bounds x="440" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_13qr05v" bpmnElement="Task_8">
+        <dc:Bounds x="620" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sopxbu" bpmnElement="SubProcess_Duration" isExpanded="true">
+        <dc:Bounds x="810" y="830" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n0geh0" bpmnElement="EventSubProcess_StartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="955" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_01typqg" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="987" y="955" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sp4b5v" bpmnElement="Task_3">
+        <dc:Bounds x="1510" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0j20tgx" bpmnElement="Task_4">
+        <dc:Bounds x="1690" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0gooim1" bpmnElement="SubProcess_CycleCron" isExpanded="true">
+        <dc:Bounds x="1880" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0oqi537_di" bpmnElement="Group_Cycle">
+        <dc:Bounds x="160" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="671" y="137" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1lmj4kq" bpmnElement="Group_Date">
+        <dc:Bounds x="160" y="450" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="675" y="457" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_100yato" bpmnElement="Group_Duration">
+        <dc:Bounds x="160" y="770" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="664" y="777" width="42" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0m8h7pu" bpmnElement="Group_CycleCron">
+        <dc:Bounds x="1230" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1721" y="137" width="71" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1_di" bpmnElement="TextAnnotation_1">
+        <dc:Bounds x="160" y="80" width="1050" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0nwveo1" bpmnElement="NonInterruptingBoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="702" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="985" width="89" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1q4qstq" bpmnElement="BoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="522" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="985" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/camunda-cloud/integration/camunda-cloud-1-3-timer-errors.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-1-3-timer-errors.bpmn
@@ -1,78 +1,376 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ot6ika" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.4.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.3.0">
-  <bpmn:process id="Process_0jflbl3" isExecutable="true">
-    <bpmn:task id="Activity_0kcb5kw">
-      <bpmn:incoming>Flow_1xwctp0</bpmn:incoming>
-    </bpmn:task>
-    <bpmn:startEvent id="StartEvent_1" name="Date">
-      <bpmn:outgoing>Flow_0b6nadt</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1fxm0mf">
-        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDate>
-      </bpmn:timerEventDefinition>
-    </bpmn:startEvent>
-    <bpmn:intermediateCatchEvent id="Event_0sbvzs9" name="Duration">
-      <bpmn:incoming>Flow_0b6nadt</bpmn:incoming>
-      <bpmn:outgoing>Flow_1xwctp0</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1rxh4l4">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDuration>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1w3xyk9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.3.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Cycle" name="IntermediateCatchEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:boundaryEvent id="Event_0hn049s" name="Duration" attachedToRef="Activity_0kcb5kw">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0bg6y33">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDuration>
-      </bpmn:timerEventDefinition>
-    </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_0b6nadt" sourceRef="StartEvent_1" targetRef="Event_0sbvzs9" />
-    <bpmn:sequenceFlow id="Flow_1xwctp0" sourceRef="Event_0sbvzs9" targetRef="Activity_0kcb5kw" />
-    <bpmn:startEvent id="Event_1jtin5z" name="Cycle">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0sm5q3w">
-        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">@daily</bpmn:timeCycle>
+    <bpmn:startEvent id="StartEvent_Cycle" name="StartEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
-    <bpmn:boundaryEvent id="Event_1metpe7" attachedToRef="Activity_0kcb5kw">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0n56omv" />
+    <bpmn:task id="Task_1" />
+    <bpmn:boundaryEvent id="BoundaryEvent_Cycle" name="BoundaryEvent_Cycle" attachedToRef="Task_1">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
+    <bpmn:task id="Task_2" />
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Cycle" name="NonInterruptingBoundaryEvent_Cycle" cancelActivity="false" attachedToRef="Task_2">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:subProcess id="SubProcess_Cycle" name="SubProcess_Cycle" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Cycle" name="EventSubProcess_StartEvent_Cycle">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Cycle" name="EventSubProcess_NonInterruptingStartEvent_Cycle" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Date" name="IntermediateCatchEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_Date" name="StartEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_5" />
+    <bpmn:task id="Task_6" />
+    <bpmn:subProcess id="SubProcess_Date" name="SubProcess_Date" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Date" name="EventSubProcess_StartEvent_Date">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Date" name="EventSubProcess_NonInterruptingStartEvent_Date" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Date" name="BoundaryEvent_Date" attachedToRef="Task_5">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Date" name="NonInterruptingBoundaryEvent_Date" cancelActivity="false" attachedToRef="Task_6">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Duration" name="IntermediateCatchEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_Duration" name="StartEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_7" />
+    <bpmn:task id="Task_8" />
+    <bpmn:subProcess id="SubProcess_Duration" name="SubProcess_Duration" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Duration" name="EventSubProcess_StartEvent_Duration">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Duration" name="EventSubProcess_NonInterruptingStartEvent_Duration" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Duration" name="BoundaryEvent_Duration" attachedToRef="Task_7">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Duration" name="NonInterruptingBoundaryEvent_Duration" cancelActivity="false" attachedToRef="Task_8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_CycleCron" name="IntermediateCatchEvent_CycleCron">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_CycleCron" name="StartEvent_CycleCron">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_3" />
+    <bpmn:task id="Task_4" />
+    <bpmn:subProcess id="SubProcess_CycleCron" name="SubProcess_CycleCron" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_CycleCron" name="EventSubProcess_StartEvent_CycleCron">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_CycleCron">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_CycleCron" name="EventSubProcess_NonInterruptingStartEvent_CycleCron" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_CycleCron">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_CycleCron" name="BoundaryEvent_CycleCron" attachedToRef="Task_3">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_CycleCron" name="NonInterruptingBoundaryEvent_CycleCron" cancelActivity="false" attachedToRef="Task_4">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:group id="Group_Cycle" categoryValueRef="CategoryValue_Cycle" />
+    <bpmn:group id="Group_Date" categoryValueRef="CategoryValue_Date" />
+    <bpmn:group id="Group_Duration" categoryValueRef="CategoryValue_Duration" />
+    <bpmn:group id="Group_CycleCron" categoryValueRef="CategoryValue_CycleCron" />
+    <bpmn:textAnnotation id="TextAnnotation_1">
+      <bpmn:text>Camunda 8 (Zeebe 1.3)</bpmn:text>
+    </bpmn:textAnnotation>
   </bpmn:process>
+  <bpmn:category id="Category_Cycle">
+    <bpmn:categoryValue id="CategoryValue_Cycle" value="Cycle" />
+  </bpmn:category>
+  <bpmn:category id="Category_Date">
+    <bpmn:categoryValue id="CategoryValue_Date" value="Date" />
+  </bpmn:category>
+  <bpmn:category id="Category_Duration">
+    <bpmn:categoryValue id="CategoryValue_Duration" value="Duration" />
+  </bpmn:category>
+  <bpmn:category id="Category_CycleCron">
+    <bpmn:categoryValue id="CategoryValue_CycleCron" value="Cycle (CRON)" />
+  </bpmn:category>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0jflbl3">
-      <bpmndi:BPMNShape id="Activity_0kcb5kw_di" bpmnElement="Activity_0kcb5kw">
-        <dc:Bounds x="370" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1socevm_di" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="99" width="36" height="36" />
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_1ih3qg9_di" bpmnElement="IntermediateCatchEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="292" y="262" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="186" y="142" width="24" height="14" />
+          <dc:Bounds x="268" y="305" width="85" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0d5th2l_di" bpmnElement="Event_0sbvzs9">
-        <dc:Bounds x="272" y="99" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1a2aqqq_di" bpmnElement="StartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="262" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="269" y="142" width="42" height="14" />
+          <dc:Bounds x="178" y="305" width="86" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1r9zfi8_di" bpmnElement="Event_1jtin5z">
-        <dc:Bounds x="179" y="212" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_158bxus_di" bpmnElement="Task_1">
+        <dc:Bounds x="440" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1c7yu62_di" bpmnElement="Task_2">
+        <dc:Bounds x="620" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0si6fbo_di" bpmnElement="SubProcess_Cycle" isExpanded="true">
+        <dc:Bounds x="810" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0emjtwi_di" bpmnElement="EventSubProcess_StartEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="922" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="183" y="255" width="29" height="14" />
+          <dc:Bounds x="901" y="315" width="88" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1qiyw8j_di" bpmnElement="Event_0hn049s">
-        <dc:Bounds x="352" y="139" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1hvn2kh_di" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="349" y="182" width="42" height="14" />
+          <dc:Bounds x="990" y="315" width="85" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1jdcr1y_di" bpmnElement="Event_1metpe7">
-        <dc:Bounds x="452" y="139" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_1noobtj" bpmnElement="IntermediateCatchEvent_Date" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="292" y="582" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="272" y="625" width="80" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0b6nadt_di" bpmnElement="Flow_0b6nadt">
-        <di:waypoint x="215" y="117" />
-        <di:waypoint x="272" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1xwctp0_di" bpmnElement="Flow_1xwctp0">
-        <di:waypoint x="308" y="117" />
-        <di:waypoint x="370" y="117" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_1daj4e0" bpmnElement="StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="582" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="180" y="625" width="82" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1godq1i" bpmnElement="Task_5">
+        <dc:Bounds x="440" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1cqtk6t" bpmnElement="Task_6">
+        <dc:Bounds x="620" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nhun69" bpmnElement="SubProcess_Date" isExpanded="true">
+        <dc:Bounds x="810" y="510" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1679ksi" bpmnElement="EventSubProcess_StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="635" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n27xdi" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="988" y="635" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0b7rl6t" bpmnElement="IntermediateCatchEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="292" y="902" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="268" y="945" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nvr3f7" bpmnElement="StartEvent_Duration" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="202" y="902" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="178" y="945" width="86" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_09h1dj0" bpmnElement="Task_7">
+        <dc:Bounds x="440" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_13qr05v" bpmnElement="Task_8">
+        <dc:Bounds x="620" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sopxbu" bpmnElement="SubProcess_Duration" isExpanded="true">
+        <dc:Bounds x="810" y="830" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n0geh0" bpmnElement="EventSubProcess_StartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="955" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_01typqg" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="987" y="955" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0tc8we8" bpmnElement="IntermediateCatchEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1362" y="262" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1337" y="305" width="87" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_114olyo" bpmnElement="StartEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1272" y="262" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1249" y="305" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sp4b5v" bpmnElement="Task_3">
+        <dc:Bounds x="1510" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0j20tgx" bpmnElement="Task_4">
+        <dc:Bounds x="1690" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0gooim1" bpmnElement="SubProcess_CycleCron" isExpanded="true">
+        <dc:Bounds x="1880" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ph0d9f" bpmnElement="EventSubProcess_StartEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1992" y="272" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1971" y="315" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_11c780k" bpmnElement="EventSubProcess_NonInterruptingStartEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="2082" y="272" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2059" y="315" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0oqi537_di" bpmnElement="Group_Cycle">
+        <dc:Bounds x="160" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="671" y="137" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1lmj4kq" bpmnElement="Group_Date">
+        <dc:Bounds x="160" y="450" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="675" y="457" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_100yato" bpmnElement="Group_Duration">
+        <dc:Bounds x="160" y="770" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="664" y="777" width="42" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0m8h7pu" bpmnElement="Group_CycleCron">
+        <dc:Bounds x="1230" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1721" y="137" width="71" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1_di" bpmnElement="TextAnnotation_1">
+        <dc:Bounds x="160" y="80" width="1050" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0lzenly" bpmnElement="NonInterruptingBoundaryEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1772" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1746" y="345" width="90" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0v29o08" bpmnElement="BoundaryEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1592" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1566" y="345" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0nwveo1" bpmnElement="NonInterruptingBoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="702" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="985" width="89" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1q4qstq" bpmnElement="BoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="522" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="985" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_02pg78j" bpmnElement="NonInterruptingBoundaryEvent_Date" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="702" y="622" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="681" y="665" width="83" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ktlobl" bpmnElement="BoundaryEvent_Date" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="522" y="622" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="500" y="665" width="83" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hdiole_di" bpmnElement="NonInterruptingBoundaryEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="702" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="677" y="345" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1iy8313_di" bpmnElement="BoundaryEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="522" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="345" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/camunda-cloud/integration/camunda-cloud-1-3-timer.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-1-3-timer.bpmn
@@ -1,61 +1,221 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ot6ika" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.4.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.3.0">
-  <bpmn:process id="Process_0jflbl3" isExecutable="true">
-    <bpmn:task id="Activity_0kcb5kw">
-      <bpmn:incoming>Flow_1xwctp0</bpmn:incoming>
-    </bpmn:task>
-    <bpmn:startEvent id="StartEvent_1" name="Date">
-      <bpmn:outgoing>Flow_0b6nadt</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1fxm0mf">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1w3xyk9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.3.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_Cycle" name="StartEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_1" />
+    <bpmn:task id="Task_2" />
+    <bpmn:subProcess id="SubProcess_Cycle" name="SubProcess_Cycle" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Cycle" name="EventSubProcess_NonInterruptingStartEvent_Cycle" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:startEvent id="StartEvent_Date" name="StartEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Date">
         <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
-    <bpmn:intermediateCatchEvent id="Event_0sbvzs9" name="Duration">
-      <bpmn:incoming>Flow_0b6nadt</bpmn:incoming>
-      <bpmn:outgoing>Flow_1xwctp0</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1rxh4l4">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT15S</bpmn:timeDuration>
+    <bpmn:task id="Task_5" />
+    <bpmn:task id="Task_6" />
+    <bpmn:subProcess id="SubProcess_Date" name="SubProcess_Date" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Date" name="EventSubProcess_StartEvent_Date">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Date" name="EventSubProcess_NonInterruptingStartEvent_Date" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Duration" name="IntermediateCatchEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:boundaryEvent id="Event_0hn049s" name="Duration" attachedToRef="Activity_0kcb5kw">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0bg6y33">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT15S</bpmn:timeDuration>
+    <bpmn:task id="Task_7" />
+    <bpmn:task id="Task_8" />
+    <bpmn:subProcess id="SubProcess_Duration" name="SubProcess_Duration" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Duration" name="EventSubProcess_StartEvent_Duration">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Duration" name="EventSubProcess_NonInterruptingStartEvent_Duration" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Duration" name="BoundaryEvent_Duration" attachedToRef="Task_7">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_0b6nadt" sourceRef="StartEvent_1" targetRef="Event_0sbvzs9" />
-    <bpmn:sequenceFlow id="Flow_1xwctp0" sourceRef="Event_0sbvzs9" targetRef="Activity_0kcb5kw" />
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Duration" name="NonInterruptingBoundaryEvent_Duration" cancelActivity="false" attachedToRef="Task_8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:task id="Task_3" />
+    <bpmn:task id="Task_4" />
+    <bpmn:subProcess id="SubProcess_CycleCron" name="SubProcess_CycleCron" triggeredByEvent="true" />
+    <bpmn:group id="Group_Cycle" categoryValueRef="CategoryValue_Cycle" />
+    <bpmn:group id="Group_Date" categoryValueRef="CategoryValue_Date" />
+    <bpmn:group id="Group_Duration" categoryValueRef="CategoryValue_Duration" />
+    <bpmn:group id="Group_CycleCron" categoryValueRef="CategoryValue_CycleCron" />
+    <bpmn:textAnnotation id="TextAnnotation_1">
+      <bpmn:text>Camunda 8 (Zeebe 1.3)</bpmn:text>
+    </bpmn:textAnnotation>
   </bpmn:process>
+  <bpmn:category id="Category_Cycle">
+    <bpmn:categoryValue id="CategoryValue_Cycle" value="Cycle" />
+  </bpmn:category>
+  <bpmn:category id="Category_Date">
+    <bpmn:categoryValue id="CategoryValue_Date" value="Date" />
+  </bpmn:category>
+  <bpmn:category id="Category_Duration">
+    <bpmn:categoryValue id="CategoryValue_Duration" value="Duration" />
+  </bpmn:category>
+  <bpmn:category id="Category_CycleCron">
+    <bpmn:categoryValue id="CategoryValue_CycleCron" value="Cycle (CRON)" />
+  </bpmn:category>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0jflbl3">
-      <bpmndi:BPMNShape id="Activity_0kcb5kw_di" bpmnElement="Activity_0kcb5kw">
-        <dc:Bounds x="370" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1socevm_di" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="99" width="36" height="36" />
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_1a2aqqq_di" bpmnElement="StartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="262" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="186" y="142" width="24" height="14" />
+          <dc:Bounds x="178" y="305" width="86" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0d5th2l_di" bpmnElement="Event_0sbvzs9">
-        <dc:Bounds x="272" y="99" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_158bxus_di" bpmnElement="Task_1">
+        <dc:Bounds x="440" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1c7yu62_di" bpmnElement="Task_2">
+        <dc:Bounds x="620" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0si6fbo_di" bpmnElement="SubProcess_Cycle" isExpanded="true">
+        <dc:Bounds x="810" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1hvn2kh_di" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="269" y="142" width="42" height="14" />
+          <dc:Bounds x="990" y="315" width="85" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1qiyw8j_di" bpmnElement="Event_0hn049s">
-        <dc:Bounds x="352" y="139" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_1daj4e0" bpmnElement="StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="582" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="349" y="182" width="42" height="14" />
+          <dc:Bounds x="180" y="625" width="82" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0b6nadt_di" bpmnElement="Flow_0b6nadt">
-        <di:waypoint x="215" y="117" />
-        <di:waypoint x="272" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1xwctp0_di" bpmnElement="Flow_1xwctp0">
-        <di:waypoint x="308" y="117" />
-        <di:waypoint x="370" y="117" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_1godq1i" bpmnElement="Task_5">
+        <dc:Bounds x="440" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1cqtk6t" bpmnElement="Task_6">
+        <dc:Bounds x="620" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nhun69" bpmnElement="SubProcess_Date" isExpanded="true">
+        <dc:Bounds x="810" y="510" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1679ksi" bpmnElement="EventSubProcess_StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="635" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n27xdi" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="988" y="635" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0b7rl6t" bpmnElement="IntermediateCatchEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="292" y="902" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="268" y="945" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_09h1dj0" bpmnElement="Task_7">
+        <dc:Bounds x="440" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_13qr05v" bpmnElement="Task_8">
+        <dc:Bounds x="620" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sopxbu" bpmnElement="SubProcess_Duration" isExpanded="true">
+        <dc:Bounds x="810" y="830" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n0geh0" bpmnElement="EventSubProcess_StartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="955" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_01typqg" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="987" y="955" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sp4b5v" bpmnElement="Task_3">
+        <dc:Bounds x="1510" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0j20tgx" bpmnElement="Task_4">
+        <dc:Bounds x="1690" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0gooim1" bpmnElement="SubProcess_CycleCron" isExpanded="true">
+        <dc:Bounds x="1880" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0oqi537_di" bpmnElement="Group_Cycle">
+        <dc:Bounds x="160" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="671" y="137" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1lmj4kq" bpmnElement="Group_Date">
+        <dc:Bounds x="160" y="450" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="675" y="457" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_100yato" bpmnElement="Group_Duration">
+        <dc:Bounds x="160" y="770" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="664" y="777" width="42" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0m8h7pu" bpmnElement="Group_CycleCron">
+        <dc:Bounds x="1230" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1721" y="137" width="71" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1_di" bpmnElement="TextAnnotation_1">
+        <dc:Bounds x="160" y="80" width="1050" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0nwveo1" bpmnElement="NonInterruptingBoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="702" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="985" width="89" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1q4qstq" bpmnElement="BoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="522" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="985" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/camunda-cloud/integration/camunda-cloud-8-0-timer-errors.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-8-0-timer-errors.bpmn
@@ -1,78 +1,376 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ot6ika" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.4.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
-  <bpmn:process id="Process_0jflbl3" isExecutable="true">
-    <bpmn:task id="Activity_0kcb5kw">
-      <bpmn:incoming>Flow_1xwctp0</bpmn:incoming>
-    </bpmn:task>
-    <bpmn:startEvent id="StartEvent_1" name="Date">
-      <bpmn:outgoing>Flow_0b6nadt</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1fxm0mf">
-        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDate>
-      </bpmn:timerEventDefinition>
-    </bpmn:startEvent>
-    <bpmn:intermediateCatchEvent id="Event_0sbvzs9" name="Duration">
-      <bpmn:incoming>Flow_0b6nadt</bpmn:incoming>
-      <bpmn:outgoing>Flow_1xwctp0</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1rxh4l4">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDuration>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1w3xyk9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Cycle" name="IntermediateCatchEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:boundaryEvent id="Event_0hn049s" name="Duration" attachedToRef="Activity_0kcb5kw">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0bg6y33">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDuration>
-      </bpmn:timerEventDefinition>
-    </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_0b6nadt" sourceRef="StartEvent_1" targetRef="Event_0sbvzs9" />
-    <bpmn:sequenceFlow id="Flow_1xwctp0" sourceRef="Event_0sbvzs9" targetRef="Activity_0kcb5kw" />
-    <bpmn:startEvent id="Event_1jtin5z" name="Cycle">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0sm5q3w">
-        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">@daily</bpmn:timeCycle>
+    <bpmn:startEvent id="StartEvent_Cycle" name="StartEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
-    <bpmn:boundaryEvent id="Event_1metpe7" attachedToRef="Activity_0kcb5kw">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0n56omv" />
+    <bpmn:task id="Task_1" />
+    <bpmn:boundaryEvent id="BoundaryEvent_Cycle" name="BoundaryEvent_Cycle" attachedToRef="Task_1">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
+    <bpmn:task id="Task_2" />
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Cycle" name="NonInterruptingBoundaryEvent_Cycle" cancelActivity="false" attachedToRef="Task_2">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:subProcess id="SubProcess_Cycle" name="SubProcess_Cycle" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Cycle" name="EventSubProcess_StartEvent_Cycle">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Cycle" name="EventSubProcess_NonInterruptingStartEvent_Cycle" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Date" name="IntermediateCatchEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_Date" name="StartEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_5" />
+    <bpmn:task id="Task_6" />
+    <bpmn:subProcess id="SubProcess_Date" name="SubProcess_Date" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Date" name="EventSubProcess_StartEvent_Date">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Date" name="EventSubProcess_NonInterruptingStartEvent_Date" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Date" name="BoundaryEvent_Date" attachedToRef="Task_5">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Date" name="NonInterruptingBoundaryEvent_Date" cancelActivity="false" attachedToRef="Task_6">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Duration" name="IntermediateCatchEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_Duration" name="StartEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_7" />
+    <bpmn:task id="Task_8" />
+    <bpmn:subProcess id="SubProcess_Duration" name="SubProcess_Duration" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Duration" name="EventSubProcess_StartEvent_Duration">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Duration" name="EventSubProcess_NonInterruptingStartEvent_Duration" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Duration" name="BoundaryEvent_Duration" attachedToRef="Task_7">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Duration" name="NonInterruptingBoundaryEvent_Duration" cancelActivity="false" attachedToRef="Task_8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_CycleCron" name="IntermediateCatchEvent_CycleCron">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_CycleCron" name="StartEvent_CycleCron">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_3" />
+    <bpmn:task id="Task_4" />
+    <bpmn:subProcess id="SubProcess_CycleCron" name="SubProcess_CycleCron" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_CycleCron" name="EventSubProcess_StartEvent_CycleCron">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_CycleCron">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_CycleCron" name="EventSubProcess_NonInterruptingStartEvent_CycleCron" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_CycleCron">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_CycleCron" name="BoundaryEvent_CycleCron" attachedToRef="Task_3">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_CycleCron" name="NonInterruptingBoundaryEvent_CycleCron" cancelActivity="false" attachedToRef="Task_4">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:group id="Group_Cycle" categoryValueRef="CategoryValue_Cycle" />
+    <bpmn:group id="Group_Date" categoryValueRef="CategoryValue_Date" />
+    <bpmn:group id="Group_Duration" categoryValueRef="CategoryValue_Duration" />
+    <bpmn:group id="Group_CycleCron" categoryValueRef="CategoryValue_CycleCron" />
+    <bpmn:textAnnotation id="TextAnnotation_1">
+      <bpmn:text>Camunda 8.0</bpmn:text>
+    </bpmn:textAnnotation>
   </bpmn:process>
+  <bpmn:category id="Category_Cycle">
+    <bpmn:categoryValue id="CategoryValue_Cycle" value="Cycle" />
+  </bpmn:category>
+  <bpmn:category id="Category_Date">
+    <bpmn:categoryValue id="CategoryValue_Date" value="Date" />
+  </bpmn:category>
+  <bpmn:category id="Category_Duration">
+    <bpmn:categoryValue id="CategoryValue_Duration" value="Duration" />
+  </bpmn:category>
+  <bpmn:category id="Category_CycleCron">
+    <bpmn:categoryValue id="CategoryValue_CycleCron" value="Cycle (CRON)" />
+  </bpmn:category>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0jflbl3">
-      <bpmndi:BPMNShape id="Activity_0kcb5kw_di" bpmnElement="Activity_0kcb5kw">
-        <dc:Bounds x="370" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1socevm_di" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="99" width="36" height="36" />
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_1ih3qg9_di" bpmnElement="IntermediateCatchEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="292" y="262" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="186" y="142" width="24" height="14" />
+          <dc:Bounds x="268" y="305" width="85" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0d5th2l_di" bpmnElement="Event_0sbvzs9">
-        <dc:Bounds x="272" y="99" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1a2aqqq_di" bpmnElement="StartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="262" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="269" y="142" width="42" height="14" />
+          <dc:Bounds x="178" y="305" width="86" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1r9zfi8_di" bpmnElement="Event_1jtin5z">
-        <dc:Bounds x="179" y="212" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_158bxus_di" bpmnElement="Task_1">
+        <dc:Bounds x="440" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1c7yu62_di" bpmnElement="Task_2">
+        <dc:Bounds x="620" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0si6fbo_di" bpmnElement="SubProcess_Cycle" isExpanded="true">
+        <dc:Bounds x="810" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0emjtwi_di" bpmnElement="EventSubProcess_StartEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="922" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="183" y="255" width="29" height="14" />
+          <dc:Bounds x="901" y="315" width="88" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1qiyw8j_di" bpmnElement="Event_0hn049s">
-        <dc:Bounds x="352" y="139" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1hvn2kh_di" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="349" y="182" width="42" height="14" />
+          <dc:Bounds x="990" y="315" width="85" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1jdcr1y_di" bpmnElement="Event_1metpe7">
-        <dc:Bounds x="452" y="139" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_1noobtj" bpmnElement="IntermediateCatchEvent_Date" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="292" y="582" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="272" y="625" width="80" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0b6nadt_di" bpmnElement="Flow_0b6nadt">
-        <di:waypoint x="215" y="117" />
-        <di:waypoint x="272" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1xwctp0_di" bpmnElement="Flow_1xwctp0">
-        <di:waypoint x="308" y="117" />
-        <di:waypoint x="370" y="117" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_1daj4e0" bpmnElement="StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="582" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="180" y="625" width="82" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1godq1i" bpmnElement="Task_5">
+        <dc:Bounds x="440" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1cqtk6t" bpmnElement="Task_6">
+        <dc:Bounds x="620" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nhun69" bpmnElement="SubProcess_Date" isExpanded="true">
+        <dc:Bounds x="810" y="510" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1679ksi" bpmnElement="EventSubProcess_StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="635" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n27xdi" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="988" y="635" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0b7rl6t" bpmnElement="IntermediateCatchEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="292" y="902" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="268" y="945" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nvr3f7" bpmnElement="StartEvent_Duration" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="202" y="902" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="178" y="945" width="86" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_09h1dj0" bpmnElement="Task_7">
+        <dc:Bounds x="440" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_13qr05v" bpmnElement="Task_8">
+        <dc:Bounds x="620" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sopxbu" bpmnElement="SubProcess_Duration" isExpanded="true">
+        <dc:Bounds x="810" y="830" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n0geh0" bpmnElement="EventSubProcess_StartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="955" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_01typqg" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="987" y="955" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0tc8we8" bpmnElement="IntermediateCatchEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1362" y="262" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1337" y="305" width="87" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_114olyo" bpmnElement="StartEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1272" y="262" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1249" y="305" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sp4b5v" bpmnElement="Task_3">
+        <dc:Bounds x="1510" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0j20tgx" bpmnElement="Task_4">
+        <dc:Bounds x="1690" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0gooim1" bpmnElement="SubProcess_CycleCron" isExpanded="true">
+        <dc:Bounds x="1880" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ph0d9f" bpmnElement="EventSubProcess_StartEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1992" y="272" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1971" y="315" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_11c780k" bpmnElement="EventSubProcess_NonInterruptingStartEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="2082" y="272" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2059" y="315" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0oqi537_di" bpmnElement="Group_Cycle">
+        <dc:Bounds x="160" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="671" y="137" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1lmj4kq" bpmnElement="Group_Date">
+        <dc:Bounds x="160" y="450" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="675" y="457" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_100yato" bpmnElement="Group_Duration">
+        <dc:Bounds x="160" y="770" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="664" y="777" width="42" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0m8h7pu" bpmnElement="Group_CycleCron">
+        <dc:Bounds x="1230" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1721" y="137" width="71" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1_di" bpmnElement="TextAnnotation_1">
+        <dc:Bounds x="160" y="80" width="1050" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0lzenly" bpmnElement="NonInterruptingBoundaryEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1772" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1746" y="345" width="90" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0v29o08" bpmnElement="BoundaryEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1592" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1566" y="345" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0nwveo1" bpmnElement="NonInterruptingBoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="702" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="985" width="89" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1q4qstq" bpmnElement="BoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="522" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="985" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_02pg78j" bpmnElement="NonInterruptingBoundaryEvent_Date" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="702" y="622" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="681" y="665" width="83" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ktlobl" bpmnElement="BoundaryEvent_Date" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="522" y="622" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="500" y="665" width="83" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hdiole_di" bpmnElement="NonInterruptingBoundaryEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="702" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="677" y="345" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1iy8313_di" bpmnElement="BoundaryEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="522" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="345" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/camunda-cloud/integration/camunda-cloud-8-0-timer.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-8-0-timer.bpmn
@@ -1,61 +1,221 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ot6ika" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.4.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
-  <bpmn:process id="Process_0jflbl3" isExecutable="true">
-    <bpmn:task id="Activity_0kcb5kw">
-      <bpmn:incoming>Flow_1xwctp0</bpmn:incoming>
-    </bpmn:task>
-    <bpmn:startEvent id="StartEvent_1" name="Date">
-      <bpmn:outgoing>Flow_0b6nadt</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1fxm0mf">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1w3xyk9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_Cycle" name="StartEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_1" />
+    <bpmn:task id="Task_2" />
+    <bpmn:subProcess id="SubProcess_Cycle" name="SubProcess_Cycle" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Cycle" name="EventSubProcess_NonInterruptingStartEvent_Cycle" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:startEvent id="StartEvent_Date" name="StartEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Date">
         <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
-    <bpmn:intermediateCatchEvent id="Event_0sbvzs9" name="Duration">
-      <bpmn:incoming>Flow_0b6nadt</bpmn:incoming>
-      <bpmn:outgoing>Flow_1xwctp0</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1rxh4l4">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT15S</bpmn:timeDuration>
+    <bpmn:task id="Task_5" />
+    <bpmn:task id="Task_6" />
+    <bpmn:subProcess id="SubProcess_Date" name="SubProcess_Date" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Date" name="EventSubProcess_StartEvent_Date">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Date" name="EventSubProcess_NonInterruptingStartEvent_Date" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Duration" name="IntermediateCatchEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:boundaryEvent id="Event_0hn049s" name="Duration" attachedToRef="Activity_0kcb5kw">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0bg6y33">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT15S</bpmn:timeDuration>
+    <bpmn:task id="Task_7" />
+    <bpmn:task id="Task_8" />
+    <bpmn:subProcess id="SubProcess_Duration" name="SubProcess_Duration" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Duration" name="EventSubProcess_StartEvent_Duration">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Duration" name="EventSubProcess_NonInterruptingStartEvent_Duration" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Duration" name="BoundaryEvent_Duration" attachedToRef="Task_7">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_0b6nadt" sourceRef="StartEvent_1" targetRef="Event_0sbvzs9" />
-    <bpmn:sequenceFlow id="Flow_1xwctp0" sourceRef="Event_0sbvzs9" targetRef="Activity_0kcb5kw" />
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Duration" name="NonInterruptingBoundaryEvent_Duration" cancelActivity="false" attachedToRef="Task_8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:task id="Task_3" />
+    <bpmn:task id="Task_4" />
+    <bpmn:subProcess id="SubProcess_CycleCron" name="SubProcess_CycleCron" triggeredByEvent="true" />
+    <bpmn:group id="Group_Cycle" categoryValueRef="CategoryValue_Cycle" />
+    <bpmn:group id="Group_Date" categoryValueRef="CategoryValue_Date" />
+    <bpmn:group id="Group_Duration" categoryValueRef="CategoryValue_Duration" />
+    <bpmn:group id="Group_CycleCron" categoryValueRef="CategoryValue_CycleCron" />
+    <bpmn:textAnnotation id="TextAnnotation_1">
+      <bpmn:text>Camunda 8.0</bpmn:text>
+    </bpmn:textAnnotation>
   </bpmn:process>
+  <bpmn:category id="Category_Cycle">
+    <bpmn:categoryValue id="CategoryValue_Cycle" value="Cycle" />
+  </bpmn:category>
+  <bpmn:category id="Category_Date">
+    <bpmn:categoryValue id="CategoryValue_Date" value="Date" />
+  </bpmn:category>
+  <bpmn:category id="Category_Duration">
+    <bpmn:categoryValue id="CategoryValue_Duration" value="Duration" />
+  </bpmn:category>
+  <bpmn:category id="Category_CycleCron">
+    <bpmn:categoryValue id="CategoryValue_CycleCron" value="Cycle (CRON)" />
+  </bpmn:category>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0jflbl3">
-      <bpmndi:BPMNShape id="Activity_0kcb5kw_di" bpmnElement="Activity_0kcb5kw">
-        <dc:Bounds x="370" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1socevm_di" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="99" width="36" height="36" />
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_1a2aqqq_di" bpmnElement="StartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="262" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="186" y="142" width="24" height="14" />
+          <dc:Bounds x="178" y="305" width="86" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0d5th2l_di" bpmnElement="Event_0sbvzs9">
-        <dc:Bounds x="272" y="99" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_158bxus_di" bpmnElement="Task_1">
+        <dc:Bounds x="440" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1c7yu62_di" bpmnElement="Task_2">
+        <dc:Bounds x="620" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0si6fbo_di" bpmnElement="SubProcess_Cycle" isExpanded="true">
+        <dc:Bounds x="810" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1hvn2kh_di" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="269" y="142" width="42" height="14" />
+          <dc:Bounds x="990" y="315" width="85" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1qiyw8j_di" bpmnElement="Event_0hn049s">
-        <dc:Bounds x="352" y="139" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_1daj4e0" bpmnElement="StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="582" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="349" y="182" width="42" height="14" />
+          <dc:Bounds x="180" y="625" width="82" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0b6nadt_di" bpmnElement="Flow_0b6nadt">
-        <di:waypoint x="215" y="117" />
-        <di:waypoint x="272" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1xwctp0_di" bpmnElement="Flow_1xwctp0">
-        <di:waypoint x="308" y="117" />
-        <di:waypoint x="370" y="117" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_1godq1i" bpmnElement="Task_5">
+        <dc:Bounds x="440" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1cqtk6t" bpmnElement="Task_6">
+        <dc:Bounds x="620" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nhun69" bpmnElement="SubProcess_Date" isExpanded="true">
+        <dc:Bounds x="810" y="510" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1679ksi" bpmnElement="EventSubProcess_StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="635" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n27xdi" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="988" y="635" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0b7rl6t" bpmnElement="IntermediateCatchEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="292" y="902" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="268" y="945" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_09h1dj0" bpmnElement="Task_7">
+        <dc:Bounds x="440" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_13qr05v" bpmnElement="Task_8">
+        <dc:Bounds x="620" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sopxbu" bpmnElement="SubProcess_Duration" isExpanded="true">
+        <dc:Bounds x="810" y="830" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n0geh0" bpmnElement="EventSubProcess_StartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="955" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_01typqg" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="987" y="955" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sp4b5v" bpmnElement="Task_3">
+        <dc:Bounds x="1510" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0j20tgx" bpmnElement="Task_4">
+        <dc:Bounds x="1690" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0gooim1" bpmnElement="SubProcess_CycleCron" isExpanded="true">
+        <dc:Bounds x="1880" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0oqi537_di" bpmnElement="Group_Cycle">
+        <dc:Bounds x="160" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="671" y="137" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1lmj4kq" bpmnElement="Group_Date">
+        <dc:Bounds x="160" y="450" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="675" y="457" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_100yato" bpmnElement="Group_Duration">
+        <dc:Bounds x="160" y="770" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="664" y="777" width="42" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0m8h7pu" bpmnElement="Group_CycleCron">
+        <dc:Bounds x="1230" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1721" y="137" width="71" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1_di" bpmnElement="TextAnnotation_1">
+        <dc:Bounds x="160" y="80" width="1050" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0nwveo1" bpmnElement="NonInterruptingBoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="702" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="985" width="89" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1q4qstq" bpmnElement="BoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="522" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="985" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/camunda-cloud/integration/camunda-cloud-8-1-timer-errors.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-8-1-timer-errors.bpmn
@@ -1,78 +1,376 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ot6ika" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.4.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
-  <bpmn:process id="Process_0jflbl3" isExecutable="true">
-    <bpmn:task id="Activity_0kcb5kw">
-      <bpmn:incoming>Flow_1xwctp0</bpmn:incoming>
-    </bpmn:task>
-    <bpmn:startEvent id="StartEvent_1" name="Date">
-      <bpmn:outgoing>Flow_0b6nadt</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1fxm0mf">
-        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDate>
-      </bpmn:timerEventDefinition>
-    </bpmn:startEvent>
-    <bpmn:intermediateCatchEvent id="Event_0sbvzs9" name="Duration">
-      <bpmn:incoming>Flow_0b6nadt</bpmn:incoming>
-      <bpmn:outgoing>Flow_1xwctp0</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1rxh4l4">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDuration>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1w3xyk9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Cycle" name="IntermediateCatchEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:boundaryEvent id="Event_0hn049s" name="Duration" attachedToRef="Activity_0kcb5kw">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0bg6y33">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDuration>
-      </bpmn:timerEventDefinition>
-    </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_0b6nadt" sourceRef="StartEvent_1" targetRef="Event_0sbvzs9" />
-    <bpmn:sequenceFlow id="Flow_1xwctp0" sourceRef="Event_0sbvzs9" targetRef="Activity_0kcb5kw" />
-    <bpmn:startEvent id="Event_1jtin5z" name="Cycle">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0sm5q3w">
-        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">@daily</bpmn:timeCycle>
+    <bpmn:startEvent id="StartEvent_Cycle" name="StartEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
-    <bpmn:boundaryEvent id="Event_1metpe7" attachedToRef="Activity_0kcb5kw">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0n56omv" />
+    <bpmn:task id="Task_1" />
+    <bpmn:boundaryEvent id="BoundaryEvent_Cycle" name="BoundaryEvent_Cycle" attachedToRef="Task_1">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
+    <bpmn:task id="Task_2" />
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Cycle" name="NonInterruptingBoundaryEvent_Cycle" cancelActivity="false" attachedToRef="Task_2">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:subProcess id="SubProcess_Cycle" name="SubProcess_Cycle" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Cycle" name="EventSubProcess_StartEvent_Cycle">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Cycle" name="EventSubProcess_NonInterruptingStartEvent_Cycle" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Date" name="IntermediateCatchEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_Date" name="StartEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_5" />
+    <bpmn:task id="Task_6" />
+    <bpmn:subProcess id="SubProcess_Date" name="SubProcess_Date" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Date" name="EventSubProcess_StartEvent_Date">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Date" name="EventSubProcess_NonInterruptingStartEvent_Date" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Date" name="BoundaryEvent_Date" attachedToRef="Task_5">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Date" name="NonInterruptingBoundaryEvent_Date" cancelActivity="false" attachedToRef="Task_6">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Duration" name="IntermediateCatchEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_Duration" name="StartEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_7" />
+    <bpmn:task id="Task_8" />
+    <bpmn:subProcess id="SubProcess_Duration" name="SubProcess_Duration" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Duration" name="EventSubProcess_StartEvent_Duration">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Duration" name="EventSubProcess_NonInterruptingStartEvent_Duration" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Duration" name="BoundaryEvent_Duration" attachedToRef="Task_7">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Duration" name="NonInterruptingBoundaryEvent_Duration" cancelActivity="false" attachedToRef="Task_8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_CycleCron" name="IntermediateCatchEvent_CycleCron">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_CycleCron" name="StartEvent_CycleCron">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_3" />
+    <bpmn:task id="Task_4" />
+    <bpmn:subProcess id="SubProcess_CycleCron" name="SubProcess_CycleCron" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_CycleCron" name="EventSubProcess_StartEvent_CycleCron">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_CycleCron">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_CycleCron" name="EventSubProcess_NonInterruptingStartEvent_CycleCron" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_CycleCron">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_CycleCron" name="BoundaryEvent_CycleCron" attachedToRef="Task_3">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_CycleCron" name="NonInterruptingBoundaryEvent_CycleCron" cancelActivity="false" attachedToRef="Task_4">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:group id="Group_Cycle" categoryValueRef="CategoryValue_Cycle" />
+    <bpmn:group id="Group_Date" categoryValueRef="CategoryValue_Date" />
+    <bpmn:group id="Group_Duration" categoryValueRef="CategoryValue_Duration" />
+    <bpmn:group id="Group_CycleCron" categoryValueRef="CategoryValue_CycleCron" />
+    <bpmn:textAnnotation id="TextAnnotation_1">
+      <bpmn:text>Camunda 8.1</bpmn:text>
+    </bpmn:textAnnotation>
   </bpmn:process>
+  <bpmn:category id="Category_Cycle">
+    <bpmn:categoryValue id="CategoryValue_Cycle" value="Cycle" />
+  </bpmn:category>
+  <bpmn:category id="Category_Date">
+    <bpmn:categoryValue id="CategoryValue_Date" value="Date" />
+  </bpmn:category>
+  <bpmn:category id="Category_Duration">
+    <bpmn:categoryValue id="CategoryValue_Duration" value="Duration" />
+  </bpmn:category>
+  <bpmn:category id="Category_CycleCron">
+    <bpmn:categoryValue id="CategoryValue_CycleCron" value="Cycle (CRON)" />
+  </bpmn:category>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0jflbl3">
-      <bpmndi:BPMNShape id="Activity_0kcb5kw_di" bpmnElement="Activity_0kcb5kw">
-        <dc:Bounds x="370" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1socevm_di" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="99" width="36" height="36" />
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_1ih3qg9_di" bpmnElement="IntermediateCatchEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="292" y="262" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="186" y="142" width="24" height="14" />
+          <dc:Bounds x="268" y="305" width="85" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0d5th2l_di" bpmnElement="Event_0sbvzs9">
-        <dc:Bounds x="272" y="99" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1a2aqqq_di" bpmnElement="StartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="262" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="269" y="142" width="42" height="14" />
+          <dc:Bounds x="178" y="305" width="86" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1r9zfi8_di" bpmnElement="Event_1jtin5z">
-        <dc:Bounds x="179" y="212" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_158bxus_di" bpmnElement="Task_1">
+        <dc:Bounds x="440" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1c7yu62_di" bpmnElement="Task_2">
+        <dc:Bounds x="620" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0si6fbo_di" bpmnElement="SubProcess_Cycle" isExpanded="true">
+        <dc:Bounds x="810" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0emjtwi_di" bpmnElement="EventSubProcess_StartEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="922" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="183" y="255" width="29" height="14" />
+          <dc:Bounds x="901" y="315" width="88" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1qiyw8j_di" bpmnElement="Event_0hn049s">
-        <dc:Bounds x="352" y="139" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1hvn2kh_di" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="349" y="182" width="42" height="14" />
+          <dc:Bounds x="990" y="315" width="85" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1jdcr1y_di" bpmnElement="Event_1metpe7">
-        <dc:Bounds x="452" y="139" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_1noobtj" bpmnElement="IntermediateCatchEvent_Date" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="292" y="582" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="272" y="625" width="80" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0b6nadt_di" bpmnElement="Flow_0b6nadt">
-        <di:waypoint x="215" y="117" />
-        <di:waypoint x="272" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1xwctp0_di" bpmnElement="Flow_1xwctp0">
-        <di:waypoint x="308" y="117" />
-        <di:waypoint x="370" y="117" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_1daj4e0" bpmnElement="StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="582" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="180" y="625" width="82" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1godq1i" bpmnElement="Task_5">
+        <dc:Bounds x="440" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1cqtk6t" bpmnElement="Task_6">
+        <dc:Bounds x="620" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nhun69" bpmnElement="SubProcess_Date" isExpanded="true">
+        <dc:Bounds x="810" y="510" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1679ksi" bpmnElement="EventSubProcess_StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="635" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n27xdi" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="988" y="635" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0b7rl6t" bpmnElement="IntermediateCatchEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="292" y="902" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="268" y="945" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nvr3f7" bpmnElement="StartEvent_Duration" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="202" y="902" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="178" y="945" width="86" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_09h1dj0" bpmnElement="Task_7">
+        <dc:Bounds x="440" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_13qr05v" bpmnElement="Task_8">
+        <dc:Bounds x="620" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sopxbu" bpmnElement="SubProcess_Duration" isExpanded="true">
+        <dc:Bounds x="810" y="830" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n0geh0" bpmnElement="EventSubProcess_StartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="955" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_01typqg" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="987" y="955" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0tc8we8" bpmnElement="IntermediateCatchEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1362" y="262" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1337" y="305" width="87" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_114olyo" bpmnElement="StartEvent_CycleCron" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1272" y="262" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1249" y="305" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sp4b5v" bpmnElement="Task_3">
+        <dc:Bounds x="1510" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0j20tgx" bpmnElement="Task_4">
+        <dc:Bounds x="1690" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0gooim1" bpmnElement="SubProcess_CycleCron" isExpanded="true">
+        <dc:Bounds x="1880" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ph0d9f" bpmnElement="EventSubProcess_StartEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1992" y="272" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1971" y="315" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_11c780k" bpmnElement="EventSubProcess_NonInterruptingStartEvent_CycleCron" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="2082" y="272" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2059" y="315" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0oqi537_di" bpmnElement="Group_Cycle">
+        <dc:Bounds x="160" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="671" y="137" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1lmj4kq" bpmnElement="Group_Date">
+        <dc:Bounds x="160" y="450" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="675" y="457" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_100yato" bpmnElement="Group_Duration">
+        <dc:Bounds x="160" y="770" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="664" y="777" width="42" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0m8h7pu" bpmnElement="Group_CycleCron">
+        <dc:Bounds x="1230" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1721" y="137" width="71" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1_di" bpmnElement="TextAnnotation_1">
+        <dc:Bounds x="160" y="80" width="1050" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0lzenly" bpmnElement="NonInterruptingBoundaryEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1772" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1746" y="345" width="90" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0v29o08" bpmnElement="BoundaryEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1592" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1566" y="345" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0nwveo1" bpmnElement="NonInterruptingBoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="702" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="985" width="89" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1q4qstq" bpmnElement="BoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="522" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="985" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_02pg78j" bpmnElement="NonInterruptingBoundaryEvent_Date" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="702" y="622" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="681" y="665" width="83" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ktlobl" bpmnElement="BoundaryEvent_Date" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="522" y="622" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="500" y="665" width="83" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hdiole_di" bpmnElement="NonInterruptingBoundaryEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="702" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="677" y="345" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1iy8313_di" bpmnElement="BoundaryEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="522" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="345" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/camunda-cloud/integration/camunda-cloud-8-1-timer.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-8-1-timer.bpmn
@@ -1,72 +1,244 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ot6ika" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.4.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
-  <bpmn:process id="Process_0jflbl3" isExecutable="true">
-    <bpmn:task id="Activity_0kcb5kw">
-      <bpmn:incoming>Flow_1xwctp0</bpmn:incoming>
-    </bpmn:task>
-    <bpmn:startEvent id="StartEvent_1" name="Date">
-      <bpmn:outgoing>Flow_0b6nadt</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1fxm0mf">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1w3xyk9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_Cycle" name="StartEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_1" />
+    <bpmn:task id="Task_2" />
+    <bpmn:subProcess id="SubProcess_Cycle" name="SubProcess_Cycle" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Cycle" name="EventSubProcess_NonInterruptingStartEvent_Cycle" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:startEvent id="StartEvent_Date" name="StartEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Date">
         <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
-    <bpmn:intermediateCatchEvent id="Event_0sbvzs9" name="Duration">
-      <bpmn:incoming>Flow_0b6nadt</bpmn:incoming>
-      <bpmn:outgoing>Flow_1xwctp0</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1rxh4l4">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT15S</bpmn:timeDuration>
+    <bpmn:task id="Task_5" />
+    <bpmn:task id="Task_6" />
+    <bpmn:subProcess id="SubProcess_Date" name="SubProcess_Date" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Date" name="EventSubProcess_StartEvent_Date">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Date" name="EventSubProcess_NonInterruptingStartEvent_Date" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Duration" name="IntermediateCatchEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:boundaryEvent id="Event_0hn049s" name="Duration" attachedToRef="Activity_0kcb5kw">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0bg6y33">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT15S</bpmn:timeDuration>
+    <bpmn:task id="Task_7" />
+    <bpmn:task id="Task_8" />
+    <bpmn:subProcess id="SubProcess_Duration" name="SubProcess_Duration" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Duration" name="EventSubProcess_StartEvent_Duration">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Duration" name="EventSubProcess_NonInterruptingStartEvent_Duration" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Duration" name="BoundaryEvent_Duration" attachedToRef="Task_7">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_0b6nadt" sourceRef="StartEvent_1" targetRef="Event_0sbvzs9" />
-    <bpmn:sequenceFlow id="Flow_1xwctp0" sourceRef="Event_0sbvzs9" targetRef="Activity_0kcb5kw" />
-    <bpmn:startEvent id="Event_1jtin5z" name="Cycle">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0sm5q3w">
-        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">@daily</bpmn:timeCycle>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Duration" name="NonInterruptingBoundaryEvent_Duration" cancelActivity="false" attachedToRef="Task_8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:startEvent id="StartEvent_CycleCron" name="StartEvent_CycleCron">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
+    <bpmn:task id="Task_3" />
+    <bpmn:task id="Task_4" />
+    <bpmn:subProcess id="SubProcess_CycleCron" name="SubProcess_CycleCron" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_CycleCron" name="EventSubProcess_NonInterruptingStartEvent_CycleCron" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_CycleCron">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:group id="Group_Cycle" categoryValueRef="CategoryValue_Cycle" />
+    <bpmn:group id="Group_Date" categoryValueRef="CategoryValue_Date" />
+    <bpmn:group id="Group_Duration" categoryValueRef="CategoryValue_Duration" />
+    <bpmn:group id="Group_CycleCron" categoryValueRef="CategoryValue_CycleCron" />
+    <bpmn:textAnnotation id="TextAnnotation_1">
+      <bpmn:text>Camunda 8.1</bpmn:text>
+    </bpmn:textAnnotation>
   </bpmn:process>
+  <bpmn:category id="Category_Cycle">
+    <bpmn:categoryValue id="CategoryValue_Cycle" value="Cycle" />
+  </bpmn:category>
+  <bpmn:category id="Category_Date">
+    <bpmn:categoryValue id="CategoryValue_Date" value="Date" />
+  </bpmn:category>
+  <bpmn:category id="Category_Duration">
+    <bpmn:categoryValue id="CategoryValue_Duration" value="Duration" />
+  </bpmn:category>
+  <bpmn:category id="Category_CycleCron">
+    <bpmn:categoryValue id="CategoryValue_CycleCron" value="Cycle (CRON)" />
+  </bpmn:category>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0jflbl3">
-      <bpmndi:BPMNShape id="Activity_0kcb5kw_di" bpmnElement="Activity_0kcb5kw">
-        <dc:Bounds x="370" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1socevm_di" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="99" width="36" height="36" />
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_1a2aqqq_di" bpmnElement="StartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="262" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="186" y="142" width="24" height="14" />
+          <dc:Bounds x="178" y="305" width="86" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0d5th2l_di" bpmnElement="Event_0sbvzs9">
-        <dc:Bounds x="272" y="99" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_158bxus_di" bpmnElement="Task_1">
+        <dc:Bounds x="440" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1c7yu62_di" bpmnElement="Task_2">
+        <dc:Bounds x="620" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0si6fbo_di" bpmnElement="SubProcess_Cycle" isExpanded="true">
+        <dc:Bounds x="810" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1hvn2kh_di" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="269" y="142" width="42" height="14" />
+          <dc:Bounds x="990" y="315" width="85" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1r9zfi8_di" bpmnElement="Event_1jtin5z">
-        <dc:Bounds x="179" y="212" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_1daj4e0" bpmnElement="StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="582" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="183" y="255" width="29" height="14" />
+          <dc:Bounds x="180" y="625" width="82" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1qiyw8j_di" bpmnElement="Event_0hn049s">
-        <dc:Bounds x="352" y="139" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_1godq1i" bpmnElement="Task_5">
+        <dc:Bounds x="440" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1cqtk6t" bpmnElement="Task_6">
+        <dc:Bounds x="620" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nhun69" bpmnElement="SubProcess_Date" isExpanded="true">
+        <dc:Bounds x="810" y="510" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1679ksi" bpmnElement="EventSubProcess_StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="592" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="349" y="182" width="42" height="14" />
+          <dc:Bounds x="896" y="635" width="88" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1xwctp0_di" bpmnElement="Flow_1xwctp0">
-        <di:waypoint x="308" y="117" />
-        <di:waypoint x="370" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0b6nadt_di" bpmnElement="Flow_0b6nadt">
-        <di:waypoint x="215" y="117" />
-        <di:waypoint x="272" y="117" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_0n27xdi" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="988" y="635" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0b7rl6t" bpmnElement="IntermediateCatchEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="292" y="902" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="268" y="945" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_09h1dj0" bpmnElement="Task_7">
+        <dc:Bounds x="440" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_13qr05v" bpmnElement="Task_8">
+        <dc:Bounds x="620" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sopxbu" bpmnElement="SubProcess_Duration" isExpanded="true">
+        <dc:Bounds x="810" y="830" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n0geh0" bpmnElement="EventSubProcess_StartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="955" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_01typqg" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="987" y="955" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_114olyo" bpmnElement="StartEvent_CycleCron" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1272" y="262" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1249" y="305" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sp4b5v" bpmnElement="Task_3">
+        <dc:Bounds x="1510" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0j20tgx" bpmnElement="Task_4">
+        <dc:Bounds x="1690" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0gooim1" bpmnElement="SubProcess_CycleCron" isExpanded="true">
+        <dc:Bounds x="1880" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_11c780k" bpmnElement="EventSubProcess_NonInterruptingStartEvent_CycleCron" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="2082" y="272" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2059" y="315" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0oqi537_di" bpmnElement="Group_Cycle">
+        <dc:Bounds x="160" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="671" y="137" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1lmj4kq" bpmnElement="Group_Date">
+        <dc:Bounds x="160" y="450" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="675" y="457" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_100yato" bpmnElement="Group_Duration">
+        <dc:Bounds x="160" y="770" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="664" y="777" width="42" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0m8h7pu" bpmnElement="Group_CycleCron">
+        <dc:Bounds x="1230" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1721" y="137" width="71" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1_di" bpmnElement="TextAnnotation_1">
+        <dc:Bounds x="160" y="80" width="1050" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0nwveo1" bpmnElement="NonInterruptingBoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="702" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="985" width="89" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1q4qstq" bpmnElement="BoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="522" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="985" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/camunda-cloud/integration/camunda-cloud-8-2-timer-errors.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-8-2-timer-errors.bpmn
@@ -1,78 +1,376 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ot6ika" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.4.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
-  <bpmn:process id="Process_0jflbl3" isExecutable="true">
-    <bpmn:task id="Activity_0kcb5kw">
-      <bpmn:incoming>Flow_1xwctp0</bpmn:incoming>
-    </bpmn:task>
-    <bpmn:startEvent id="StartEvent_1" name="Date">
-      <bpmn:outgoing>Flow_0b6nadt</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1fxm0mf">
-        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDate>
-      </bpmn:timerEventDefinition>
-    </bpmn:startEvent>
-    <bpmn:intermediateCatchEvent id="Event_0sbvzs9" name="Duration">
-      <bpmn:incoming>Flow_0b6nadt</bpmn:incoming>
-      <bpmn:outgoing>Flow_1xwctp0</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1rxh4l4">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDuration>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1w3xyk9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Cycle" name="IntermediateCatchEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:boundaryEvent id="Event_0hn049s" name="Duration" attachedToRef="Activity_0kcb5kw">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0bg6y33">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDuration>
-      </bpmn:timerEventDefinition>
-    </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_0b6nadt" sourceRef="StartEvent_1" targetRef="Event_0sbvzs9" />
-    <bpmn:sequenceFlow id="Flow_1xwctp0" sourceRef="Event_0sbvzs9" targetRef="Activity_0kcb5kw" />
-    <bpmn:startEvent id="Event_1jtin5z" name="Cycle">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0sm5q3w">
-        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">@daily</bpmn:timeCycle>
+    <bpmn:startEvent id="StartEvent_Cycle" name="StartEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
-    <bpmn:boundaryEvent id="Event_1metpe7" attachedToRef="Activity_0kcb5kw">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0n56omv" />
+    <bpmn:task id="Task_1" />
+    <bpmn:boundaryEvent id="BoundaryEvent_Cycle" name="BoundaryEvent_Cycle" attachedToRef="Task_1">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
+    <bpmn:task id="Task_2" />
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Cycle" name="NonInterruptingBoundaryEvent_Cycle" cancelActivity="false" attachedToRef="Task_2">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:subProcess id="SubProcess_Cycle" name="SubProcess_Cycle" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Cycle" name="EventSubProcess_StartEvent_Cycle">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Cycle" name="EventSubProcess_NonInterruptingStartEvent_Cycle" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Date" name="IntermediateCatchEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_Date" name="StartEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_5" />
+    <bpmn:task id="Task_6" />
+    <bpmn:subProcess id="SubProcess_Date" name="SubProcess_Date" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Date" name="EventSubProcess_StartEvent_Date">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Date" name="EventSubProcess_NonInterruptingStartEvent_Date" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Date" name="BoundaryEvent_Date" attachedToRef="Task_5">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Date" name="NonInterruptingBoundaryEvent_Date" cancelActivity="false" attachedToRef="Task_6">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Duration" name="IntermediateCatchEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_Duration" name="StartEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_7" />
+    <bpmn:task id="Task_8" />
+    <bpmn:subProcess id="SubProcess_Duration" name="SubProcess_Duration" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Duration" name="EventSubProcess_StartEvent_Duration">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Duration" name="EventSubProcess_NonInterruptingStartEvent_Duration" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Duration" name="BoundaryEvent_Duration" attachedToRef="Task_7">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Duration" name="NonInterruptingBoundaryEvent_Duration" cancelActivity="false" attachedToRef="Task_8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_CycleCron" name="IntermediateCatchEvent_CycleCron">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_CycleCron" name="StartEvent_CycleCron">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_3" />
+    <bpmn:task id="Task_4" />
+    <bpmn:subProcess id="SubProcess_CycleCron" name="SubProcess_CycleCron" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_CycleCron" name="EventSubProcess_StartEvent_CycleCron">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_CycleCron">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_CycleCron" name="EventSubProcess_NonInterruptingStartEvent_CycleCron" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_CycleCron">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_CycleCron" name="BoundaryEvent_CycleCron" attachedToRef="Task_3">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_CycleCron" name="NonInterruptingBoundaryEvent_CycleCron" cancelActivity="false" attachedToRef="Task_4">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:group id="Group_Cycle" categoryValueRef="CategoryValue_Cycle" />
+    <bpmn:group id="Group_Date" categoryValueRef="CategoryValue_Date" />
+    <bpmn:group id="Group_Duration" categoryValueRef="CategoryValue_Duration" />
+    <bpmn:group id="Group_CycleCron" categoryValueRef="CategoryValue_CycleCron" />
+    <bpmn:textAnnotation id="TextAnnotation_1">
+      <bpmn:text>Camunda 8.2</bpmn:text>
+    </bpmn:textAnnotation>
   </bpmn:process>
+  <bpmn:category id="Category_Cycle">
+    <bpmn:categoryValue id="CategoryValue_Cycle" value="Cycle" />
+  </bpmn:category>
+  <bpmn:category id="Category_Date">
+    <bpmn:categoryValue id="CategoryValue_Date" value="Date" />
+  </bpmn:category>
+  <bpmn:category id="Category_Duration">
+    <bpmn:categoryValue id="CategoryValue_Duration" value="Duration" />
+  </bpmn:category>
+  <bpmn:category id="Category_CycleCron">
+    <bpmn:categoryValue id="CategoryValue_CycleCron" value="Cycle (CRON)" />
+  </bpmn:category>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0jflbl3">
-      <bpmndi:BPMNShape id="Activity_0kcb5kw_di" bpmnElement="Activity_0kcb5kw">
-        <dc:Bounds x="370" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1socevm_di" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="99" width="36" height="36" />
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_1ih3qg9_di" bpmnElement="IntermediateCatchEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="292" y="262" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="186" y="142" width="24" height="14" />
+          <dc:Bounds x="268" y="305" width="85" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0d5th2l_di" bpmnElement="Event_0sbvzs9">
-        <dc:Bounds x="272" y="99" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1a2aqqq_di" bpmnElement="StartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="262" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="269" y="142" width="42" height="14" />
+          <dc:Bounds x="178" y="305" width="86" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1r9zfi8_di" bpmnElement="Event_1jtin5z">
-        <dc:Bounds x="179" y="212" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_158bxus_di" bpmnElement="Task_1">
+        <dc:Bounds x="440" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1c7yu62_di" bpmnElement="Task_2">
+        <dc:Bounds x="620" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0si6fbo_di" bpmnElement="SubProcess_Cycle" isExpanded="true">
+        <dc:Bounds x="810" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0emjtwi_di" bpmnElement="EventSubProcess_StartEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="922" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="183" y="255" width="29" height="14" />
+          <dc:Bounds x="901" y="315" width="88" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1qiyw8j_di" bpmnElement="Event_0hn049s">
-        <dc:Bounds x="352" y="139" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1hvn2kh_di" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="349" y="182" width="42" height="14" />
+          <dc:Bounds x="990" y="315" width="85" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1jdcr1y_di" bpmnElement="Event_1metpe7">
-        <dc:Bounds x="452" y="139" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_1noobtj" bpmnElement="IntermediateCatchEvent_Date" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="292" y="582" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="272" y="625" width="80" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0b6nadt_di" bpmnElement="Flow_0b6nadt">
-        <di:waypoint x="215" y="117" />
-        <di:waypoint x="272" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1xwctp0_di" bpmnElement="Flow_1xwctp0">
-        <di:waypoint x="308" y="117" />
-        <di:waypoint x="370" y="117" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_1daj4e0" bpmnElement="StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="582" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="180" y="625" width="82" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1godq1i" bpmnElement="Task_5">
+        <dc:Bounds x="440" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1cqtk6t" bpmnElement="Task_6">
+        <dc:Bounds x="620" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nhun69" bpmnElement="SubProcess_Date" isExpanded="true">
+        <dc:Bounds x="810" y="510" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1679ksi" bpmnElement="EventSubProcess_StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="635" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n27xdi" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="988" y="635" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0b7rl6t" bpmnElement="IntermediateCatchEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="292" y="902" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="268" y="945" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nvr3f7" bpmnElement="StartEvent_Duration" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="202" y="902" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="178" y="945" width="86" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_09h1dj0" bpmnElement="Task_7">
+        <dc:Bounds x="440" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_13qr05v" bpmnElement="Task_8">
+        <dc:Bounds x="620" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sopxbu" bpmnElement="SubProcess_Duration" isExpanded="true">
+        <dc:Bounds x="810" y="830" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n0geh0" bpmnElement="EventSubProcess_StartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="955" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_01typqg" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="987" y="955" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0tc8we8" bpmnElement="IntermediateCatchEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1362" y="262" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1337" y="305" width="87" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_114olyo" bpmnElement="StartEvent_CycleCron" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1272" y="262" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1249" y="305" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sp4b5v" bpmnElement="Task_3">
+        <dc:Bounds x="1510" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0j20tgx" bpmnElement="Task_4">
+        <dc:Bounds x="1690" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0gooim1" bpmnElement="SubProcess_CycleCron" isExpanded="true">
+        <dc:Bounds x="1880" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ph0d9f" bpmnElement="EventSubProcess_StartEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1992" y="272" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1971" y="315" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_11c780k" bpmnElement="EventSubProcess_NonInterruptingStartEvent_CycleCron" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="2082" y="272" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2059" y="315" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0oqi537_di" bpmnElement="Group_Cycle">
+        <dc:Bounds x="160" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="671" y="137" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1lmj4kq" bpmnElement="Group_Date">
+        <dc:Bounds x="160" y="450" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="675" y="457" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_100yato" bpmnElement="Group_Duration">
+        <dc:Bounds x="160" y="770" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="664" y="777" width="42" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0m8h7pu" bpmnElement="Group_CycleCron">
+        <dc:Bounds x="1230" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1721" y="137" width="71" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1_di" bpmnElement="TextAnnotation_1">
+        <dc:Bounds x="160" y="80" width="1050" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0lzenly" bpmnElement="NonInterruptingBoundaryEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1772" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1746" y="345" width="90" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0v29o08" bpmnElement="BoundaryEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1592" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1566" y="345" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0nwveo1" bpmnElement="NonInterruptingBoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="702" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="985" width="89" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1q4qstq" bpmnElement="BoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="522" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="985" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_02pg78j" bpmnElement="NonInterruptingBoundaryEvent_Date" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="702" y="622" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="681" y="665" width="83" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ktlobl" bpmnElement="BoundaryEvent_Date" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="522" y="622" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="500" y="665" width="83" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hdiole_di" bpmnElement="NonInterruptingBoundaryEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="702" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="677" y="345" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1iy8313_di" bpmnElement="BoundaryEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="522" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="345" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/camunda-cloud/integration/camunda-cloud-8-2-timer.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-8-2-timer.bpmn
@@ -1,72 +1,244 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ot6ika" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.4.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
-  <bpmn:process id="Process_0jflbl3" isExecutable="true">
-    <bpmn:task id="Activity_0kcb5kw">
-      <bpmn:incoming>Flow_1xwctp0</bpmn:incoming>
-    </bpmn:task>
-    <bpmn:startEvent id="StartEvent_1" name="Date">
-      <bpmn:outgoing>Flow_0b6nadt</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1fxm0mf">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1w3xyk9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_Cycle" name="StartEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_1" />
+    <bpmn:task id="Task_2" />
+    <bpmn:subProcess id="SubProcess_Cycle" name="SubProcess_Cycle" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Cycle" name="EventSubProcess_NonInterruptingStartEvent_Cycle" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:startEvent id="StartEvent_Date" name="StartEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Date">
         <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
-    <bpmn:intermediateCatchEvent id="Event_0sbvzs9" name="Duration">
-      <bpmn:incoming>Flow_0b6nadt</bpmn:incoming>
-      <bpmn:outgoing>Flow_1xwctp0</bpmn:outgoing>
-      <bpmn:timerEventDefinition id="TimerEventDefinition_1rxh4l4">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT15S</bpmn:timeDuration>
+    <bpmn:task id="Task_5" />
+    <bpmn:task id="Task_6" />
+    <bpmn:subProcess id="SubProcess_Date" name="SubProcess_Date" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Date" name="EventSubProcess_StartEvent_Date">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Date" name="EventSubProcess_NonInterruptingStartEvent_Date" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Duration" name="IntermediateCatchEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:boundaryEvent id="Event_0hn049s" name="Duration" attachedToRef="Activity_0kcb5kw">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0bg6y33">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT15S</bpmn:timeDuration>
+    <bpmn:task id="Task_7" />
+    <bpmn:task id="Task_8" />
+    <bpmn:subProcess id="SubProcess_Duration" name="SubProcess_Duration" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Duration" name="EventSubProcess_StartEvent_Duration">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Duration" name="EventSubProcess_NonInterruptingStartEvent_Duration" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Duration" name="BoundaryEvent_Duration" attachedToRef="Task_7">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_0b6nadt" sourceRef="StartEvent_1" targetRef="Event_0sbvzs9" />
-    <bpmn:sequenceFlow id="Flow_1xwctp0" sourceRef="Event_0sbvzs9" targetRef="Activity_0kcb5kw" />
-    <bpmn:startEvent id="Event_1jtin5z" name="Cycle">
-      <bpmn:timerEventDefinition id="TimerEventDefinition_0sm5q3w">
-        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">@daily</bpmn:timeCycle>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Duration" name="NonInterruptingBoundaryEvent_Duration" cancelActivity="false" attachedToRef="Task_8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:startEvent id="StartEvent_CycleCron" name="StartEvent_CycleCron">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
+    <bpmn:task id="Task_3" />
+    <bpmn:task id="Task_4" />
+    <bpmn:subProcess id="SubProcess_CycleCron" name="SubProcess_CycleCron" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_CycleCron" name="EventSubProcess_NonInterruptingStartEvent_CycleCron" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_CycleCron">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:group id="Group_Cycle" categoryValueRef="CategoryValue_Cycle" />
+    <bpmn:group id="Group_Date" categoryValueRef="CategoryValue_Date" />
+    <bpmn:group id="Group_Duration" categoryValueRef="CategoryValue_Duration" />
+    <bpmn:group id="Group_CycleCron" categoryValueRef="CategoryValue_CycleCron" />
+    <bpmn:textAnnotation id="TextAnnotation_1">
+      <bpmn:text>Camunda 8.2</bpmn:text>
+    </bpmn:textAnnotation>
   </bpmn:process>
+  <bpmn:category id="Category_Cycle">
+    <bpmn:categoryValue id="CategoryValue_Cycle" value="Cycle" />
+  </bpmn:category>
+  <bpmn:category id="Category_Date">
+    <bpmn:categoryValue id="CategoryValue_Date" value="Date" />
+  </bpmn:category>
+  <bpmn:category id="Category_Duration">
+    <bpmn:categoryValue id="CategoryValue_Duration" value="Duration" />
+  </bpmn:category>
+  <bpmn:category id="Category_CycleCron">
+    <bpmn:categoryValue id="CategoryValue_CycleCron" value="Cycle (CRON)" />
+  </bpmn:category>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0jflbl3">
-      <bpmndi:BPMNShape id="Activity_0kcb5kw_di" bpmnElement="Activity_0kcb5kw">
-        <dc:Bounds x="370" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1socevm_di" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="99" width="36" height="36" />
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_1a2aqqq_di" bpmnElement="StartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="262" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="186" y="142" width="24" height="14" />
+          <dc:Bounds x="178" y="305" width="86" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0d5th2l_di" bpmnElement="Event_0sbvzs9">
-        <dc:Bounds x="272" y="99" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_158bxus_di" bpmnElement="Task_1">
+        <dc:Bounds x="440" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1c7yu62_di" bpmnElement="Task_2">
+        <dc:Bounds x="620" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0si6fbo_di" bpmnElement="SubProcess_Cycle" isExpanded="true">
+        <dc:Bounds x="810" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1hvn2kh_di" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="272" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="269" y="142" width="42" height="14" />
+          <dc:Bounds x="990" y="315" width="85" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1r9zfi8_di" bpmnElement="Event_1jtin5z">
-        <dc:Bounds x="179" y="212" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_1daj4e0" bpmnElement="StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="582" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="183" y="255" width="29" height="14" />
+          <dc:Bounds x="180" y="625" width="82" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1qiyw8j_di" bpmnElement="Event_0hn049s">
-        <dc:Bounds x="352" y="139" width="36" height="36" />
+      <bpmndi:BPMNShape id="BPMNShape_1godq1i" bpmnElement="Task_5">
+        <dc:Bounds x="440" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1cqtk6t" bpmnElement="Task_6">
+        <dc:Bounds x="620" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nhun69" bpmnElement="SubProcess_Date" isExpanded="true">
+        <dc:Bounds x="810" y="510" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1679ksi" bpmnElement="EventSubProcess_StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="592" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="349" y="182" width="42" height="14" />
+          <dc:Bounds x="896" y="635" width="88" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1xwctp0_di" bpmnElement="Flow_1xwctp0">
-        <di:waypoint x="308" y="117" />
-        <di:waypoint x="370" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0b6nadt_di" bpmnElement="Flow_0b6nadt">
-        <di:waypoint x="215" y="117" />
-        <di:waypoint x="272" y="117" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_0n27xdi" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="988" y="635" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0b7rl6t" bpmnElement="IntermediateCatchEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="292" y="902" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="268" y="945" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_09h1dj0" bpmnElement="Task_7">
+        <dc:Bounds x="440" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_13qr05v" bpmnElement="Task_8">
+        <dc:Bounds x="620" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sopxbu" bpmnElement="SubProcess_Duration" isExpanded="true">
+        <dc:Bounds x="810" y="830" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n0geh0" bpmnElement="EventSubProcess_StartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="955" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_01typqg" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="987" y="955" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_114olyo" bpmnElement="StartEvent_CycleCron" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1272" y="262" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1249" y="305" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sp4b5v" bpmnElement="Task_3">
+        <dc:Bounds x="1510" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0j20tgx" bpmnElement="Task_4">
+        <dc:Bounds x="1690" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0gooim1" bpmnElement="SubProcess_CycleCron" isExpanded="true">
+        <dc:Bounds x="1880" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_11c780k" bpmnElement="EventSubProcess_NonInterruptingStartEvent_CycleCron" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="2082" y="272" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2059" y="315" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0oqi537_di" bpmnElement="Group_Cycle">
+        <dc:Bounds x="160" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="671" y="137" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1lmj4kq" bpmnElement="Group_Date">
+        <dc:Bounds x="160" y="450" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="675" y="457" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_100yato" bpmnElement="Group_Duration">
+        <dc:Bounds x="160" y="770" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="664" y="777" width="42" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0m8h7pu" bpmnElement="Group_CycleCron">
+        <dc:Bounds x="1230" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1721" y="137" width="71" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1_di" bpmnElement="TextAnnotation_1">
+        <dc:Bounds x="160" y="80" width="1050" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0nwveo1" bpmnElement="NonInterruptingBoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="702" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="985" width="89" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1q4qstq" bpmnElement="BoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="522" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="985" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/camunda-cloud/integration/camunda-cloud-8-3-timer-errors.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-8-3-timer-errors.bpmn
@@ -1,0 +1,376 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1w3xyk9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.3.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Cycle" name="IntermediateCatchEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_Cycle" name="StartEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_1" />
+    <bpmn:boundaryEvent id="BoundaryEvent_Cycle" name="BoundaryEvent_Cycle" attachedToRef="Task_1">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:task id="Task_2" />
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Cycle" name="NonInterruptingBoundaryEvent_Cycle" cancelActivity="false" attachedToRef="Task_2">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:subProcess id="SubProcess_Cycle" name="SubProcess_Cycle" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Cycle" name="EventSubProcess_StartEvent_Cycle">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Cycle" name="EventSubProcess_NonInterruptingStartEvent_Cycle" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Date" name="IntermediateCatchEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_Date" name="StartEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_5" />
+    <bpmn:task id="Task_6" />
+    <bpmn:subProcess id="SubProcess_Date" name="SubProcess_Date" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Date" name="EventSubProcess_StartEvent_Date">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Date" name="EventSubProcess_NonInterruptingStartEvent_Date" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Date" name="BoundaryEvent_Date" attachedToRef="Task_5">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Date" name="NonInterruptingBoundaryEvent_Date" cancelActivity="false" attachedToRef="Task_6">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Duration" name="IntermediateCatchEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_Duration" name="StartEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_7" />
+    <bpmn:task id="Task_8" />
+    <bpmn:subProcess id="SubProcess_Duration" name="SubProcess_Duration" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Duration" name="EventSubProcess_StartEvent_Duration">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Duration" name="EventSubProcess_NonInterruptingStartEvent_Duration" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Duration" name="BoundaryEvent_Duration" attachedToRef="Task_7">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Duration" name="NonInterruptingBoundaryEvent_Duration" cancelActivity="false" attachedToRef="Task_8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_CycleCron" name="IntermediateCatchEvent_CycleCron">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_CycleCron" name="StartEvent_CycleCron">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_3" />
+    <bpmn:task id="Task_4" />
+    <bpmn:subProcess id="SubProcess_CycleCron" name="SubProcess_CycleCron" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_CycleCron" name="EventSubProcess_StartEvent_CycleCron">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_CycleCron">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_CycleCron" name="EventSubProcess_NonInterruptingStartEvent_CycleCron" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_CycleCron">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_CycleCron" name="BoundaryEvent_CycleCron" attachedToRef="Task_3">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_CycleCron" name="NonInterruptingBoundaryEvent_CycleCron" cancelActivity="false" attachedToRef="Task_4">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:group id="Group_Cycle" categoryValueRef="CategoryValue_Cycle" />
+    <bpmn:group id="Group_Date" categoryValueRef="CategoryValue_Date" />
+    <bpmn:group id="Group_Duration" categoryValueRef="CategoryValue_Duration" />
+    <bpmn:group id="Group_CycleCron" categoryValueRef="CategoryValue_CycleCron" />
+    <bpmn:textAnnotation id="TextAnnotation_1">
+      <bpmn:text>Camunda 8.3</bpmn:text>
+    </bpmn:textAnnotation>
+  </bpmn:process>
+  <bpmn:category id="Category_Cycle">
+    <bpmn:categoryValue id="CategoryValue_Cycle" value="Cycle" />
+  </bpmn:category>
+  <bpmn:category id="Category_Date">
+    <bpmn:categoryValue id="CategoryValue_Date" value="Date" />
+  </bpmn:category>
+  <bpmn:category id="Category_Duration">
+    <bpmn:categoryValue id="CategoryValue_Duration" value="Duration" />
+  </bpmn:category>
+  <bpmn:category id="Category_CycleCron">
+    <bpmn:categoryValue id="CategoryValue_CycleCron" value="Cycle (CRON)" />
+  </bpmn:category>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_1ih3qg9_di" bpmnElement="IntermediateCatchEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="292" y="262" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="268" y="305" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1a2aqqq_di" bpmnElement="StartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="262" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="178" y="305" width="86" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_158bxus_di" bpmnElement="Task_1">
+        <dc:Bounds x="440" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1c7yu62_di" bpmnElement="Task_2">
+        <dc:Bounds x="620" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0si6fbo_di" bpmnElement="SubProcess_Cycle" isExpanded="true">
+        <dc:Bounds x="810" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0emjtwi_di" bpmnElement="EventSubProcess_StartEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="922" y="272" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="901" y="315" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1hvn2kh_di" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="272" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="990" y="315" width="85" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1noobtj" bpmnElement="IntermediateCatchEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="292" y="582" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="272" y="625" width="80" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1daj4e0" bpmnElement="StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="582" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="180" y="625" width="82" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1godq1i" bpmnElement="Task_5">
+        <dc:Bounds x="440" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1cqtk6t" bpmnElement="Task_6">
+        <dc:Bounds x="620" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nhun69" bpmnElement="SubProcess_Date" isExpanded="true">
+        <dc:Bounds x="810" y="510" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1679ksi" bpmnElement="EventSubProcess_StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="635" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n27xdi" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="988" y="635" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0b7rl6t" bpmnElement="IntermediateCatchEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="292" y="902" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="268" y="945" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nvr3f7" bpmnElement="StartEvent_Duration" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="202" y="902" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="178" y="945" width="86" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_09h1dj0" bpmnElement="Task_7">
+        <dc:Bounds x="440" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_13qr05v" bpmnElement="Task_8">
+        <dc:Bounds x="620" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sopxbu" bpmnElement="SubProcess_Duration" isExpanded="true">
+        <dc:Bounds x="810" y="830" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n0geh0" bpmnElement="EventSubProcess_StartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="955" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_01typqg" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="987" y="955" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0tc8we8" bpmnElement="IntermediateCatchEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1362" y="262" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1337" y="305" width="87" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_114olyo" bpmnElement="StartEvent_CycleCron" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1272" y="262" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1249" y="305" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sp4b5v" bpmnElement="Task_3">
+        <dc:Bounds x="1510" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0j20tgx" bpmnElement="Task_4">
+        <dc:Bounds x="1690" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0gooim1" bpmnElement="SubProcess_CycleCron" isExpanded="true">
+        <dc:Bounds x="1880" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ph0d9f" bpmnElement="EventSubProcess_StartEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1992" y="272" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1971" y="315" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_11c780k" bpmnElement="EventSubProcess_NonInterruptingStartEvent_CycleCron" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="2082" y="272" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2059" y="315" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0oqi537_di" bpmnElement="Group_Cycle">
+        <dc:Bounds x="160" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="671" y="137" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1lmj4kq" bpmnElement="Group_Date">
+        <dc:Bounds x="160" y="450" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="675" y="457" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_100yato" bpmnElement="Group_Duration">
+        <dc:Bounds x="160" y="770" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="664" y="777" width="42" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0m8h7pu" bpmnElement="Group_CycleCron">
+        <dc:Bounds x="1230" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1721" y="137" width="71" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1_di" bpmnElement="TextAnnotation_1">
+        <dc:Bounds x="160" y="80" width="1050" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0lzenly" bpmnElement="NonInterruptingBoundaryEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1772" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1746" y="345" width="90" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0v29o08" bpmnElement="BoundaryEvent_CycleCron" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="1592" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1566" y="345" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0nwveo1" bpmnElement="NonInterruptingBoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="702" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="985" width="89" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1q4qstq" bpmnElement="BoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="522" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="985" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_02pg78j" bpmnElement="NonInterruptingBoundaryEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="702" y="622" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="681" y="665" width="83" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ktlobl" bpmnElement="BoundaryEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="522" y="622" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="500" y="665" width="83" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hdiole_di" bpmnElement="NonInterruptingBoundaryEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="702" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="677" y="345" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1iy8313_di" bpmnElement="BoundaryEvent_Cycle" bioc:stroke="#831311" bioc:fill="#ffcdd2" color:background-color="#ffcdd2" color:border-color="#831311">
+        <dc:Bounds x="522" y="302" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="345" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/camunda-cloud/integration/camunda-cloud-8-3-timer.bpmn
+++ b/test/camunda-cloud/integration/camunda-cloud-8-3-timer.bpmn
@@ -1,0 +1,277 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1w3xyk9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.11.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.3.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_Cycle" name="StartEvent_Cycle">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Cycle">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_1" />
+    <bpmn:task id="Task_2" />
+    <bpmn:subProcess id="SubProcess_Cycle" name="SubProcess_Cycle" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Cycle" name="EventSubProcess_NonInterruptingStartEvent_Cycle" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Cycle">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R/P1D</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Date" name="IntermediateCatchEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="StartEvent_Date" name="StartEvent_Date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_5" />
+    <bpmn:task id="Task_6" />
+    <bpmn:subProcess id="SubProcess_Date" name="SubProcess_Date" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Date" name="EventSubProcess_StartEvent_Date">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Date" name="EventSubProcess_NonInterruptingStartEvent_Date" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Date">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Date" name="BoundaryEvent_Date" attachedToRef="Task_5">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Date" name="NonInterruptingBoundaryEvent_Date" cancelActivity="false" attachedToRef="Task_6">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Date">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2019-10-01T12:00:00Z</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_Duration" name="IntermediateCatchEvent_Duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_IntermediateCatchEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:task id="Task_7" />
+    <bpmn:task id="Task_8" />
+    <bpmn:subProcess id="SubProcess_Duration" name="SubProcess_Duration" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_StartEvent_Duration" name="EventSubProcess_StartEvent_Duration">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_StartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_Duration" name="EventSubProcess_NonInterruptingStartEvent_Duration" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_Duration">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_Duration" name="BoundaryEvent_Duration" attachedToRef="Task_7">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_BoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="NonInterruptingBoundaryEvent_Duration" name="NonInterruptingBoundaryEvent_Duration" cancelActivity="false" attachedToRef="Task_8">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_NonInterruptingBoundaryEvent_Duration">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P14D</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:startEvent id="StartEvent_CycleCron" name="StartEvent_CycleCron">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_StartEvent_CycleCron">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_3" />
+    <bpmn:task id="Task_4" />
+    <bpmn:subProcess id="SubProcess_CycleCron" name="SubProcess_CycleCron" triggeredByEvent="true">
+      <bpmn:startEvent id="EventSubProcess_NonInterruptingStartEvent_CycleCron" name="EventSubProcess_NonInterruptingStartEvent_CycleCron" isInterrupting="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_EventSubProcess_NonInterruptingStartEvent_CycleCron">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:group id="Group_Cycle" categoryValueRef="CategoryValue_Cycle" />
+    <bpmn:group id="Group_Date" categoryValueRef="CategoryValue_Date" />
+    <bpmn:group id="Group_Duration" categoryValueRef="CategoryValue_Duration" />
+    <bpmn:group id="Group_CycleCron" categoryValueRef="CategoryValue_CycleCron" />
+    <bpmn:textAnnotation id="TextAnnotation_1">
+      <bpmn:text>Camunda 8.3</bpmn:text>
+    </bpmn:textAnnotation>
+  </bpmn:process>
+  <bpmn:category id="Category_Cycle">
+    <bpmn:categoryValue id="CategoryValue_Cycle" value="Cycle" />
+  </bpmn:category>
+  <bpmn:category id="Category_Date">
+    <bpmn:categoryValue id="CategoryValue_Date" value="Date" />
+  </bpmn:category>
+  <bpmn:category id="Category_Duration">
+    <bpmn:categoryValue id="CategoryValue_Duration" value="Duration" />
+  </bpmn:category>
+  <bpmn:category id="Category_CycleCron">
+    <bpmn:categoryValue id="CategoryValue_CycleCron" value="Cycle (CRON)" />
+  </bpmn:category>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Event_1a2aqqq_di" bpmnElement="StartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="262" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="178" y="305" width="86" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_158bxus_di" bpmnElement="Task_1">
+        <dc:Bounds x="440" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1c7yu62_di" bpmnElement="Task_2">
+        <dc:Bounds x="620" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0si6fbo_di" bpmnElement="SubProcess_Cycle" isExpanded="true">
+        <dc:Bounds x="810" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1hvn2kh_di" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Cycle" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="272" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="990" y="315" width="85" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1noobtj" bpmnElement="IntermediateCatchEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="292" y="582" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="272" y="625" width="80" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1daj4e0" bpmnElement="StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="202" y="582" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="180" y="625" width="82" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1godq1i" bpmnElement="Task_5">
+        <dc:Bounds x="440" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1cqtk6t" bpmnElement="Task_6">
+        <dc:Bounds x="620" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nhun69" bpmnElement="SubProcess_Date" isExpanded="true">
+        <dc:Bounds x="810" y="510" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1679ksi" bpmnElement="EventSubProcess_StartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="635" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n27xdi" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="988" y="635" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0b7rl6t" bpmnElement="IntermediateCatchEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="292" y="902" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="268" y="945" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_09h1dj0" bpmnElement="Task_7">
+        <dc:Bounds x="440" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_13qr05v" bpmnElement="Task_8">
+        <dc:Bounds x="620" y="880" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sopxbu" bpmnElement="SubProcess_Duration" isExpanded="true">
+        <dc:Bounds x="810" y="830" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0n0geh0" bpmnElement="EventSubProcess_StartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="922" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="896" y="955" width="88" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_01typqg" bpmnElement="EventSubProcess_NonInterruptingStartEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1012" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="987" y="955" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_114olyo" bpmnElement="StartEvent_CycleCron" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="1272" y="262" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1249" y="305" width="85" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0sp4b5v" bpmnElement="Task_3">
+        <dc:Bounds x="1510" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0j20tgx" bpmnElement="Task_4">
+        <dc:Bounds x="1690" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0gooim1" bpmnElement="SubProcess_CycleCron" isExpanded="true">
+        <dc:Bounds x="1880" y="190" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_11c780k" bpmnElement="EventSubProcess_NonInterruptingStartEvent_CycleCron" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="2082" y="272" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2059" y="315" width="88" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0oqi537_di" bpmnElement="Group_Cycle">
+        <dc:Bounds x="160" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="671" y="137" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1lmj4kq" bpmnElement="Group_Date">
+        <dc:Bounds x="160" y="450" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="675" y="457" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_100yato" bpmnElement="Group_Duration">
+        <dc:Bounds x="160" y="770" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="664" y="777" width="42" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0m8h7pu" bpmnElement="Group_CycleCron">
+        <dc:Bounds x="1230" y="130" width="1050" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1721" y="137" width="71" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1_di" bpmnElement="TextAnnotation_1">
+        <dc:Bounds x="160" y="80" width="1050" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0nwveo1" bpmnElement="NonInterruptingBoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="702" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="676" y="985" width="89" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1q4qstq" bpmnElement="BoundaryEvent_Duration" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="522" y="942" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="985" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_02pg78j" bpmnElement="NonInterruptingBoundaryEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="702" y="622" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="681" y="665" width="83" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ktlobl" bpmnElement="BoundaryEvent_Date" bioc:stroke="#205022" bioc:fill="#c8e6c9" color:background-color="#c8e6c9" color:border-color="#205022">
+        <dc:Bounds x="522" y="622" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="500" y="665" width="83" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/camunda-cloud/integration/timer.spec.js
+++ b/test/camunda-cloud/integration/timer.spec.js
@@ -13,7 +13,8 @@ const versions = [
   '1.3',
   '8.0',
   '8.1',
-  '8.2'
+  '8.2',
+  '8.3'
 ];
 
 describe('integration - timer', function() {

--- a/test/camunda-cloud/timer.spec.js
+++ b/test/camunda-cloud/timer.spec.js
@@ -369,7 +369,7 @@ const invalid = [
     `)),
     report: {
       id: 'StartEvent_1',
-      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeCycle> or <timeDate>',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have property <timeCycle> or <timeDate>',
       path: [
         'eventDefinitions',
         0
@@ -475,7 +475,7 @@ const invalid = [
     `)),
     report: {
       id: 'StartEvent_1',
-      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeCycle> or <timeDate>',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have property <timeCycle> or <timeDate>',
       path: [
         'eventDefinitions',
         0
@@ -505,7 +505,7 @@ const invalid = [
     `)),
     report: {
       id: 'IntermediateCatchEvent_1',
-      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeDuration>',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have property <timeDuration>',
       path: [
         'eventDefinitions',
         0
@@ -558,7 +558,7 @@ const invalid = [
     `)),
     report: {
       id: 'IntermediateCatchEvent_1',
-      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeDuration>',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have property <timeDuration>',
       path: [
         'eventDefinitions',
         0
@@ -585,7 +585,7 @@ const invalid = [
     `)),
     report: {
       id: 'IntermediateCatchEvent_1',
-      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeDuration>',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have property <timeDuration>',
       path: [
         'eventDefinitions',
         0
@@ -641,7 +641,7 @@ const invalid = [
     `)),
     report: {
       id: 'BoundaryEvent_1',
-      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeDuration>',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have property <timeDuration>',
       path: [
         'eventDefinitions',
         0
@@ -696,7 +696,7 @@ const invalid = [
     `)),
     report: {
       id: 'BoundaryEvent_1',
-      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeDuration>',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have property <timeDuration>',
       path: [
         'eventDefinitions',
         0
@@ -724,7 +724,7 @@ const invalid = [
     `)),
     report: {
       id: 'BoundaryEvent_1',
-      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeDuration>',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have property <timeDuration>',
       path: [
         'eventDefinitions',
         0
@@ -781,7 +781,7 @@ const invalid = [
     `)),
     report: {
       id: 'BoundaryEvent_1',
-      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeCycle> or <timeDuration>',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have property <timeCycle> or <timeDuration>',
       path: [
         'eventDefinitions',
         0
@@ -864,7 +864,7 @@ const invalid = [
     `)),
     report: {
       id: 'BoundaryEvent_1',
-      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeCycle> or <timeDuration>',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have property <timeCycle> or <timeDuration>',
       path: [
         'eventDefinitions',
         0
@@ -923,7 +923,7 @@ const invalid = [
     `)),
     report: {
       id: 'StartEvent_1',
-      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeDate> or <timeDuration>',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have property <timeDate> or <timeDuration>',
       path: [
         'eventDefinitions',
         0
@@ -981,7 +981,7 @@ const invalid = [
     `)),
     report: {
       id: 'StartEvent_1',
-      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeDate> or <timeDuration>',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have property <timeDate> or <timeDuration>',
       path: [
         'eventDefinitions',
         0
@@ -1069,7 +1069,7 @@ const invalid = [
     `)),
     report: {
       id: 'StartEvent_1',
-      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeCycle>, <timeDate> or <timeDuration>',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have property <timeCycle>, <timeDate> or <timeDuration>',
       path: [
         'eventDefinitions',
         0

--- a/test/camunda-cloud/timer.spec.js
+++ b/test/camunda-cloud/timer.spec.js
@@ -89,6 +89,17 @@ const valid = [
    * Intermediate Catch Event
    */
   {
+    name: 'timer intermediate catch event with time date (ISO-8601)',
+    config: { version: '8.3' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">${ EXPRESSION_VALUES.ISO_8601.TIME_DATE }</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:intermediateCatchEvent>
+    `))
+  },
+  {
     name: 'intermediate catch event with time duration (ISO-8601)',
     config: { version: '1.0' },
     moddleElement: createModdle(createProcess(`
@@ -103,6 +114,30 @@ const valid = [
   /**
    * Boundary Event, Interrupting
    */
+  {
+    name: 'boundary event with date (ISO-8601)',
+    config: { version: '8.3' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:task id="Task_1" />
+      <bpmn:boundaryEvent id="Event" attachedToRef="Task_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">${ EXPRESSION_VALUES.ISO_8601.TIME_DATE }</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:boundaryEvent>
+    `))
+  },
+  {
+    name: 'boundary event with time date (expression)',
+    config: { version: '8.3' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:task id="Task_1" />
+      <bpmn:boundaryEvent id="Event" attachedToRef="Task_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">${ FEEL_EXPRESSION_VALUE }</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:boundaryEvent>
+    `))
+  },
   {
     name: 'boundary event with duration (ISO-8601)',
     config: { version: '1.0' },

--- a/test/camunda-cloud/timer.spec.js
+++ b/test/camunda-cloud/timer.spec.js
@@ -10,101 +10,302 @@ const {
 
 const { ERROR_TYPES } = require('../../rules/utils/element');
 
+const EXPRESSION_VALUES = {
+  CRON: {
+    EXPRESSION: '0 0 9-17 * * MON-FRI',
+    MACRO: '@daily',
+  },
+  ISO_8601: {
+    TIME_CYCLE: 'R/P1D',
+    TIME_DATE: '2019-10-01T12:00:00Z',
+    TIME_DURATION: 'P1D'
+  }
+};
+
+const FEEL_EXPRESSION_VALUE = '=foo';
+
 const valid = [
+
+  /**
+   * Start Event, Interrupting
+   */
   {
-    name: 'time duration (ISO-8601)',
+    name: 'start event with time cycle (ISO-8601)',
     config: { version: '1.0' },
     moddleElement: createModdle(createProcess(`
-      <bpmn:task id="Task" />
-      <bpmn:boundaryEvent id="Event" cancelActivity="false" attachedToRef="Task">
-        <bpmn:timerEventDefinition id="TimerEventDefinition">
-          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y2M</bpmn:timeDuration>
-        </bpmn:timerEventDefinition>
-      </bpmn:boundaryEvent>
-    `))
-  },
-  {
-    name: 'time duration (expression)',
-    config: { version: '1.0' },
-    moddleElement: createModdle(createProcess(`
-      <bpmn:task id="Task" />
-      <bpmn:boundaryEvent id="Event" cancelActivity="false" attachedToRef="Task">
-        <bpmn:timerEventDefinition id="TimerEventDefinition">
-          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">= expression</bpmn:timeDuration>
-        </bpmn:timerEventDefinition>
-      </bpmn:boundaryEvent>
-    `))
-  },
-  {
-    name: 'time date (ISO-8601)',
-    config: { version: '1.0' },
-    moddleElement: createModdle(createProcess(`
-      <bpmn:startEvent id="Event">
-        <bpmn:timerEventDefinition id="TimerEventDefinition">
-          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">2022-09-21T00:00:00Z</bpmn:timeDate>
+      <bpmn:startEvent id="StartEvent_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">${ EXPRESSION_VALUES.ISO_8601.TIME_CYCLE }</bpmn:timeCycle>
         </bpmn:timerEventDefinition>
       </bpmn:startEvent>
     `))
   },
   {
-    name: 'time date (expression)',
-    config: { version: '1.0' },
+    name: 'start event with time cycle (cron)',
+    config: { version: '8.1' },
     moddleElement: createModdle(createProcess(`
-      <bpmn:startEvent id="Event">
-        <bpmn:timerEventDefinition id="TimerEventDefinition">
-          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">= date and time("2022-09-21T00:00:00Z")</bpmn:timeDate>
+      <bpmn:startEvent id="StartEvent_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">${ EXPRESSION_VALUES.CRON.EXPRESSION }</bpmn:timeCycle>
         </bpmn:timerEventDefinition>
       </bpmn:startEvent>
     `))
   },
   {
-    name: 'time cycle (ISO-8601)',
+    name: 'start event with time cycle (expression)',
     config: { version: '1.0' },
     moddleElement: createModdle(createProcess(`
-      <bpmn:task id="Task" />
-      <bpmn:boundaryEvent id="Event" cancelActivity="false" attachedToRef="Task">
-        <bpmn:timerEventDefinition id="TimerEventDefinition">
-          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">R5/P1D</bpmn:timeCycle>
+      <bpmn:startEvent id="StartEvent_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">${ FEEL_EXPRESSION_VALUE }</bpmn:timeCycle>
         </bpmn:timerEventDefinition>
-      </bpmn:boundaryEvent>
+      </bpmn:startEvent>
     `))
   },
   {
-    name: 'time cycle (cron)',
-    config: { version: '8.1' },
-    moddleElement: createModdle(createProcess(`
-      <bpmn:task id="Task" />
-      <bpmn:boundaryEvent id="Event" cancelActivity="false" attachedToRef="Task">
-        <bpmn:timerEventDefinition id="TimerEventDefinition">
-          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">0 0 9-17 * * MON-FRI</bpmn:timeCycle>
-        </bpmn:timerEventDefinition>
-      </bpmn:boundaryEvent>
-    `))
-  },
-  {
-    name: 'time cycle (cron macro)',
-    config: { version: '8.1' },
-    moddleElement: createModdle(createProcess(`
-      <bpmn:task id="Task" />
-      <bpmn:boundaryEvent id="Event" cancelActivity="false" attachedToRef="Task">
-        <bpmn:timerEventDefinition id="TimerEventDefinition">
-          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">@yearly</bpmn:timeCycle>
-        </bpmn:timerEventDefinition>
-      </bpmn:boundaryEvent>
-    `))
-  },
-  {
-    name: 'time cycle (expression)',
+    name: 'start event with time date (ISO-8601)',
     config: { version: '1.0' },
     moddleElement: createModdle(createProcess(`
-      <bpmn:task id="Task" />
-      <bpmn:boundaryEvent id="Event" cancelActivity="false" attachedToRef="Task">
-        <bpmn:timerEventDefinition id="TimerEventDefinition">
-          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">= today</bpmn:timeDuration>
+      <bpmn:startEvent id="StartEvent_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">${ EXPRESSION_VALUES.ISO_8601.TIME_DATE }</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    `))
+  },
+  {
+    name: 'start event time date (expression)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:startEvent id="StartEvent_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">${ FEEL_EXPRESSION_VALUE }</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    `))
+  },
+
+  /**
+   * Intermediate Catch Event
+   */
+  {
+    name: 'intermediate catch event with time duration (ISO-8601)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">${ EXPRESSION_VALUES.ISO_8601.TIME_DURATION }</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:intermediateCatchEvent>
+    `))
+  },
+
+  /**
+   * Boundary Event, Interrupting
+   */
+  {
+    name: 'boundary event with duration (ISO-8601)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:task id="Task_1" />
+      <bpmn:boundaryEvent id="Event" attachedToRef="Task_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">${ EXPRESSION_VALUES.ISO_8601.TIME_DURATION }</bpmn:timeDuration>
         </bpmn:timerEventDefinition>
       </bpmn:boundaryEvent>
     `))
   },
+  {
+    name: 'boundary event with time duration (expression)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:task id="Task_1" />
+      <bpmn:boundaryEvent id="Event" attachedToRef="Task_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">${ FEEL_EXPRESSION_VALUE }</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:boundaryEvent>
+    `))
+  },
+
+  /**
+   * Boundary Event, Non-Interrupting
+   */
+  {
+    name: 'boundary event with time cycle (ISO-8601)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:task id="Task_1" />
+      <bpmn:boundaryEvent id="Event" cancelActivity="false" attachedToRef="Task_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">${ EXPRESSION_VALUES.ISO_8601.TIME_CYCLE }</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:boundaryEvent>
+    `))
+  },
+  {
+    name: 'boundary event with time cycle (cron)',
+    config: { version: '8.1' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:task id="Task_1" />
+      <bpmn:boundaryEvent id="Event" cancelActivity="false" attachedToRef="Task_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">${ EXPRESSION_VALUES.CRON.EXPRESSION }</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:boundaryEvent>
+    `))
+  },
+  {
+    name: 'boundary event with time cycle (cron macro)',
+    config: { version: '8.1' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:task id="Task_1" />
+      <bpmn:boundaryEvent id="Event" cancelActivity="false" attachedToRef="Task_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">${ EXPRESSION_VALUES.CRON.MACRO }</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:boundaryEvent>
+    `))
+  },
+  {
+    name: 'boudary event with time cycle (expression)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:task id="Task_1" />
+      <bpmn:boundaryEvent id="Event" cancelActivity="false" attachedToRef="Task_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">${ FEEL_EXPRESSION_VALUE }</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:boundaryEvent>
+    `))
+  },
+  {
+    name: 'boundary event with time duration (ISO-8601)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:task id="Task_1" />
+      <bpmn:boundaryEvent id="Event" cancelActivity="false" attachedToRef="Task_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">${ EXPRESSION_VALUES.ISO_8601.TIME_DURATION }</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:boundaryEvent>
+    `))
+  },
+  {
+    name: 'boundary event with time duration (expression)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:task id="Task_1" />
+      <bpmn:boundaryEvent id="Event" cancelActivity="false" attachedToRef="Task_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">${ FEEL_EXPRESSION_VALUE }</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:boundaryEvent>
+    `))
+  },
+
+  /**
+   * Start Event, Interrupting, Event Sub-Process
+   */
+  {
+    name: 'start event with time date (ISO-8601)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:subProcess id="SubProcess_1" triggeredByEvent="true">
+        <bpmn:startEvent id="StartEvent_1">
+          <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+            <bpmn:timeDate xsi:type="bpmn:tFormalExpression">${ EXPRESSION_VALUES.ISO_8601.TIME_DATE }</bpmn:timeDate>
+          </bpmn:timerEventDefinition>
+        </bpmn:startEvent>
+      </bpmn:subProcess>
+    `))
+  },
+  {
+    name: 'start event with time duration (ISO-8601)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:subProcess id="SubProcess_1" triggeredByEvent="true">
+        <bpmn:startEvent id="StartEvent_1">
+          <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">${ EXPRESSION_VALUES.ISO_8601.TIME_DURATION }</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </bpmn:startEvent>
+      </bpmn:subProcess>
+    `))
+  },
+
+  /**
+   * Start Event, Non-Interrupting, Event Sub-Process
+   */
+  {
+    name: 'start event with time cycle (ISO-8601)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:subProcess id="SubProcess_1" triggeredByEvent="true">
+        <bpmn:startEvent id="StartEvent_1" isInterrupting="false">
+          <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+            <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">${ EXPRESSION_VALUES.ISO_8601.TIME_CYCLE }</bpmn:timeCycle>
+          </bpmn:timerEventDefinition>
+        </bpmn:startEvent>
+      </bpmn:subProcess>
+    `))
+  },
+  {
+    name: 'start event with time cycle (cron)',
+    config: { version: '8.1' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:subProcess id="SubProcess_1" triggeredByEvent="true">
+        <bpmn:startEvent id="StartEvent_1" isInterrupting="false">
+          <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+            <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">${ EXPRESSION_VALUES.CRON.EXPRESSION }</bpmn:timeCycle>
+          </bpmn:timerEventDefinition>
+        </bpmn:startEvent>
+      </bpmn:subProcess>
+    `))
+  },
+  {
+    name: 'start event with time cycle (expression)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:subProcess id="SubProcess_1" triggeredByEvent="true">
+        <bpmn:startEvent id="StartEvent_1" isInterrupting="false">
+          <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+            <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">${ FEEL_EXPRESSION_VALUE }</bpmn:timeCycle>
+          </bpmn:timerEventDefinition>
+        </bpmn:startEvent>
+      </bpmn:subProcess>
+    `))
+  },
+  {
+    name: 'start event with time date (ISO-8601)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:subProcess id="SubProcess_1" triggeredByEvent="true">
+        <bpmn:startEvent id="StartEvent_1" isInterrupting="false">
+          <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+            <bpmn:timeDate xsi:type="bpmn:tFormalExpression">${ EXPRESSION_VALUES.ISO_8601.TIME_DATE }</bpmn:timeDate>
+          </bpmn:timerEventDefinition>
+        </bpmn:startEvent>
+      </bpmn:subProcess>
+    `))
+  },
+  {
+    name: 'start event with time duration (ISO-8601)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:subProcess id="SubProcess_1" triggeredByEvent="true">
+        <bpmn:startEvent id="StartEvent_1" isInterrupting="false">
+          <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">${ EXPRESSION_VALUES.ISO_8601.TIME_DURATION }</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </bpmn:startEvent>
+      </bpmn:subProcess>
+    `))
+  },
+
+  /**
+   * Non-Executable Process
+   */
   {
     name: 'timer start event (no expression) (non-executable process)',
     config: { version: '8.2' },
@@ -119,16 +320,20 @@ const valid = [
 ];
 
 const invalid = [
+
+  /**
+   * Start Event, Interrupting
+   */
   {
     name: 'timer start event (no expression)',
     config: { version: '1.0' },
     moddleElement: createModdle(createProcess(`
-      <bpmn:startEvent id="Event">
-        <bpmn:timerEventDefinition id="TimerEventDefinition" />
+      <bpmn:startEvent id="StartEvent_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1" />
       </bpmn:startEvent>
     `)),
     report: {
-      id: 'Event',
+      id: 'StartEvent_1',
       message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeCycle> or <timeDate>',
       path: [
         'eventDefinitions',
@@ -136,8 +341,8 @@ const invalid = [
       ],
       data: {
         type: ERROR_TYPES.PROPERTY_REQUIRED,
-        node: 'TimerEventDefinition',
-        parentNode: 'Event',
+        node: 'TimerEventDefinition_1',
+        parentNode: 'StartEvent_1',
         requiredProperty: [
           'timeCycle',
           'timeDate'
@@ -146,96 +351,152 @@ const invalid = [
     }
   },
   {
-    name: 'timer intermediate catch event (no expression)',
-    config: { version: '1.0' },
-    moddleElement: createModdle(createProcess(`
-      <bpmn:intermediateCatchEvent id="Event">
-        <bpmn:timerEventDefinition id="TimerEventDefinition" />
-      </bpmn:intermediateCatchEvent>
-    `)),
-    report: {
-      id: 'Event',
-      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeDuration>',
-      path: [
-        'eventDefinitions',
-        0
-      ],
-      data: {
-        type: ERROR_TYPES.PROPERTY_REQUIRED,
-        node: 'TimerEventDefinition',
-        parentNode: 'Event',
-        requiredProperty: [
-          'timeDuration'
-        ]
-      }
-    }
-  },
-  {
-    name: 'timer interrupting boundary event (no expression)',
-    config: { version: '1.0' },
-    moddleElement: createModdle(createProcess(`
-      <bpmn:task id="Task" />
-      <bpmn:boundaryEvent id="Event" attachedToRef="Task">
-        <bpmn:timerEventDefinition id="TimerEventDefinition" />
-      </bpmn:boundaryEvent>
-    `)),
-    report: {
-      id: 'Event',
-      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeDuration>',
-      path: [
-        'eventDefinitions',
-        0
-      ],
-      data: {
-        type: ERROR_TYPES.PROPERTY_REQUIRED,
-        node: 'TimerEventDefinition',
-        parentNode: 'Event',
-        requiredProperty: [
-          'timeDuration'
-        ]
-      }
-    }
-  },
-  {
-    name: 'timer non-interrupting boundary event (no expression)',
-    config: { version: '1.0' },
-    moddleElement: createModdle(createProcess(`
-      <bpmn:task id="Task" />
-      <bpmn:boundaryEvent id="Event" cancelActivity="false" attachedToRef="Task">
-        <bpmn:timerEventDefinition id="TimerEventDefinition" />
-      </bpmn:boundaryEvent>
-    `)),
-    report: {
-      id: 'Event',
-      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeCycle> or <timeDuration>',
-      path: [
-        'eventDefinitions',
-        0
-      ],
-      data: {
-        type: ERROR_TYPES.PROPERTY_REQUIRED,
-        node: 'TimerEventDefinition',
-        parentNode: 'Event',
-        requiredProperty: [
-          'timeCycle',
-          'timeDuration'
-        ]
-      }
-    }
-  },
-  {
     name: 'timer start event (empty expression)',
     config: { version: '1.0' },
     moddleElement: createModdle(createProcess(`
-      <bpmn:task id="Task" />
-      <bpmn:boundaryEvent id="Event" cancelActivity="false" attachedToRef="Task">
-        <bpmn:timerEventDefinition id="TimerEventDefinition">
-          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression" />
+      <bpmn:startEvent id="StartEvent_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression" />
         </bpmn:timerEventDefinition>
-      </bpmn:boundaryEvent>
+      </bpmn:startEvent>
     `)),
     report: {
-      id: 'Event',
+      id: 'StartEvent_1',
+      message: 'Property <timeCycle> must have expression value',
+      path: [
+        'eventDefinitions',
+        0,
+        'timeCycle'
+      ],
+      data: {
+        type: ERROR_TYPES.EXPRESSION_REQUIRED,
+        node: 'bpmn:FormalExpression',
+        parentNode: 'StartEvent_1',
+        property: 'timeCycle'
+      }
+    }
+  },
+  {
+    name: 'timer start event with time cycle (invalid)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:startEvent id="StartEvent_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">foo</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    `)),
+    report: {
+      id: 'StartEvent_1',
+      message: 'Expression value of <foo> not allowed',
+      path: [
+        'eventDefinitions',
+        0,
+        'timeCycle'
+      ],
+      data: {
+        type: ERROR_TYPES.EXPRESSION_VALUE_NOT_ALLOWED,
+        node: 'bpmn:FormalExpression',
+        parentNode: 'StartEvent_1',
+        property: 'timeCycle'
+      }
+    }
+  },
+  {
+    name: 'timer start event with time date (invalid)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:startEvent id="StartEvent_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDate>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    `)),
+    report: {
+      id: 'StartEvent_1',
+      message: 'Expression value of <foo> not allowed',
+      path: [
+        'eventDefinitions',
+        0,
+        'timeDate'
+      ],
+      data: {
+        type: ERROR_TYPES.EXPRESSION_VALUE_NOT_ALLOWED,
+        node: 'bpmn:FormalExpression',
+        parentNode: 'StartEvent_1',
+        property: 'timeDate'
+      }
+    }
+  },
+  {
+    name: 'timer start event with time duration (not allowed)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:startEvent id="StartEvent_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression" />
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    `)),
+    report: {
+      id: 'StartEvent_1',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeCycle> or <timeDate>',
+      path: [
+        'eventDefinitions',
+        0
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'TimerEventDefinition_1',
+        parentNode: 'StartEvent_1',
+        requiredProperty: [
+          'timeCycle',
+          'timeDate'
+        ]
+      }
+    }
+  },
+
+  /**
+   * Intermediate Catch Event
+   */
+  {
+    name: 'timer intermediate catch event (no expression)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1" />
+      </bpmn:intermediateCatchEvent>
+    `)),
+    report: {
+      id: 'IntermediateCatchEvent_1',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeDuration>',
+      path: [
+        'eventDefinitions',
+        0
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'TimerEventDefinition_1',
+        parentNode: 'IntermediateCatchEvent_1',
+        requiredProperty: [
+          'timeDuration'
+        ]
+      }
+    }
+  },
+  {
+    name: 'timer intermediate catch event (empty expression)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression" />
+        </bpmn:timerEventDefinition>
+      </bpmn:intermediateCatchEvent>
+    `)),
+    report: {
+      id: 'IntermediateCatchEvent_1',
       message: 'Property <timeDuration> must have expression value',
       path: [
         'eventDefinitions',
@@ -245,25 +506,78 @@ const invalid = [
       data: {
         type: ERROR_TYPES.EXPRESSION_REQUIRED,
         node: 'bpmn:FormalExpression',
-        parentNode: 'Event',
+        parentNode: 'IntermediateCatchEvent_1',
         property: 'timeDuration'
       }
     }
   },
   {
-    name: 'timer boundary event (cron in Camunda Platform 8.0)',
-    config: { version: '8.0' },
+    name: 'timer intermediate catch event with time cycle (not allowed)',
+    config: { version: '1.0' },
     moddleElement: createModdle(createProcess(`
-      <bpmn:task id="Task" />
-      <bpmn:boundaryEvent id="Event" cancelActivity="false" attachedToRef="Task">
-        <bpmn:timerEventDefinition id="TimerEventDefinition">
-          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">@daily</bpmn:timeDuration>
+      <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression" />
         </bpmn:timerEventDefinition>
-      </bpmn:boundaryEvent>
+      </bpmn:intermediateCatchEvent>
     `)),
     report: {
-      id: 'Event',
-      message: 'Expression value of <@daily> not allowed',
+      id: 'IntermediateCatchEvent_1',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeDuration>',
+      path: [
+        'eventDefinitions',
+        0
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'TimerEventDefinition_1',
+        parentNode: 'IntermediateCatchEvent_1',
+        requiredProperty: [
+          'timeDuration'
+        ]
+      }
+    }
+  },
+  {
+    name: 'timer intermediate catch event with time date (not allowed)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression" />
+        </bpmn:timerEventDefinition>
+      </bpmn:intermediateCatchEvent>
+    `)),
+    report: {
+      id: 'IntermediateCatchEvent_1',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeDuration>',
+      path: [
+        'eventDefinitions',
+        0
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'TimerEventDefinition_1',
+        parentNode: 'IntermediateCatchEvent_1',
+        requiredProperty: [
+          'timeDuration'
+        ]
+      }
+    }
+  },
+  {
+    name: 'timer intermediate catch event with time duration (invalid)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:intermediateCatchEvent>
+    `)),
+    report: {
+      id: 'IntermediateCatchEvent_1',
+      message: 'Expression value of <foo> not allowed',
       path: [
         'eventDefinitions',
         0,
@@ -272,25 +586,138 @@ const invalid = [
       data: {
         type: ERROR_TYPES.EXPRESSION_VALUE_NOT_ALLOWED,
         node: 'bpmn:FormalExpression',
-        parentNode: 'Event',
+        parentNode: 'IntermediateCatchEvent_1',
+        property: 'timeDuration'
+      }
+    }
+  },
+
+  /**
+   * Boundary Event, Interrupting
+   */
+  {
+    name: 'timer boundary event (no expression)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:task id="Task_1" />
+      <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="Task_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1" />
+      </bpmn:boundaryEvent>
+    `)),
+    report: {
+      id: 'BoundaryEvent_1',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeDuration>',
+      path: [
+        'eventDefinitions',
+        0
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'TimerEventDefinition_1',
+        parentNode: 'BoundaryEvent_1',
+        requiredProperty: [
+          'timeDuration'
+        ]
+      }
+    }
+  },
+  {
+    name: 'timer boundary event (empty expression)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:task id="Task_1" />
+      <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="Task_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression" />
+        </bpmn:timerEventDefinition>
+      </bpmn:boundaryEvent>
+    `)),
+    report: {
+      id: 'BoundaryEvent_1',
+      message: 'Property <timeDuration> must have expression value',
+      path: [
+        'eventDefinitions',
+        0,
+        'timeDuration'
+      ],
+      data: {
+        type: ERROR_TYPES.EXPRESSION_REQUIRED,
+        node: 'bpmn:FormalExpression',
+        parentNode: 'BoundaryEvent_1',
         property: 'timeDuration'
       }
     }
   },
   {
-    name: 'timer boundary event (invalid duration)',
+    name: 'timer boundary event with time cycle (not allowed)',
     config: { version: '1.0' },
     moddleElement: createModdle(createProcess(`
-      <bpmn:task id="Task" />
-      <bpmn:boundaryEvent id="Event" cancelActivity="false" attachedToRef="Task">
-        <bpmn:timerEventDefinition id="TimerEventDefinition">
-          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">invalid</bpmn:timeDuration>
+      <bpmn:task id="Task_1" />
+      <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="Task_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression" />
         </bpmn:timerEventDefinition>
       </bpmn:boundaryEvent>
     `)),
     report: {
-      id: 'Event',
-      message: 'Expression value of <invalid> not allowed',
+      id: 'BoundaryEvent_1',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeDuration>',
+      path: [
+        'eventDefinitions',
+        0
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'TimerEventDefinition_1',
+        parentNode: 'BoundaryEvent_1',
+        requiredProperty: [
+          'timeDuration'
+        ]
+      }
+    }
+  },
+  {
+    name: 'timer boundary event with time date (not allowed)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:task id="Task_1" />
+      <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="Task_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression" />
+        </bpmn:timerEventDefinition>
+      </bpmn:boundaryEvent>
+    `)),
+    report: {
+      id: 'BoundaryEvent_1',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeDuration>',
+      path: [
+        'eventDefinitions',
+        0
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'TimerEventDefinition_1',
+        parentNode: 'BoundaryEvent_1',
+        requiredProperty: [
+          'timeDuration'
+        ]
+      }
+    }
+  },
+  {
+    name: 'timer boundary event with time duration (invalid)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:task id="Task_1" />
+      <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="Task_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:boundaryEvent>
+    `)),
+    report: {
+      id: 'BoundaryEvent_1',
+      message: 'Expression value of <foo> not allowed',
       path: [
         'eventDefinitions',
         0,
@@ -299,25 +726,83 @@ const invalid = [
       data: {
         type: ERROR_TYPES.EXPRESSION_VALUE_NOT_ALLOWED,
         node: 'bpmn:FormalExpression',
-        parentNode: 'Event',
+        parentNode: 'BoundaryEvent_1',
+        property: 'timeDuration'
+      }
+    }
+  },
+
+  /**
+   * Boundary Event, Non-Interrupting
+   */
+  {
+    name: 'non-interrupting timer boundary event (no expression)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:task id="Task_1" />
+      <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="Task_1" cancelActivity="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1" />
+      </bpmn:boundaryEvent>
+    `)),
+    report: {
+      id: 'BoundaryEvent_1',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeCycle> or <timeDuration>',
+      path: [
+        'eventDefinitions',
+        0
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'TimerEventDefinition_1',
+        parentNode: 'BoundaryEvent_1',
+        requiredProperty: [
+          'timeCycle',
+          'timeDuration'
+        ]
+      }
+    }
+  },
+  {
+    name: 'non-interrupting timer boundary event (empty expression)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:task id="Task_1" />
+      <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="Task_1" cancelActivity="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression" />
+        </bpmn:timerEventDefinition>
+      </bpmn:boundaryEvent>
+    `)),
+    report: {
+      id: 'BoundaryEvent_1',
+      message: 'Property <timeDuration> must have expression value',
+      path: [
+        'eventDefinitions',
+        0,
+        'timeDuration'
+      ],
+      data: {
+        type: ERROR_TYPES.EXPRESSION_REQUIRED,
+        node: 'bpmn:FormalExpression',
+        parentNode: 'BoundaryEvent_1',
         property: 'timeDuration'
       }
     }
   },
   {
-    name: 'timer boundary event (invalid cycle)',
+    name: 'non-interrupting timer boundary event with time cycle (invalid)',
     config: { version: '1.0' },
     moddleElement: createModdle(createProcess(`
-      <bpmn:task id="Task" />
-      <bpmn:boundaryEvent id="Event" cancelActivity="false" attachedToRef="Task">
-        <bpmn:timerEventDefinition id="TimerEventDefinition">
-          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">invalid</bpmn:timeCycle>
+      <bpmn:task id="Task_1" />
+      <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="Task_1" cancelActivity="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">foo</bpmn:timeCycle>
         </bpmn:timerEventDefinition>
       </bpmn:boundaryEvent>
     `)),
     report: {
-      id: 'Event',
-      message: 'Expression value of <invalid> not allowed',
+      id: 'BoundaryEvent_1',
+      message: 'Expression value of <foo> not allowed',
       path: [
         'eventDefinitions',
         0,
@@ -326,24 +811,172 @@ const invalid = [
       data: {
         type: ERROR_TYPES.EXPRESSION_VALUE_NOT_ALLOWED,
         node: 'bpmn:FormalExpression',
-        parentNode: 'Event',
+        parentNode: 'BoundaryEvent_1',
         property: 'timeCycle'
       }
     }
   },
   {
-    name: 'timer start event (invalid date)',
+    name: 'non-interrupting timer boundary event with time date (not allowed)',
     config: { version: '1.0' },
     moddleElement: createModdle(createProcess(`
-      <bpmn:startEvent id="Event">
-        <bpmn:timerEventDefinition id="TimerEventDefinition">
-          <bpmn:timeDate xsi:type="bpmn:tFormalExpression">invalid</bpmn:timeDate>
+      <bpmn:task id="Task_1" />
+      <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="Task_1" cancelActivity="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeDate xsi:type="bpmn:tFormalExpression" />
         </bpmn:timerEventDefinition>
-      </bpmn:startEvent>
+      </bpmn:boundaryEvent>
     `)),
     report: {
-      id: 'Event',
-      message: 'Expression value of <invalid> not allowed',
+      id: 'BoundaryEvent_1',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeCycle> or <timeDuration>',
+      path: [
+        'eventDefinitions',
+        0
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'TimerEventDefinition_1',
+        parentNode: 'BoundaryEvent_1',
+        requiredProperty: [
+          'timeCycle',
+          'timeDuration'
+        ]
+      }
+    }
+  },
+  {
+    name: 'non-interrupting timer boundary event with time duration (invalid)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:task id="Task_1" />
+      <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="Task_1" cancelActivity="false">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:boundaryEvent>
+    `)),
+    report: {
+      id: 'BoundaryEvent_1',
+      message: 'Expression value of <foo> not allowed',
+      path: [
+        'eventDefinitions',
+        0,
+        'timeDuration'
+      ],
+      data: {
+        type: ERROR_TYPES.EXPRESSION_VALUE_NOT_ALLOWED,
+        node: 'bpmn:FormalExpression',
+        parentNode: 'BoundaryEvent_1',
+        property: 'timeDuration'
+      }
+    }
+  },
+
+  /**
+   * Start Event, Interrupting, Event Sub-Process
+   */
+  {
+    name: 'timer start event in event sub-process (no expression)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:subProcess id="SubProcess_1" triggeredByEvent="true">
+        <bpmn:startEvent id="StartEvent_1">
+          <bpmn:timerEventDefinition id="TimerEventDefinition_1" />
+        </bpmn:startEvent>
+      </bpmn:subProcess>
+    `)),
+    report: {
+      id: 'StartEvent_1',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeDate> or <timeDuration>',
+      path: [
+        'eventDefinitions',
+        0
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'TimerEventDefinition_1',
+        parentNode: 'StartEvent_1',
+        requiredProperty: [
+          'timeDate',
+          'timeDuration'
+        ]
+      }
+    }
+  },
+  {
+    name: 'timer start event in event sub-process (empty expression)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:subProcess id="SubProcess_1" triggeredByEvent="true">
+        <bpmn:startEvent id="StartEvent_1">
+          <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+            <bpmn:timeDate xsi:type="bpmn:tFormalExpression" />
+          </bpmn:timerEventDefinition>
+        </bpmn:startEvent>
+      </bpmn:subProcess>
+    `)),
+    report: {
+      id: 'StartEvent_1',
+      message: 'Property <timeDate> must have expression value',
+      path: [
+        'eventDefinitions',
+        0,
+        'timeDate'
+      ],
+      data: {
+        type: ERROR_TYPES.EXPRESSION_REQUIRED,
+        node: 'bpmn:FormalExpression',
+        parentNode: 'StartEvent_1',
+        property: 'timeDate'
+      }
+    }
+  },
+  {
+    name: 'timer start event with time cycle in event sub-process (not allowed)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:subProcess id="SubProcess_1" triggeredByEvent="true">
+        <bpmn:startEvent id="StartEvent_1">
+          <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+            <bpmn:timeCycle xsi:type="bpmn:tFormalExpression" />
+          </bpmn:timerEventDefinition>
+        </bpmn:startEvent>
+      </bpmn:subProcess>
+    `)),
+    report: {
+      id: 'StartEvent_1',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeDate> or <timeDuration>',
+      path: [
+        'eventDefinitions',
+        0
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'TimerEventDefinition_1',
+        parentNode: 'StartEvent_1',
+        requiredProperty: [
+          'timeDate',
+          'timeDuration'
+        ]
+      }
+    }
+  },
+  {
+    name: 'timer start event with time date in event sub-process (invalid)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:subProcess id="SubProcess_1" triggeredByEvent="true">
+        <bpmn:startEvent id="StartEvent_1">
+          <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+            <bpmn:timeDate xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDate>
+          </bpmn:timerEventDefinition>
+        </bpmn:startEvent>
+      </bpmn:subProcess>
+    `)),
+    report: {
+      id: 'StartEvent_1',
+      message: 'Expression value of <foo> not allowed',
       path: [
         'eventDefinitions',
         0,
@@ -352,12 +985,218 @@ const invalid = [
       data: {
         type: ERROR_TYPES.EXPRESSION_VALUE_NOT_ALLOWED,
         node: 'bpmn:FormalExpression',
-        parentNode: 'Event',
+        parentNode: 'StartEvent_1',
         property: 'timeDate'
+      }
+    }
+  },
+  {
+    name: 'timer start event with time duration in event sub-process (invalid)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:subProcess id="SubProcess_1" triggeredByEvent="true">
+        <bpmn:startEvent id="StartEvent_1">
+          <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </bpmn:startEvent>
+      </bpmn:subProcess>
+    `)),
+    report: {
+      id: 'StartEvent_1',
+      message: 'Expression value of <foo> not allowed',
+      path: [
+        'eventDefinitions',
+        0,
+        'timeDuration'
+      ],
+      data: {
+        type: ERROR_TYPES.EXPRESSION_VALUE_NOT_ALLOWED,
+        node: 'bpmn:FormalExpression',
+        parentNode: 'StartEvent_1',
+        property: 'timeDuration'
+      }
+    }
+  },
+
+  /**
+   * Start Event, Non-Interrupting, Event Sub-Process
+   */
+  {
+    name: 'non-interrupting timer start event in event sub-process (no expression)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:subProcess id="SubProcess_1" triggeredByEvent="true">
+        <bpmn:startEvent id="StartEvent_1" isInterrupting="false">
+          <bpmn:timerEventDefinition id="TimerEventDefinition_1" />
+        </bpmn:startEvent>
+      </bpmn:subProcess>
+    `)),
+    report: {
+      id: 'StartEvent_1',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeCycle>, <timeDate> or <timeDuration>',
+      path: [
+        'eventDefinitions',
+        0
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'TimerEventDefinition_1',
+        parentNode: 'StartEvent_1',
+        requiredProperty: [
+          'timeCycle',
+          'timeDate',
+          'timeDuration'
+        ]
+      }
+    }
+  },
+  {
+    name: 'non-interrupting timer start event in event sub-process (empty expression)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:subProcess id="SubProcess_1" triggeredByEvent="true">
+        <bpmn:startEvent id="StartEvent_1" isInterrupting="false">
+          <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+            <bpmn:timeDate xsi:type="bpmn:tFormalExpression" />
+          </bpmn:timerEventDefinition>
+        </bpmn:startEvent>
+      </bpmn:subProcess>
+    `)),
+    report: {
+      id: 'StartEvent_1',
+      message: 'Property <timeDate> must have expression value',
+      path: [
+        'eventDefinitions',
+        0,
+        'timeDate'
+      ],
+      data: {
+        type: ERROR_TYPES.EXPRESSION_REQUIRED,
+        node: 'bpmn:FormalExpression',
+        parentNode: 'StartEvent_1',
+        property: 'timeDate'
+      }
+    }
+  },
+  {
+    name: 'non-interrupting timer start event with time cycle in event sub-process (invalid)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:subProcess id="SubProcess_1" triggeredByEvent="true">
+        <bpmn:startEvent id="StartEvent_1" isInterrupting="false">
+          <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+            <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">foo</bpmn:timeCycle>
+          </bpmn:timerEventDefinition>
+        </bpmn:startEvent>
+      </bpmn:subProcess>
+    `)),
+    report: {
+      id: 'StartEvent_1',
+      message: 'Expression value of <foo> not allowed',
+      path: [
+        'eventDefinitions',
+        0,
+        'timeCycle'
+      ],
+      data: {
+        type: ERROR_TYPES.EXPRESSION_VALUE_NOT_ALLOWED,
+        node: 'bpmn:FormalExpression',
+        parentNode: 'StartEvent_1',
+        property: 'timeCycle'
+      }
+    }
+  },
+  {
+    name: 'non-interrupting timer start event with time date in event sub-process (invalid)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:subProcess id="SubProcess_1" triggeredByEvent="true">
+        <bpmn:startEvent id="StartEvent_1" isInterrupting="false">
+          <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+            <bpmn:timeDate xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDate>
+          </bpmn:timerEventDefinition>
+        </bpmn:startEvent>
+      </bpmn:subProcess>
+    `)),
+    report: {
+      id: 'StartEvent_1',
+      message: 'Expression value of <foo> not allowed',
+      path: [
+        'eventDefinitions',
+        0,
+        'timeDate'
+      ],
+      data: {
+        type: ERROR_TYPES.EXPRESSION_VALUE_NOT_ALLOWED,
+        node: 'bpmn:FormalExpression',
+        parentNode: 'StartEvent_1',
+        property: 'timeDate'
+      }
+    }
+  },
+  {
+    name: 'non-interrupting timer start event with time duration in event sub-process (invalid)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:subProcess id="SubProcess_1" triggeredByEvent="true">
+        <bpmn:startEvent id="StartEvent_1" isInterrupting="false">
+          <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+            <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">foo</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </bpmn:startEvent>
+      </bpmn:subProcess>
+    `)),
+    report: {
+      id: 'StartEvent_1',
+      message: 'Expression value of <foo> not allowed',
+      path: [
+        'eventDefinitions',
+        0,
+        'timeDuration'
+      ],
+      data: {
+        type: ERROR_TYPES.EXPRESSION_VALUE_NOT_ALLOWED,
+        node: 'bpmn:FormalExpression',
+        parentNode: 'StartEvent_1',
+        property: 'timeDuration'
+      }
+    }
+  },
+
+  /**
+   * CRON Expressions
+   */
+  {
+    name: 'timer start event with time cycle (CRON expression with Camunda < 8.1)',
+    config: { version: '1.0' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:startEvent id="StartEvent_1">
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1">
+          <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">${ EXPRESSION_VALUES.CRON.EXPRESSION }</bpmn:timeCycle>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    `)),
+    report: {
+      id: 'StartEvent_1',
+      message: 'Expression value of <0 0 9-17 * * MON-FRI> only allowed by Camunda Platform 8.1',
+      path: [
+        'eventDefinitions',
+        0,
+        'timeCycle'
+      ],
+      data: {
+        type: ERROR_TYPES.EXPRESSION_VALUE_NOT_ALLOWED,
+        node: 'bpmn:FormalExpression',
+        parentNode: 'StartEvent_1',
+        property: 'timeCycle',
+        allowedVersion: '8.1'
       }
     }
   }
 ];
+
+// TODO: validate CRON in Camunda Platform < 8.1 fails
 
 RuleTester.verify('timer', rule, {
   valid,

--- a/test/camunda-cloud/timer.spec.js
+++ b/test/camunda-cloud/timer.spec.js
@@ -155,17 +155,18 @@ const invalid = [
     `)),
     report: {
       id: 'Event',
-      message: 'Element of type <bpmn:TimerEventDefinition> must have property <timeDuration>',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeDuration>',
       path: [
         'eventDefinitions',
-        0,
-        'timeDuration'
+        0
       ],
       data: {
         type: ERROR_TYPES.PROPERTY_REQUIRED,
         node: 'TimerEventDefinition',
         parentNode: 'Event',
-        requiredProperty: 'timeDuration'
+        requiredProperty: [
+          'timeDuration'
+        ]
       }
     }
   },
@@ -180,17 +181,18 @@ const invalid = [
     `)),
     report: {
       id: 'Event',
-      message: 'Element of type <bpmn:TimerEventDefinition> must have property <timeDuration>',
+      message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeDuration>',
       path: [
         'eventDefinitions',
-        0,
-        'timeDuration'
+        0
       ],
       data: {
         type: ERROR_TYPES.PROPERTY_REQUIRED,
         node: 'TimerEventDefinition',
         parentNode: 'Event',
-        requiredProperty: 'timeDuration'
+        requiredProperty: [
+          'timeDuration'
+        ]
       }
     }
   },

--- a/test/utils/element.spec.js
+++ b/test/utils/element.spec.js
@@ -2,7 +2,7 @@ const { expect } = require('chai');
 
 const {
   ERROR_TYPES,
-  formatTypes,
+  formatNames,
   hasDuplicatedPropertyValues,
   hasExpression,
   hasExtensionElement,
@@ -17,7 +17,7 @@ const { createElement } = require('../helper');
 
 describe('utils/element', function() {
 
-  describe('#formatTypes', function() {
+  describe('#formatNames', function() {
 
     it('one', function() {
 
@@ -25,7 +25,7 @@ describe('utils/element', function() {
       const types = [ 'foo' ];
 
       // then
-      expect(formatTypes(types)).to.eql('<foo>');
+      expect(formatNames(types)).to.eql('<foo>');
     });
 
 
@@ -35,7 +35,7 @@ describe('utils/element', function() {
       const types = [ 'foo', 'bar' ];
 
       // then
-      expect(formatTypes(types)).to.eql('<foo> and <bar>');
+      expect(formatNames(types)).to.eql('<foo> and <bar>');
     });
 
 
@@ -45,7 +45,7 @@ describe('utils/element', function() {
       const types = [ 'foo', 'bar' ];
 
       // then
-      expect(formatTypes(types, true)).to.eql('<foo> or <bar>');
+      expect(formatNames(types, true)).to.eql('<foo> or <bar>');
     });
 
 
@@ -55,7 +55,7 @@ describe('utils/element', function() {
       const types = [ 'foo', 'bar', 'baz' ];
 
       // then
-      expect(formatTypes(types)).to.eql('<foo>, <bar> and <baz>');
+      expect(formatNames(types)).to.eql('<foo>, <bar> and <baz>');
     });
 
   });
@@ -508,7 +508,7 @@ describe('utils/element', function() {
       // then
       expect(errors).to.eql([
         {
-          message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeCycle> or <timeDuration>',
+          message: 'Element of type <bpmn:TimerEventDefinition> must have property <timeCycle> or <timeDuration>',
           path: null,
           data: {
             type: ERROR_TYPES.PROPERTY_REQUIRED,
@@ -538,7 +538,7 @@ describe('utils/element', function() {
       // then
       expect(errors).to.eql([
         {
-          message: 'Element of type <bpmn:TimerEventDefinition> must have one property of type <timeCycle> or <timeDuration>',
+          message: 'Element of type <bpmn:TimerEventDefinition> must have property <timeCycle> or <timeDuration>',
           path: null,
           data: {
             type: ERROR_TYPES.PROPERTY_REQUIRED,


### PR DESCRIPTION
* [x] validate time expression type is supported
* [x] refactor `timer` tests to be able to make changes with confidence
* [x] support time date expression type for timer intermediate catch and boundary events in Camunda 8.3

### Time Expression Support

* 💚 supported by Zeebe 
* 💙 supported by Zeebe, cannot be modeled
* 🧡 supported by Zeebe 8.3 
* ❤️ not supported

![timer-expression-support](https://github.com/camunda/bpmnlint-plugin-camunda-compat/assets/7633572/91bc16b3-c228-4fe4-a697-f3c55362720d)


Related to https://github.com/camunda/camunda-modeler/issues/3516