### PR TITLE
feat: remove support for converging inclusive gateway in 8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmnlint-plugin-camunda-compat](https://github.com/camun
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: remove support converging inclusive gateway in Camunda 8.3
+
 ## 2.2.0
 
 * `FEAT`: support converging inclusive gateway in Camunda 8.3 ([#111](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/111))

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ const camundaCloud82Rules = withConfig({
 }, { version: '8.2' });
 
 const camundaCloud83Rules = withConfig({
-  ...omit(camundaCloud82Rules, 'inclusive-gateway'),
+  ...camundaCloud82Rules,
   'signal-reference': 'error'
 }, { version: '8.3' });
 

--- a/test/config/configs.spec.js
+++ b/test/config/configs.spec.js
@@ -190,6 +190,7 @@ describe('configs', function() {
     'event-based-gateway-target': [ 'error', { version: '8.3' } ],
     'executable-process': [ 'error', { version: '8.3' } ],
     'feel': [ 'error', { version: '8.3' } ],
+    'inclusive-gateway': [ 'error', { version: '8.3' } ],
     'loop-characteristics': [ 'error', { version: '8.3' } ],
     'message-reference': [ 'error', { version: '8.3' } ],
     'no-expression': [ 'error', { version: '8.3' } ],


### PR DESCRIPTION
This reverts commit 7ed5bb3d93abeb596232d42fb6d3c4244723933a. 
Related to https://github.com/camunda/camunda-modeler/issues/3747