### PR TITLE
fix(link-event): fix check for link event definition

### DIFF
--- a/rules/camunda-cloud/link-event.js
+++ b/rules/camunda-cloud/link-event.js
@@ -89,7 +89,7 @@ module.exports = skipInNonExecutableProcess(function() {
 
     // check for missing link catch & throw event names
     if (isLinkEvent(node)) {
-      const linkEventDefinition = getEventDefinition(node, 'bpmn:LinkEventDefinition');
+      const linkEventDefinition = getEventDefinition(node);
 
       const errors = hasProperties(linkEventDefinition, {
         name: {
@@ -109,15 +109,19 @@ module.exports = skipInNonExecutableProcess(function() {
 });
 
 function isLinkEvent(element) {
+  const eventDefinition = getEventDefinition(element);
+
   return isAny(element, [
     'bpmn:IntermediateCatchEvent',
     'bpmn:IntermediateThrowEvent'
-  ]) && getEventDefinition(element, 'bpmn:LinkEventDefinition');
+  ]) && eventDefinition && is(eventDefinition, 'bpmn:LinkEventDefinition');
 }
 
 function isLinkCatchEvent(element) {
+  const eventDefinition = getEventDefinition(element);
+
   return is(element, 'bpmn:IntermediateCatchEvent')
-    && getEventDefinition(element, 'bpmn:LinkEventDefinition');
+    && eventDefinition && is(eventDefinition, 'bpmn:LinkEventDefinition');
 }
 
 function getLinkCatchEvents(flowElementsContainer) {

--- a/test/camunda-cloud/link-event.spec.js
+++ b/test/camunda-cloud/link-event.spec.js
@@ -12,6 +12,14 @@ const { ERROR_TYPES } = require('../../rules/utils/element');
 
 const valid = [
   {
+    name: 'escalation event',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_1">
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_1" />
+      </bpmn:intermediateCatchEvent>
+    `))
+  },
+  {
     name: 'link catch events',
     moddleElement: createModdle(createProcess(`
       <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_1">


### PR DESCRIPTION
Turns out `getEventDefinition` returns the first event definition and doesn't filter by type. Should be fixed now. 😅 