### PR TITLE
Allow spaces and `-` in secret identifiers

### DIFF
--- a/rules/camunda-cloud/secrets.js
+++ b/rules/camunda-cloud/secrets.js
@@ -115,5 +115,5 @@ function isValidSecret(value) {
   return !value
     || !isString(value)
     || !value.includes('secrets.')
-    || /{{secrets\.[a-zA-Z0-9_]+}}/.test(value);
+    || /{{\s*secrets\.[\w-]+\s*}}/.test(value);
 }

--- a/test/camunda-cloud/secrets.spec.js
+++ b/test/camunda-cloud/secrets.spec.js
@@ -51,6 +51,30 @@ const valid = [
         </bpmn:extensionElements>
       </bpmn:intermediateCatchEvent>
     `))
+  },
+  {
+    name: 'property with valid value with dashes',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_1">
+        <bpmn:extensionElements>
+          <zeebe:properties>
+            <zeebe:property name="bar" value="{{secrets.FOO-BAR}}" />
+          </zeebe:properties>
+        </bpmn:extensionElements>
+      </bpmn:intermediateCatchEvent>
+    `))
+  },
+  {
+    name: 'property with valid value with spaces',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_1">
+        <bpmn:extensionElements>
+          <zeebe:properties>
+            <zeebe:property name="bar" value="{{  secrets.FOO_BAR   }}" />
+          </zeebe:properties>
+        </bpmn:extensionElements>
+      </bpmn:intermediateCatchEvent>
+    `))
   }
 ];
 
@@ -131,6 +155,38 @@ const invalid = [
         <bpmn:extensionElements>
           <zeebe:properties>
             <zeebe:property name="bar" value="secrets.FOO" />
+          </zeebe:properties>
+        </bpmn:extensionElements>
+      </bpmn:intermediateCatchEvent>
+    `)),
+    report: [
+      {
+        id: 'IntermediateCatchEvent_1',
+        message: 'Property <value> uses deprecated secret expression format',
+        path: [
+          'extensionElements',
+          'values',
+          0,
+          'properties',
+          0,
+          'value'
+        ],
+        data: {
+          type: ERROR_TYPES.SECRET_EXPRESSION_FORMAT_DEPRECATED,
+          node: 'zeebe:Property',
+          parentNode: 'IntermediateCatchEvent_1',
+          property: 'value'
+        }
+      }
+    ]
+  },
+  {
+    name: 'property with invalid value with space',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_1">
+        <bpmn:extensionElements>
+          <zeebe:properties>
+            <zeebe:property name="bar" value="{{secrets.FOO FOO}}" />
           </zeebe:properties>
         </bpmn:extensionElements>
       </bpmn:intermediateCatchEvent>


### PR DESCRIPTION
Corrected secrets.js regex pattern;

Links to issue : https://camunda.slack.com/archives/C034N0E5YCX/p1696966815142039
