### PR TITLE
deps: integrate `@bpmn-io/feel-lint@1.2.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.14.0",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/feel-lint": "^1.0.0",
+        "@bpmn-io/feel-lint": "^1.2.0",
         "@bpmn-io/moddle-utils": "^0.2.1",
         "bpmnlint-utils": "^1.0.2",
         "min-dash": "^4.1.1",
@@ -42,12 +42,15 @@
       }
     },
     "node_modules/@bpmn-io/feel-lint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-1.0.0.tgz",
-      "integrity": "sha512-wCA5tsxOWejOJRi6if66mayyI2pWgohCp9NctOH+3fBnsCv/I4dlqnwGw4f8S8EnrFFyRJY5IrRBmQeUQ8WBmw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-1.2.0.tgz",
+      "integrity": "sha512-nsvAYxiSbWyjpd3gNnJd+60aTWrZvngYnZfe+GpmkM/pQoOgtF17GhD/p4fgaeAd/uUP3q9sO6EWRX+OU/p9dw==",
       "dependencies": {
         "@codemirror/language": "^6.8.0",
-        "lezer-feel": "^1.0.1"
+        "lezer-feel": "^1.2.3"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@bpmn-io/moddle-utils": {
@@ -189,9 +192,9 @@
       }
     },
     "node_modules/@lezer/lr": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.10.tgz",
-      "integrity": "sha512-BZfVvf7Re5BIwJHlZXbJn9L8lus5EonxQghyn+ih8Wl36XMFBPTXC0KM0IdUtj9w/diPHsKlXVgL+AlX2jYJ0Q==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.0.tgz",
+      "integrity": "sha512-Wst46p51km8gH0ZUmeNrtpRYmdlRHUpN1DQd3GFAyKANi8WVz8c2jHYTf1CVScFaCjQw1iO3ZZdqGDxQPRErTg==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
@@ -1858,12 +1861,15 @@
       }
     },
     "node_modules/lezer-feel": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-1.0.2.tgz",
-      "integrity": "sha512-WEqRVhYZNOr6+aTWfS2CLVX1ebS1KeQjTeVQVgzXkGNC0AqmFWcRwEgAGm3FHKE66cxj3RPKx7T+ofr6FzmJjQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-1.2.4.tgz",
+      "integrity": "sha512-ASi0yQd6A8a2xeNF+b5Sr7fPcko236i81q9yzMbzi81lKc93CZ3SRR7rgCZgHMVifVthofZRoNczR5lenCRmlw==",
       "dependencies": {
         "@lezer/highlight": "^1.1.6",
-        "@lezer/lr": "^1.3.9"
+        "@lezer/lr": "^1.3.12"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/locate-path": {
@@ -3137,12 +3143,12 @@
       "dev": true
     },
     "@bpmn-io/feel-lint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-1.0.0.tgz",
-      "integrity": "sha512-wCA5tsxOWejOJRi6if66mayyI2pWgohCp9NctOH+3fBnsCv/I4dlqnwGw4f8S8EnrFFyRJY5IrRBmQeUQ8WBmw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-1.2.0.tgz",
+      "integrity": "sha512-nsvAYxiSbWyjpd3gNnJd+60aTWrZvngYnZfe+GpmkM/pQoOgtF17GhD/p4fgaeAd/uUP3q9sO6EWRX+OU/p9dw==",
       "requires": {
         "@codemirror/language": "^6.8.0",
-        "lezer-feel": "^1.0.1"
+        "lezer-feel": "^1.2.3"
       }
     },
     "@bpmn-io/moddle-utils": {
@@ -3256,9 +3262,9 @@
       }
     },
     "@lezer/lr": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.10.tgz",
-      "integrity": "sha512-BZfVvf7Re5BIwJHlZXbJn9L8lus5EonxQghyn+ih8Wl36XMFBPTXC0KM0IdUtj9w/diPHsKlXVgL+AlX2jYJ0Q==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.0.tgz",
+      "integrity": "sha512-Wst46p51km8gH0ZUmeNrtpRYmdlRHUpN1DQd3GFAyKANi8WVz8c2jHYTf1CVScFaCjQw1iO3ZZdqGDxQPRErTg==",
       "requires": {
         "@lezer/common": "^1.0.0"
       }
@@ -4494,12 +4500,12 @@
       }
     },
     "lezer-feel": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-1.0.2.tgz",
-      "integrity": "sha512-WEqRVhYZNOr6+aTWfS2CLVX1ebS1KeQjTeVQVgzXkGNC0AqmFWcRwEgAGm3FHKE66cxj3RPKx7T+ofr6FzmJjQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-1.2.4.tgz",
+      "integrity": "sha512-ASi0yQd6A8a2xeNF+b5Sr7fPcko236i81q9yzMbzi81lKc93CZ3SRR7rgCZgHMVifVthofZRoNczR5lenCRmlw==",
       "requires": {
         "@lezer/highlight": "^1.1.6",
-        "@lezer/lr": "^1.3.9"
+        "@lezer/lr": "^1.3.12"
       }
     },
     "locate-path": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "zeebe-bpmn-moddle": "^1.0.0"
   },
   "dependencies": {
-    "@bpmn-io/feel-lint": "^1.0.0",
+    "@bpmn-io/feel-lint": "^1.2.0",
     "@bpmn-io/moddle-utils": "^0.2.1",
     "bpmnlint-utils": "^1.0.2",
     "min-dash": "^4.1.1",

--- a/rules/camunda-cloud/feel.js
+++ b/rules/camunda-cloud/feel.js
@@ -35,7 +35,7 @@ module.exports = skipInNonExecutableProcess(function() {
         const lintErrors = lintExpression(propertyValue.substring(1));
 
         // syntax error
-        if (lintErrors.find(({ type }) => type === 'syntaxError')) {
+        if (lintErrors.find(({ type }) => type === 'Syntax Error')) {
           const path = getPath(node, parentNode);
 
           errors.push(


### PR DESCRIPTION
This PR integrates latest FEEL linter changes and restores the 1.1.0 Behavior of overriding the supplied error message. The Detailes message will be shown in the editor:

![image](https://github.com/camunda/bpmnlint-plugin-camunda-compat/assets/21984219/93efc27e-bb8e-407f-bd54-231eebfd3682)

related to https://github.com/camunda/camunda-modeler/issues/3991