### PR TITLE
chore(no-loop): use BFS to find loops

### DIFF
--- a/rules/camunda-cloud/no-loop.js
+++ b/rules/camunda-cloud/no-loop.js
@@ -38,7 +38,7 @@ module.exports = skipInNonExecutableProcess(function() {
       return;
     }
 
-    // Create subgrapg of nodes that can be part of an infinite loop
+    // Create subgraph of nodes that can be part of an infinite loop
     const relevantNodes = getFlowElements(node)
       .filter(flowElement => {
         return isAnyExactly(flowElement, LOOP_ELEMENT_TYPES);

--- a/rules/camunda-cloud/no-loop.js
+++ b/rules/camunda-cloud/no-loop.js
@@ -53,7 +53,7 @@ module.exports = skipInNonExecutableProcess(function() {
     // Any loop found within the simplified graph is a valid loop, as all Vertices in the graph are `LOOP_REQUIRED_ELEMENT_TYPES`.
     const minimalGraph = simplifyGraph(relevantNodes);
 
-    // 3. Use BFS to find loops in the simplified Graph.
+    // 3. Use breadth-first search to find loops in the simplified Graph.
     const errors = findLoops(minimalGraph, node);
 
     if (errors) {
@@ -75,7 +75,7 @@ module.exports = skipInNonExecutableProcess(function() {
 
 /**
  * Simplifies the graph by removing all non-`LOOP_REQUIRED_ELEMENT_TYPES` elements and connecting incoming and outgoing nodes directly.
- * Annotates the edges with the original path. Uses BFS to find paths.
+ * Annotates the edges with the original path. Uses breadth-first search to find paths.
  *
  * @param {Array<ModdleElement>} flowElements
  * @returns {Map<ModdleElement, GraphNode>}
@@ -85,7 +85,7 @@ function simplifyGraph(flowElements) {
   // Transform Array<ModdleElement> into Map<ModdleElement, GraphNode>
   const graph = elementsToGraph(flowElements);
 
-  BFS(graph, (node) => {
+  breadthFirstSearch(graph, (node) => {
     const { element, outgoing } = node;
 
     // Remove non-required element and connect incoming and outgoing nodes directly
@@ -116,7 +116,7 @@ function simplifyGraph(flowElements) {
 
 
 /**
- * Uses BFS to find loops in the graph and generate errors.
+ * Uses breadth-first search to find loops in the graph and generate errors.
  *
  * @param {Map<ModdleElement, GraphNode>} graph The simplified graph containing only required elements
  * @param {ModdleElement} root used for reporting the errors
@@ -125,8 +125,8 @@ function simplifyGraph(flowElements) {
 function findLoops(graph, root) {
   const errors = [];
 
-  // Traverse graph using BFS, remembering the path. If we find a loop, report it.
-  BFS(graph, (node) => {
+  // Traverse graph using breadth-first search, remembering the path. If we find a loop, report it.
+  breadthFirstSearch(graph, (node) => {
     const { element, outgoing, path = [] } = node;
 
     const nextElements = [ ];
@@ -285,12 +285,12 @@ function connectNodes(graph, node) {
 }
 
 /**
- * Iterates over all nodes in the graph using BFS.
+ * Iterates over all nodes in the graph using breadth-first search.
  *
  * @param {Map<ModdleElement, GraphNode>} graph
  * @param {Function} iterationCallback
  */
-function BFS(graph, iterationCallback) {
+function breadthFirstSearch(graph, iterationCallback) {
   const unvisited = new Set(graph.values());
 
   while (unvisited.size) {

--- a/test/camunda-cloud/no-loop.spec.js
+++ b/test/camunda-cloud/no-loop.spec.js
@@ -160,16 +160,16 @@ const invalid = [
     `)),
     report: {
       id: 'Process_1',
-      message: 'Loop detected: ExclusiveGateway_1 -> Task_1 -> ExclusiveGateway_2 -> ExclusiveGateway_1',
+      message: 'Loop detected: Task_1 -> ExclusiveGateway_2 -> ExclusiveGateway_1 -> Task_1',
       path: null,
       data: {
         type: ERROR_TYPES.LOOP_NOT_ALLOWED,
         node: 'Process_1',
         parentNode: null,
         elements: [
-          'ExclusiveGateway_1',
           'Task_1',
-          'ExclusiveGateway_2'
+          'ExclusiveGateway_2',
+          'ExclusiveGateway_1'
         ]
       }
     }
@@ -217,19 +217,19 @@ const invalid = [
     `)),
     report: {
       id: 'Process_1',
-      message: 'Loop detected: ExclusiveGateway_1 -> SubProcess_1 -> StartEvent_2 -> Task_1 -> EndEvent_2 -> ExclusiveGateway_2 -> ExclusiveGateway_1',
+      message: 'Loop detected: Task_1 -> EndEvent_2 -> ExclusiveGateway_2 -> ExclusiveGateway_1 -> SubProcess_1 -> StartEvent_2 -> Task_1',
       path: null,
       data: {
         type: ERROR_TYPES.LOOP_NOT_ALLOWED,
         node: 'Process_1',
         parentNode: null,
         elements: [
+          'Task_1',
+          'EndEvent_2',
+          'ExclusiveGateway_2',
           'ExclusiveGateway_1',
           'SubProcess_1',
           'StartEvent_2',
-          'Task_1',
-          'EndEvent_2',
-          'ExclusiveGateway_2'
         ]
       }
     }
@@ -262,19 +262,150 @@ const invalid = [
     `)),
     report: {
       id: 'Process_1',
-      message: 'Loop detected: StartEvent_1 -> ManualTask_1 -> CallActivity_1 -> StartEvent_1',
+      message: 'Loop detected: ManualTask_1 -> CallActivity_1 -> StartEvent_1 -> ManualTask_1',
       path: null,
       data: {
         type: ERROR_TYPES.LOOP_NOT_ALLOWED,
         node: 'Process_1',
         parentNode: null,
         elements: [
-          'StartEvent_1',
           'ManualTask_1',
-          'CallActivity_1'
+          'CallActivity_1',
+          'StartEvent_1',
         ]
       }
     }
+  },
+  {
+    name: '2 loops, shortest ignored',
+    moddleElement: createModdle(createDefinitions(`
+      <bpmn:process id="Process_1" isExecutable="true">
+        <bpmn:task id="Task_1">
+          <bpmn:outgoing>Flow_0ytl4pq</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:exclusiveGateway id="Gateway_1">
+          <bpmn:incoming>Flow_0ytl4pq</bpmn:incoming>
+          <bpmn:incoming>Flow_0wqka6l</bpmn:incoming>
+          <bpmn:outgoing>Flow_1u6nw5j</bpmn:outgoing>
+          <bpmn:outgoing>Flow_12khikv</bpmn:outgoing>
+        </bpmn:exclusiveGateway>
+        <bpmn:sequenceFlow id="Flow_0ytl4pq" sourceRef="Task_1" targetRef="Gateway_1" />
+        <bpmn:exclusiveGateway id="Gateway_2">
+          <bpmn:incoming>Flow_1u6nw5j</bpmn:incoming>
+          <bpmn:incoming>Flow_0uw5w0n</bpmn:incoming>
+          <bpmn:outgoing>Flow_0wqka6l</bpmn:outgoing>
+        </bpmn:exclusiveGateway>
+        <bpmn:sequenceFlow id="Flow_1u6nw5j" sourceRef="Gateway_1" targetRef="Gateway_2" />
+        <bpmn:task id="Task_2">
+          <bpmn:incoming>Flow_12khikv</bpmn:incoming>
+          <bpmn:outgoing>Flow_0jtp70h</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:sequenceFlow id="Flow_12khikv" sourceRef="Gateway_1" targetRef="Task_2" />
+        <bpmn:task id="Task_3">
+          <bpmn:incoming>Flow_0jtp70h</bpmn:incoming>
+          <bpmn:outgoing>Flow_0uw5w0n</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:sequenceFlow id="Flow_0jtp70h" sourceRef="Task_2" targetRef="Task_3" />
+        <bpmn:sequenceFlow id="Flow_0uw5w0n" sourceRef="Task_3" targetRef="Gateway_2" />
+        <bpmn:sequenceFlow id="Flow_0wqka6l" sourceRef="Gateway_2" targetRef="Gateway_1" />
+      </bpmn:process>
+    `)),
+    report: {
+      id: 'Process_1',
+      message: 'Loop detected: Task_2 -> Task_3 -> Gateway_2 -> Gateway_1 -> Task_2',
+      path: null,
+      data: {
+        type: ERROR_TYPES.LOOP_NOT_ALLOWED,
+        node: 'Process_1',
+        parentNode: null,
+        elements: [
+          'Task_2',
+          'Task_3',
+          'Gateway_2',
+          'Gateway_1'
+        ]
+      }
+    }
+  },
+  {
+    name: 'Single element loop',
+    moddleElement: createModdle(createDefinitions(`
+      <bpmn:process id="Process_1" isExecutable="true">
+        <bpmn:task id="Task_1">
+          <bpmn:incoming>Flow_18rglkr</bpmn:incoming>
+          <bpmn:outgoing>Flow_18rglkr</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:sequenceFlow id="Flow_18rglkr" sourceRef="Task_1" targetRef="Task_1" />
+      </bpmn:process>
+    `)),
+    report: {
+      id: 'Process_1',
+      message: 'Loop detected: Task_1 -> Task_1',
+      path: null,
+      data: {
+        type: ERROR_TYPES.LOOP_NOT_ALLOWED,
+        node: 'Process_1',
+        parentNode: null,
+        elements: [
+          'Task_1'
+        ]
+      }
+    }
+  },
+  {
+    name: 'Multiple Loops',
+    moddleElement: createModdle(createDefinitions(`
+      <bpmn:process id="Process_1" isExecutable="true">
+        <bpmn:task id="Task_1">
+          <bpmn:incoming>Flow_18rglkr</bpmn:incoming>
+          <bpmn:incoming>Flow_0xockgw</bpmn:incoming>
+          <bpmn:outgoing>Flow_18rglkr</bpmn:outgoing>
+          <bpmn:outgoing>Flow_0mxutgr</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:sequenceFlow id="Flow_18rglkr" sourceRef="Task_1" targetRef="Task_1" />
+        <bpmn:task id="Task_2">
+          <bpmn:incoming>Flow_0mxutgr</bpmn:incoming>
+          <bpmn:outgoing>Flow_12x9u0e</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:sequenceFlow id="Flow_0mxutgr" sourceRef="Task_1" targetRef="Task_2" />
+        <bpmn:task id="Task_3">
+          <bpmn:incoming>Flow_12x9u0e</bpmn:incoming>
+          <bpmn:outgoing>Flow_0xockgw</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:sequenceFlow id="Flow_12x9u0e" sourceRef="Task_2" targetRef="Task_3" />
+        <bpmn:sequenceFlow id="Flow_0xockgw" sourceRef="Task_3" targetRef="Task_1" />
+      </bpmn:process>
+    `)),
+    report: [
+      {
+        id: 'Process_1',
+        message: 'Loop detected: Task_1 -> Task_1',
+        path: null,
+        data: {
+          type: ERROR_TYPES.LOOP_NOT_ALLOWED,
+          node: 'Process_1',
+          parentNode: null,
+          elements: [
+            'Task_1'
+          ]
+        }
+      },
+      {
+        id: 'Process_1',
+        message: 'Loop detected: Task_1 -> Task_2 -> Task_3 -> Task_1',
+        path: null,
+        data: {
+          type: ERROR_TYPES.LOOP_NOT_ALLOWED,
+          node: 'Process_1',
+          parentNode: null,
+          elements: [
+            'Task_1',
+            'Task_2',
+            'Task_3'
+          ]
+        }
+      }
+    ]
   }
 ];
 


### PR DESCRIPTION
This uses [breadth-first search](https://en.wikipedia.org/wiki/Breadth-first_search), [cf. detailed rationale](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/165#issuecomment-2196882155). As a result it reduces the time needed for traversing the diagram from [SUPPORT-22488](https://jira.camunda.com/browse/SUPPORT-22488) from ~1 minute to 6ms. 

Related to https://github.com/camunda/camunda-modeler/issues/4401

![image](https://github.com/camunda/bpmnlint-plugin-camunda-compat/assets/21984219/5bb01858-fd59-4ba5-8453-62d6571601f1)

Try it out with 
```
npx @bpmn-io/sr camunda/linting -l camunda/bpmnlint-plugin-camunda-compat#make-loop-detection-more-perfomant
```