### PR TITLE
chore(no-loop): use `Array.from` instead of spread operator

### DIFF
--- a/rules/camunda-cloud/no-loop.js
+++ b/rules/camunda-cloud/no-loop.js
@@ -93,7 +93,7 @@ function simplifyGraph(flowElements) {
       connectNodes(graph, node);
     }
 
-    return [ ...outgoing.keys() ].map(key => graph.get(key));
+    return Array.from(outgoing.keys(), key => graph.get(key));
   });
 
   // Clean up all references to removed elements


### PR DESCRIPTION
This is just a code-style change, related to the discussion here: https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/165#discussion_r1661077364