### PR TITLE
fix(no-version-tag): do not lint `zeebe:bindingType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to [bpmnlint-plugin-camunda-compat](https://github.com/camun
 
 ___Note:__ Yet to be released changes appear here._
 
+## 2.25.0
+
+* `FEAT`: add `no-version-tag` rule ([#172](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/172))
+* `DEPS`: bump zeebe-bpmn-moddle@1.6.0
+
 ## 2.24.0
 
 * `FEAT`: add `no-priority-definition` and `priority-definition` rules ([#170](https://github.com/camunda/bpmnlint-plugin-camunda-compat/issues/170))

--- a/rules/camunda-cloud/no-version-tag.js
+++ b/rules/camunda-cloud/no-version-tag.js
@@ -31,20 +31,7 @@ module.exports = skipInNonExecutableProcess(function() {
     }
 
     if (extensionElement) {
-      let errors = hasProperties(extensionElement, {
-        bindingType: {
-          allowed: (value) => value !== 'versionTag',
-          allowedVersion
-        }
-      }, node);
-
-      if (errors && errors.length) {
-        reportErrors(node, reporter, errors);
-
-        return;
-      }
-
-      errors = hasProperties(extensionElement, {
+      const errors = hasProperties(extensionElement, {
         versionTag: {
           allowed: false,
           allowedVersion

--- a/test/camunda-cloud/no-version-tag.spec.js
+++ b/test/camunda-cloud/no-version-tag.spec.js
@@ -118,7 +118,7 @@ const invalid = [
     }
   },
   {
-    name: 'business rule task (binding type)',
+    name: 'business rule task (version tag)',
     config: { version: '8.5' },
     moddleElement: createModdle(createProcess(`
       <bpmn:businessRuleTask id="BusinessRuleTask_1">
@@ -129,34 +129,6 @@ const invalid = [
     `)),
     report: {
       id: 'BusinessRuleTask_1',
-      message: 'Property value of <versionTag> only allowed by Camunda 8.6 or newer',
-      path: [
-        'extensionElements',
-        'values',
-        0,
-        'bindingType'
-      ],
-      data: {
-        type: ERROR_TYPES.PROPERTY_VALUE_NOT_ALLOWED,
-        node: 'zeebe:CalledDecision',
-        parentNode: 'BusinessRuleTask_1',
-        property: 'bindingType',
-        allowedVersion: '8.6'
-      }
-    }
-  },
-  {
-    name: 'business rule task (version tag)',
-    config: { version: '8.5' },
-    moddleElement: createModdle(createProcess(`
-      <bpmn:businessRuleTask id="BusinessRuleTask_1">
-        <bpmn:extensionElements>
-          <zeebe:calledDecision versionTag="v1.0.0" />
-        </bpmn:extensionElements>
-      </bpmn:businessRuleTask>
-    `)),
-    report: {
-      id: 'BusinessRuleTask_1',
       message: 'Property <versionTag> only allowed by Camunda 8.6 or newer',
       path: [
         'extensionElements',
@@ -169,34 +141,6 @@ const invalid = [
         node: 'zeebe:CalledDecision',
         parentNode: 'BusinessRuleTask_1',
         property: 'versionTag',
-        allowedVersion: '8.6'
-      }
-    }
-  },
-  {
-    name: 'call activity (binding type)',
-    config: { version: '8.5' },
-    moddleElement: createModdle(createProcess(`
-      <bpmn:callActivity id="CallActivity_1">
-        <bpmn:extensionElements>
-          <zeebe:calledElement bindingType="versionTag" versionTag="v1.0.0" />
-        </bpmn:extensionElements>
-      </bpmn:callActivity>
-    `)),
-    report: {
-      id: 'CallActivity_1',
-      message: 'Property value of <versionTag> only allowed by Camunda 8.6 or newer',
-      path: [
-        'extensionElements',
-        'values',
-        0,
-        'bindingType'
-      ],
-      data: {
-        type: ERROR_TYPES.PROPERTY_VALUE_NOT_ALLOWED,
-        node: 'zeebe:CalledElement',
-        parentNode: 'CallActivity_1',
-        property: 'bindingType',
         allowedVersion: '8.6'
       }
     }
@@ -207,7 +151,7 @@ const invalid = [
     moddleElement: createModdle(createProcess(`
       <bpmn:callActivity id="CallActivity_1">
         <bpmn:extensionElements>
-          <zeebe:calledElement versionTag="v1.0.0" />
+          <zeebe:calledElement bindingType="versionTag" versionTag="v1.0.0" />
         </bpmn:extensionElements>
       </bpmn:callActivity>
     `)),
@@ -230,40 +174,12 @@ const invalid = [
     }
   },
   {
-    name: 'user task (binding type)',
-    config: { version: '8.5' },
-    moddleElement: createModdle(createProcess(`
-      <bpmn:userTask id="UserTask_1">
-        <bpmn:extensionElements>
-          <zeebe:formDefinition bindingType="versionTag" versionTag="v1.0.0" />
-        </bpmn:extensionElements>
-      </bpmn:userTask>
-    `)),
-    report: {
-      id: 'UserTask_1',
-      message: 'Property value of <versionTag> only allowed by Camunda 8.6 or newer',
-      path: [
-        'extensionElements',
-        'values',
-        0,
-        'bindingType'
-      ],
-      data: {
-        type: ERROR_TYPES.PROPERTY_VALUE_NOT_ALLOWED,
-        node: 'zeebe:FormDefinition',
-        parentNode: 'UserTask_1',
-        property: 'bindingType',
-        allowedVersion: '8.6'
-      }
-    }
-  },
-  {
     name: 'user task (version tag)',
     config: { version: '8.5' },
     moddleElement: createModdle(createProcess(`
       <bpmn:userTask id="UserTask_1">
         <bpmn:extensionElements>
-          <zeebe:formDefinition versionTag="v1.0.0" />
+          <zeebe:formDefinition bindingType="versionTag" versionTag="v1.0.0" />
         </bpmn:extensionElements>
       </bpmn:userTask>
     `)),


### PR DESCRIPTION
Overlaps with `no-binding-type`. Since 8.6 supports all known binding types we can keep the code simple.