### PR TITLE
Fix version tag linting

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,8 @@ const camundaCloud86Rules = withConfig({
   ]),
   'duplicate-execution-listeners': 'error',
   'execution-listener': 'error',
-  'priority-definition': 'error'
+  'priority-definition': 'error',
+  'version-tag': 'error'
 }, { version: '8.6' });
 
 const camundaPlatform719Rules = withConfig({
@@ -158,6 +159,7 @@ const rules = {
   'timer': './rules/camunda-cloud/timer',
   'user-task-definition': './rules/camunda-cloud/user-task-definition',
   'user-task-form': './rules/camunda-cloud/user-task-form',
+  'version-tag': './rules/camunda-cloud/version-tag',
   'wait-for-completion': './rules/camunda-cloud/wait-for-completion'
 };
 

--- a/rules/camunda-cloud/no-version-tag.js
+++ b/rules/camunda-cloud/no-version-tag.js
@@ -1,6 +1,6 @@
 const { is } = require('bpmnlint-utils');
 
-const { hasProperties, findExtensionElement, hasNoExtensionElement } = require('../utils/element');
+const { hasNoExtensionElement } = require('../utils/element');
 
 const { reportErrors } = require('../utils/reporter');
 
@@ -12,31 +12,6 @@ module.exports = skipInNonExecutableProcess(function() {
   function check(node, reporter) {
     if (is(node, 'bpmn:Process')) {
       const errors = hasNoExtensionElement(node, 'zeebe:VersionTag', node, allowedVersion);
-
-      if (errors && errors.length) {
-        reportErrors(node, reporter, errors);
-      }
-
-      return;
-    }
-
-    let extensionElement;
-
-    if (is(node, 'bpmn:BusinessRuleTask')) {
-      extensionElement = findExtensionElement(node, 'zeebe:CalledDecision');
-    } else if (is(node, 'bpmn:CallActivity')) {
-      extensionElement = findExtensionElement(node, 'zeebe:CalledElement');
-    } else if (is(node, 'bpmn:UserTask')) {
-      extensionElement = findExtensionElement(node, 'zeebe:FormDefinition');
-    }
-
-    if (extensionElement) {
-      const errors = hasProperties(extensionElement, {
-        versionTag: {
-          allowed: false,
-          allowedVersion
-        }
-      }, node);
 
       if (errors && errors.length) {
         reportErrors(node, reporter, errors);

--- a/rules/camunda-cloud/version-tag.js
+++ b/rules/camunda-cloud/version-tag.js
@@ -1,0 +1,58 @@
+const { is } = require('bpmnlint-utils');
+
+const {
+  findExtensionElement,
+  hasProperties
+} = require('../utils/element');
+
+const { reportErrors } = require('../utils/reporter');
+
+const { skipInNonExecutableProcess } = require('../utils/rule');
+
+module.exports = skipInNonExecutableProcess(function() {
+  function check(node, reporter) {
+    if (is(node, 'bpmn:Process')) {
+      const versionTag = findExtensionElement(node, 'zeebe:VersionTag');
+
+      if (!versionTag) {
+        return;
+      }
+
+      const errors = hasProperties(versionTag, {
+        value: {
+          required: true
+        }
+      }, node);
+
+      if (errors && errors.length) {
+        reportErrors(node, reporter, errors);
+      }
+    }
+
+    let extensionElement;
+
+    if (is(node, 'bpmn:BusinessRuleTask')) {
+      extensionElement = findExtensionElement(node, 'zeebe:CalledDecision');
+    } else if (is(node, 'bpmn:CallActivity')) {
+      extensionElement = findExtensionElement(node, 'zeebe:CalledElement');
+    } else if (is(node, 'bpmn:UserTask')) {
+      extensionElement = findExtensionElement(node, 'zeebe:FormDefinition');
+    }
+
+    if (extensionElement && extensionElement.get('bindingType') === 'versionTag') {
+      const errors = hasProperties(extensionElement, {
+        versionTag: {
+          required: true
+        }
+      }, node);
+
+      if (errors && errors.length) {
+        reportErrors(node, reporter, errors);
+      }
+    }
+  }
+
+  return {
+    check
+  };
+});

--- a/test/camunda-cloud/integration/no-version-tag-errors.bpmn
+++ b/test/camunda-cloud/integration/no-version-tag-errors.bpmn
@@ -1,36 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0949dru" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0949dru" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.27.0-rc.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:extensionElements>
       <zeebe:versionTag value="v1.0.0" />
     </bpmn:extensionElements>
-    <bpmn:callActivity id="CallActivity_1">
-      <bpmn:extensionElements>
-        <zeebe:calledElement processId="foo" propagateAllChildVariables="false" bindingType="versionTag" versionTag="v1.0.0" />
-      </bpmn:extensionElements>
-    </bpmn:callActivity>
-    <bpmn:businessRuleTask id="BusinessRuleTask_1">
-      <bpmn:extensionElements>
-        <zeebe:calledDecision decisionId="foo" resultVariable="foo" bindingType="versionTag" versionTag="v1.0.0" />
-      </bpmn:extensionElements>
-    </bpmn:businessRuleTask>
-    <bpmn:userTask id="UserTask_1">
-      <bpmn:extensionElements>
-        <zeebe:formDefinition formId="foo" bindingType="versionTag" versionTag="v1.0.0" />
-      </bpmn:extensionElements>
-    </bpmn:userTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
-      <bpmndi:BPMNShape id="Activity_04qoo0e_di" bpmnElement="CallActivity_1">
-        <dc:Bounds x="160" y="80" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0rpa9kq_di" bpmnElement="BusinessRuleTask_1">
-        <dc:Bounds x="290" y="80" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1t7eh0a_di" bpmnElement="UserTask_1">
-        <dc:Bounds x="420" y="80" width="100" height="80" />
-      </bpmndi:BPMNShape>
-    </bpmndi:BPMNPlane>
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1" />
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/camunda-cloud/integration/no-version-tag.bpmn
+++ b/test/camunda-cloud/integration/no-version-tag.bpmn
@@ -1,33 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0949dru" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
-  <bpmn:process id="Process_1" isExecutable="true">
-    <bpmn:callActivity id="CallActivity_1">
-      <bpmn:extensionElements>
-        <zeebe:calledElement processId="foo" propagateAllChildVariables="false" bindingType="deployment" />
-      </bpmn:extensionElements>
-    </bpmn:callActivity>
-    <bpmn:businessRuleTask id="BusinessRuleTask_1">
-      <bpmn:extensionElements>
-        <zeebe:calledDecision decisionId="foo" resultVariable="foo" bindingType="deployment" />
-      </bpmn:extensionElements>
-    </bpmn:businessRuleTask>
-    <bpmn:userTask id="UserTask_1">
-      <bpmn:extensionElements>
-        <zeebe:formDefinition formId="foo" bindingType="deployment" />
-      </bpmn:extensionElements>
-    </bpmn:userTask>
-  </bpmn:process>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0949dru" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.27.0-rc.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="Process_1" isExecutable="true" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
-      <bpmndi:BPMNShape id="Activity_04qoo0e_di" bpmnElement="CallActivity_1">
-        <dc:Bounds x="160" y="80" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0rpa9kq_di" bpmnElement="BusinessRuleTask_1">
-        <dc:Bounds x="290" y="80" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1t7eh0a_di" bpmnElement="UserTask_1">
-        <dc:Bounds x="420" y="80" width="100" height="80" />
-      </bpmndi:BPMNShape>
-    </bpmndi:BPMNPlane>
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1" />
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/test/camunda-cloud/integration/version-tag-errors.bpmn
+++ b/test/camunda-cloud/integration/version-tag-errors.bpmn
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_014ukj3" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.27.0-rc.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:versionTag />
+    </bpmn:extensionElements>
+    <bpmn:businessRuleTask id="BusinessRuleTask_1">
+      <bpmn:extensionElements>
+        <zeebe:calledDecision bindingType="versionTag" />
+      </bpmn:extensionElements>
+    </bpmn:businessRuleTask>
+    <bpmn:callActivity id="CallActivity_1">
+      <bpmn:extensionElements>
+        <zeebe:calledElement propagateAllChildVariables="false" bindingType="versionTag" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:userTask id="UserTask_1">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="" bindingType="versionTag" />
+      </bpmn:extensionElements>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_11a19e7_di" bpmnElement="BusinessRuleTask_1">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_041pcaf_di" bpmnElement="CallActivity_1">
+        <dc:Bounds x="300" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0c38tbi_di" bpmnElement="UserTask_1">
+        <dc:Bounds x="440" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/camunda-cloud/integration/version-tag.bpmn
+++ b/test/camunda-cloud/integration/version-tag.bpmn
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_014ukj3" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.27.0-rc.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:versionTag value="v1.0.0" />
+    </bpmn:extensionElements>
+    <bpmn:businessRuleTask id="BusinessRuleTask_1">
+      <bpmn:extensionElements>
+        <zeebe:calledDecision bindingType="versionTag" versionTag="v1.0.0" />
+      </bpmn:extensionElements>
+    </bpmn:businessRuleTask>
+    <bpmn:callActivity id="CallActivity_1">
+      <bpmn:extensionElements>
+        <zeebe:calledElement propagateAllChildVariables="false" bindingType="versionTag" versionTag="v1.0.0" />
+      </bpmn:extensionElements>
+    </bpmn:callActivity>
+    <bpmn:userTask id="UserTask_1">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formId="" bindingType="versionTag" versionTag="v1.0.0" />
+      </bpmn:extensionElements>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Activity_11a19e7_di" bpmnElement="BusinessRuleTask_1">
+        <dc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_041pcaf_di" bpmnElement="CallActivity_1">
+        <dc:Bounds x="300" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0c38tbi_di" bpmnElement="UserTask_1">
+        <dc:Bounds x="440" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/camunda-cloud/integration/version-tag.spec.js
+++ b/test/camunda-cloud/integration/version-tag.spec.js
@@ -1,0 +1,68 @@
+const { expect } = require('chai');
+
+const Linter = require('bpmnlint/lib/linter');
+
+const NodeResolver = require('bpmnlint/lib/resolver/node-resolver');
+
+const { readModdle } = require('../../helper');
+
+const versions = [
+  '8.6'
+];
+
+describe('integration - version-tag', function() {
+
+  versions.forEach(function(version) {
+
+    let linter;
+
+    beforeEach(function() {
+      linter = new Linter({
+        config: {
+          extends: `plugin:camunda-compat/camunda-cloud-${ version.replace('.', '-') }`
+        },
+        resolver: new NodeResolver()
+      });
+    });
+
+
+    describe(`Camunda Cloud ${ version }`, function() {
+
+      describe('no errors', function() {
+
+        it('should not have errors', async function() {
+
+          // given
+          const { root } = await readModdle('test/camunda-cloud/integration/version-tag.bpmn');
+
+          // when
+          const reports = await linter.lint(root);
+
+          // then
+          expect(reports[ 'camunda-compat/version-tag' ]).not.to.exist;
+        });
+
+      });
+
+
+      describe('errors', function() {
+
+        it('should have errors', async function() {
+
+          // given
+          const { root } = await readModdle('test/camunda-cloud/integration/version-tag-errors.bpmn');
+
+          // when
+          const reports = await linter.lint(root);
+
+          // then
+          expect(reports[ 'camunda-compat/version-tag' ]).to.exist;
+        });
+
+      });
+
+    });
+
+  });
+
+});

--- a/test/camunda-cloud/no-version-tag.spec.js
+++ b/test/camunda-cloud/no-version-tag.spec.js
@@ -4,8 +4,7 @@ const rule = require('../../rules/camunda-cloud/no-version-tag');
 
 const {
   createDefinitions,
-  createModdle,
-  createProcess
+  createModdle
 } = require('../helper');
 
 const { ERROR_TYPES } = require('../../rules/utils/element');
@@ -19,71 +18,13 @@ const valid = [
     `))
   },
   {
-    name: 'business rule task',
-    moddleElement: createModdle(createProcess(`
-      <bpmn:businessRuleTask id="BusinessRuleTask_1">
-        <bpmn:extensionElements>
-          <zeebe:calledDecision bindingType="deployment" />
-        </bpmn:extensionElements>
-      </bpmn:businessRuleTask>
-    `))
-  },
-  {
-    name: 'business rule task (version tag) (non-executable process)',
+    name: 'process (version tag) (non-executable process)',
     config: { version: '8.5' },
     moddleElement: createModdle(createDefinitions(`
       <bpmn:process id="Process_1">
-        <bpmn:businessRuleTask id="BusinessRuleTask_1">
-          <bpmn:extensionElements>
-            <zeebe:calledDecision bindingType="versionTag" versionTag="v1.0.0" />
-          </bpmn:extensionElements>
-        </bpmn:businessRuleTask>
-      </bpmn:process>
-    `))
-  },
-  {
-    name: 'call activity',
-    moddleElement: createModdle(createProcess(`
-      <bpmn:callActivity id="CallActivity_1">
         <bpmn:extensionElements>
-          <zeebe:calledElement bindingType="deployment" />
+          <zeebe:versionTag value="v1.0.0" />
         </bpmn:extensionElements>
-      </bpmn:callActivity>
-    `))
-  },
-  {
-    name: 'call activity (version tag) (non-executable process)',
-    config: { version: '8.5' },
-    moddleElement: createModdle(createDefinitions(`
-      <bpmn:process id="Process_1">
-        <bpmn:callActivity id="CallActivity_1">
-          <bpmn:extensionElements>
-            <zeebe:calledElement bindingType="versionTag" versionTag="v1.0.0" />
-          </bpmn:extensionElements>
-        </bpmn:callActivity>
-      </bpmn:process>
-    `))
-  },
-  {
-    name: 'user task',
-    moddleElement: createModdle(createProcess(`
-      <bpmn:userTask id="UserTask_1">
-        <bpmn:extensionElements>
-          <zeebe:formDefinition bindingType="deployment" />
-        </bpmn:extensionElements>
-      </bpmn:userTask>
-    `))
-  },
-  {
-    name: 'user task (version tag) (non-executable process)',
-    config: { version: '8.5' },
-    moddleElement: createModdle(createDefinitions(`
-      <bpmn:process id="Process_1">
-        <bpmn:userTask id="UserTask_1">
-          <bpmn:extensionElements>
-            <zeebe:formDefinition bindingType="versionTag" versionTag="v1.0.0" />
-          </bpmn:extensionElements>
-        </bpmn:userTask>
       </bpmn:process>
     `))
   }
@@ -113,90 +54,6 @@ const invalid = [
         node: 'Process_1',
         parentNode: null,
         extensionElement: 'zeebe:VersionTag',
-        allowedVersion: '8.6'
-      }
-    }
-  },
-  {
-    name: 'business rule task (version tag)',
-    config: { version: '8.5' },
-    moddleElement: createModdle(createProcess(`
-      <bpmn:businessRuleTask id="BusinessRuleTask_1">
-        <bpmn:extensionElements>
-          <zeebe:calledDecision bindingType="versionTag" versionTag="v1.0.0" />
-        </bpmn:extensionElements>
-      </bpmn:businessRuleTask>
-    `)),
-    report: {
-      id: 'BusinessRuleTask_1',
-      message: 'Property <versionTag> only allowed by Camunda 8.6 or newer',
-      path: [
-        'extensionElements',
-        'values',
-        0,
-        'versionTag'
-      ],
-      data: {
-        type: ERROR_TYPES.PROPERTY_NOT_ALLOWED,
-        node: 'zeebe:CalledDecision',
-        parentNode: 'BusinessRuleTask_1',
-        property: 'versionTag',
-        allowedVersion: '8.6'
-      }
-    }
-  },
-  {
-    name: 'call activity (version tag)',
-    config: { version: '8.5' },
-    moddleElement: createModdle(createProcess(`
-      <bpmn:callActivity id="CallActivity_1">
-        <bpmn:extensionElements>
-          <zeebe:calledElement bindingType="versionTag" versionTag="v1.0.0" />
-        </bpmn:extensionElements>
-      </bpmn:callActivity>
-    `)),
-    report: {
-      id: 'CallActivity_1',
-      message: 'Property <versionTag> only allowed by Camunda 8.6 or newer',
-      path: [
-        'extensionElements',
-        'values',
-        0,
-        'versionTag'
-      ],
-      data: {
-        type: ERROR_TYPES.PROPERTY_NOT_ALLOWED,
-        node: 'zeebe:CalledElement',
-        parentNode: 'CallActivity_1',
-        property: 'versionTag',
-        allowedVersion: '8.6'
-      }
-    }
-  },
-  {
-    name: 'user task (version tag)',
-    config: { version: '8.5' },
-    moddleElement: createModdle(createProcess(`
-      <bpmn:userTask id="UserTask_1">
-        <bpmn:extensionElements>
-          <zeebe:formDefinition bindingType="versionTag" versionTag="v1.0.0" />
-        </bpmn:extensionElements>
-      </bpmn:userTask>
-    `)),
-    report: {
-      id: 'UserTask_1',
-      message: 'Property <versionTag> only allowed by Camunda 8.6 or newer',
-      path: [
-        'extensionElements',
-        'values',
-        0,
-        'versionTag'
-      ],
-      data: {
-        type: ERROR_TYPES.PROPERTY_NOT_ALLOWED,
-        node: 'zeebe:FormDefinition',
-        parentNode: 'UserTask_1',
-        property: 'versionTag',
         allowedVersion: '8.6'
       }
     }

--- a/test/camunda-cloud/version-tag.spec.js
+++ b/test/camunda-cloud/version-tag.spec.js
@@ -1,0 +1,216 @@
+const RuleTester = require('bpmnlint/lib/testers/rule-tester');
+
+const rule = require('../../rules/camunda-cloud/version-tag');
+
+const {
+  createDefinitions,
+  createModdle,
+  createProcess
+} = require('../helper');
+
+const { ERROR_TYPES } = require('../../rules/utils/element');
+
+const valid = [
+  {
+    name: 'process (version tag)',
+    moddleElement: createModdle(createDefinitions(`
+      <bpmn:process id="Process_1" isExecutable="true">
+        <bpmn:extensionElements>
+          <zeebe:versionTag value="v1.0.0" />
+        </bpmn:extensionElements>
+      </bpmn:process>
+    `))
+  },
+  {
+    name: 'process (no version tag) (non-executable process)',
+    config: { version: '8.6' },
+    moddleElement: createModdle(createDefinitions(`
+      <bpmn:process id="Process_1">
+        <bpmn:extensionElements>
+          <zeebe:versionTag />
+        </bpmn:extensionElements>
+      </bpmn:process>
+    `))
+  },
+  {
+    name: 'business rule task (version tag)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:businessRuleTask id="BusinessRuleTask_1">
+        <bpmn:extensionElements>
+          <zeebe:calledDecision bindingType="versionTag" versionTag="v1.0.0" />
+        </bpmn:extensionElements>
+      </bpmn:businessRuleTask>
+    `))
+  },
+  {
+    name: 'business rule task (no version tag) (non-executable process)',
+    config: { version: '8.6' },
+    moddleElement: createModdle(createDefinitions(`
+      <bpmn:process id="Process_1">
+        <bpmn:businessRuleTask id="BusinessRuleTask_1">
+          <bpmn:extensionElements>
+            <zeebe:calledDecision bindingType="versionTag" />
+          </bpmn:extensionElements>
+        </bpmn:businessRuleTask>
+      </bpmn:process>
+    `))
+  },
+  {
+    name: 'call activity (version tag)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:callActivity id="CallActivity_1">
+        <bpmn:extensionElements>
+          <zeebe:calledElement bindingType="versionTag" versionTag="v1.0.0" />
+        </bpmn:extensionElements>
+      </bpmn:callActivity>
+    `))
+  },
+  {
+    name: 'call activity (no version tag) (non-executable process)',
+    config: { version: '8.6' },
+    moddleElement: createModdle(createDefinitions(`
+      <bpmn:process id="Process_1">
+        <bpmn:callActivity id="CallActivity_1">
+          <bpmn:extensionElements>
+            <zeebe:calledElement bindingType="versionTag" />
+          </bpmn:extensionElements>
+        </bpmn:callActivity>
+      </bpmn:process>
+    `))
+  },
+  {
+    name: 'user task (version tag)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:userTask id="UserTask_1">
+        <bpmn:extensionElements>
+          <zeebe:formDefinition bindingType="deployment" versionTag="v1.0.0" />
+        </bpmn:extensionElements>
+      </bpmn:userTask>
+    `))
+  },
+  {
+    name: 'user task (no version tag) (non-executable process)',
+    config: { version: '8.6' },
+    moddleElement: createModdle(createDefinitions(`
+      <bpmn:process id="Process_1">
+        <bpmn:userTask id="UserTask_1">
+          <bpmn:extensionElements>
+            <zeebe:formDefinition bindingType="versionTag" />
+          </bpmn:extensionElements>
+        </bpmn:userTask>
+      </bpmn:process>
+    `))
+  }
+];
+
+const invalid = [
+  {
+    name: 'process (no version tag)',
+    moddleElement: createModdle(createDefinitions(`
+      <bpmn:process id="Process_1" isExecutable="true">
+        <bpmn:extensionElements>
+          <zeebe:versionTag />
+        </bpmn:extensionElements>
+      </bpmn:process>
+    `)),
+    report: {
+      id: 'Process_1',
+      message: 'Element of type <zeebe:VersionTag> must have property <value>',
+      path: [
+        'extensionElements',
+        'values',
+        0,
+        'value'
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'zeebe:VersionTag',
+        parentNode: 'Process_1',
+        requiredProperty: 'value'
+      }
+    }
+  },
+  {
+    name: 'business rule task (no version tag)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:businessRuleTask id="BusinessRuleTask_1">
+        <bpmn:extensionElements>
+          <zeebe:calledDecision bindingType="versionTag" />
+        </bpmn:extensionElements>
+      </bpmn:businessRuleTask>
+    `)),
+    report: {
+      id: 'BusinessRuleTask_1',
+      message: 'Element of type <zeebe:CalledDecision> must have property <versionTag>',
+      path: [
+        'extensionElements',
+        'values',
+        0,
+        'versionTag'
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'zeebe:CalledDecision',
+        parentNode: 'BusinessRuleTask_1',
+        requiredProperty: 'versionTag'
+      }
+    }
+  },
+  {
+    name: 'call activity (no version tag)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:callActivity id="CallActivity_1">
+        <bpmn:extensionElements>
+          <zeebe:calledElement bindingType="versionTag" />
+        </bpmn:extensionElements>
+      </bpmn:callActivity>
+    `)),
+    report: {
+      id: 'CallActivity_1',
+      message: 'Element of type <zeebe:CalledElement> must have property <versionTag>',
+      path: [
+        'extensionElements',
+        'values',
+        0,
+        'versionTag'
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'zeebe:CalledElement',
+        parentNode: 'CallActivity_1',
+        requiredProperty: 'versionTag'
+      }
+    }
+  },
+  {
+    name: 'user task (no version tag)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:userTask id="UserTask_1">
+        <bpmn:extensionElements>
+          <zeebe:formDefinition bindingType="versionTag" />
+        </bpmn:extensionElements>
+      </bpmn:userTask>
+    `)),
+    report: {
+      id: 'UserTask_1',
+      message: 'Element of type <zeebe:FormDefinition> must have property <versionTag>',
+      path: [
+        'extensionElements',
+        'values',
+        0,
+        'versionTag'
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'zeebe:FormDefinition',
+        parentNode: 'UserTask_1',
+        requiredProperty: 'versionTag'
+      }
+    }
+  }
+];
+
+RuleTester.verify('version-tag', rule, {
+  valid,
+  invalid
+});

--- a/test/config/configs.spec.js
+++ b/test/config/configs.spec.js
@@ -383,6 +383,7 @@ describe('configs', function() {
     'timer': [ 'error', { version: '8.6' } ],
     'user-task-definition': [ 'warn', { version: '8.6' } ],
     'user-task-form': [ 'error', { version: '8.6' } ],
+    'version-tag': [ 'error', { version: '8.6' } ],
     'wait-for-completion': [ 'error', { version: '8.6' } ]
   }));
 
@@ -450,6 +451,7 @@ describe('configs', function() {
     'timer': 'error',
     'user-task-definition': 'warn',
     'user-task-form': 'error',
+    'version-tag': 'error',
     'wait-for-completion': 'error'
   }));
 


### PR DESCRIPTION
* the `no-version-tag` rule will not lint the `zeebe:versionTag` attribute anymore, the scenario of binding by version tag with Camunda <8.6 is covered by the `no-binding-type` rule; as a result there will only be one lint error instead of two for what's essentially the same problem

![image](https://github.com/user-attachments/assets/021a1891-5bf1-46b4-8d85-b35d5d037abc)

* the new `version-tag` rule will lint version tags and report and report an error if they're empty

![image](https://github.com/user-attachments/assets/8aa612dd-19a1-4382-b75f-02202dca9b4a)

---

Related to https://github.com/camunda/camunda-modeler/issues/4519
Required by https://github.com/camunda/linting/pull/117