### PR TITLE
fix(feel): report errors for flow element containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [bpmnlint-plugin-camunda-compat](https://github.com/camun
 
 ___Note:__ Yet to be released changes appear here._
 
+## 2.26.1
+
+* `FIX`: report FEEL errors for processes ([#175](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/175))
+
 ## 2.26.0
 
 * `FEAT`: introduce `version-tag` rule ([#174](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/174))

--- a/rules/camunda-cloud/feel.js
+++ b/rules/camunda-cloud/feel.js
@@ -1,6 +1,9 @@
 const { isString } = require('min-dash');
 
-const { is } = require('bpmnlint-utils');
+const {
+  is,
+  isAny
+} = require('bpmnlint-utils');
 
 const { lintExpression } = require('@bpmn-io/feel-lint');
 
@@ -18,7 +21,7 @@ module.exports = skipInNonExecutableProcess(function() {
       return;
     }
 
-    const parentNode = findFlowElement(node);
+    const parentNode = findParentNode(node);
 
     if (!parentNode) {
       return;
@@ -74,8 +77,8 @@ const isIgnoredProperty = propertyName => {
   return propertyName.startsWith('$');
 };
 
-const findFlowElement = node => {
-  while (node && !is(node, 'bpmn:FlowElement')) {
+const findParentNode = node => {
+  while (node && !isAny(node, [ 'bpmn:FlowElement', 'bpmn:FlowElementsContainer' ])) {
     node = node.$parent;
   }
 

--- a/test/camunda-cloud/feel.spec.js
+++ b/test/camunda-cloud/feel.spec.js
@@ -119,7 +119,6 @@ const invalid = [
     }
   },
   {
-    it: it.only,
     name: 'invalid FEEL expression (string property) (process)',
     moddleElement: createModdle(createProcess(`
       <bpmn:extensionElements>

--- a/test/camunda-cloud/feel.spec.js
+++ b/test/camunda-cloud/feel.spec.js
@@ -64,7 +64,7 @@ const valid = [
 
 const invalid = [
   {
-    name: 'invalid FEEL expression (string property)',
+    name: 'invalid FEEL expression (string property) (task)',
     moddleElement: createModdle(createProcess(`
       <bpmn:serviceTask id="Task_1">
         <bpmn:extensionElements>
@@ -94,7 +94,7 @@ const invalid = [
     }
   },
   {
-    name: 'invalid FEEL expression (bpmn:Expression property)',
+    name: 'invalid FEEL expression (bpmn:Expression property) (start event)',
     moddleElement: createModdle(createProcess(`
       <bpmn:startEvent id="StartEvent_1">
         <bpmn:timerEventDefinition id="TimerEventDefinition_1">
@@ -115,6 +115,35 @@ const invalid = [
         node: 'TimerEventDefinition_1',
         parentNode: 'StartEvent_1',
         property: 'timeCycle'
+      }
+    }
+  },
+  {
+    it: it.only,
+    name: 'invalid FEEL expression (string property) (process)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" type="=1 >" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+    `)),
+    report: {
+      id: 'Process_1',
+      message: 'Property <type> is not a valid FEEL expression',
+      path: [
+        'extensionElements',
+        'values',
+        0,
+        'listeners',
+        0,
+        'type'
+      ],
+      data: {
+        type: ERROR_TYPES.FEEL_EXPRESSION_INVALID,
+        node: 'zeebe:ExecutionListener',
+        parentNode: 'Process_1',
+        property: 'type'
       }
     }
   }


### PR DESCRIPTION
`bpmn:Process` is not a `bpmn:FlowElement` and was therefore ignored.

Related to https://github.com/camunda/camunda-modeler/issues/4562