### PR TITLE
Add documentation URL to rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "bpmn-moddle": "^9.0.1",
-        "bpmnlint": "^11.1.0",
+        "bpmnlint": "^11.2.0",
         "camunda-bpmn-moddle": "^7.0.1",
         "chai": "^4.4.1",
         "eslint": "^9.20.1",
@@ -617,10 +617,11 @@
       }
     },
     "node_modules/bpmnlint": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-11.1.0.tgz",
-      "integrity": "sha512-4y9p642nCmEurluWb/IWvlGNQF5hUvM1SBw37wkTdGCkuP41bx9hIW0C3rrBymSSCwyfg2pM1S5e4o9cr1B7eg==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-11.2.0.tgz",
+      "integrity": "sha512-0Sht1sbsXBdPwj0/u6cc92GL9E1VTxLHuaeU3K3Ki6Rt8rYb88Nt1v1cOuFGI/KU/0eihnoaBv/zi0ofMdxQfA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@bpmn-io/moddle-utils": "^0.2.1",
         "ansi-colors": "^4.1.3",
@@ -628,7 +629,7 @@
         "bpmnlint-utils": "^1.1.1",
         "cli-table": "^0.3.11",
         "color-support": "^1.1.3",
-        "min-dash": "^4.2.2",
+        "min-dash": "^4.2.3",
         "mri": "^1.2.0",
         "pluralize": "^7.0.0",
         "tiny-glob": "^0.2.9"
@@ -4630,9 +4631,9 @@
       }
     },
     "bpmnlint": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-11.1.0.tgz",
-      "integrity": "sha512-4y9p642nCmEurluWb/IWvlGNQF5hUvM1SBw37wkTdGCkuP41bx9hIW0C3rrBymSSCwyfg2pM1S5e4o9cr1B7eg==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-11.2.0.tgz",
+      "integrity": "sha512-0Sht1sbsXBdPwj0/u6cc92GL9E1VTxLHuaeU3K3Ki6Rt8rYb88Nt1v1cOuFGI/KU/0eihnoaBv/zi0ofMdxQfA==",
       "dev": true,
       "requires": {
         "@bpmn-io/moddle-utils": "^0.2.1",
@@ -4641,7 +4642,7 @@
         "bpmnlint-utils": "^1.1.1",
         "cli-table": "^0.3.11",
         "color-support": "^1.1.3",
-        "min-dash": "^4.2.2",
+        "min-dash": "^4.2.3",
         "mri": "^1.2.0",
         "pluralize": "^7.0.0",
         "tiny-glob": "^0.2.9"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "devDependencies": {
     "bpmn-moddle": "^9.0.1",
-    "bpmnlint": "^11.1.0",
+    "bpmnlint": "^11.2.0",
     "camunda-bpmn-moddle": "^7.0.1",
     "chai": "^4.4.1",
     "eslint": "^9.20.1",

--- a/rules/camunda-cloud/called-element.js
+++ b/rules/camunda-cloud/called-element.js
@@ -6,6 +6,8 @@ const {
   hasProperties
 } = require('../utils/element');
 
+const { annotateRule } = require('../helper');
+
 const { reportErrors } = require('../utils/reporter');
 
 const { skipInNonExecutableProcess } = require('../utils/rule');
@@ -37,7 +39,7 @@ module.exports = skipInNonExecutableProcess(function() {
     }
   }
 
-  return {
+  return annotateRule('called-element', {
     check
-  };
+  });
 });

--- a/rules/camunda-cloud/element-type/index.js
+++ b/rules/camunda-cloud/element-type/index.js
@@ -14,6 +14,8 @@ const { reportErrors } = require('../../utils/reporter');
 
 const { skipInNonExecutableProcess } = require('../../utils/rule');
 
+const { annotateRule } = require('../../helper');
+
 module.exports = skipInNonExecutableProcess(function({ version }) {
   function check(node, reporter) {
     if (!isAny(node, [ 'bpmn:FlowElement', 'bpmn:FlowElementsContainer' ])) {
@@ -128,7 +130,7 @@ module.exports = skipInNonExecutableProcess(function({ version }) {
     }
   }
 
-  return {
+  return annotateRule('element-type', {
     check
-  };
+  });
 });

--- a/rules/camunda-cloud/error-reference.js
+++ b/rules/camunda-cloud/error-reference.js
@@ -13,6 +13,7 @@ const { reportErrors } = require('../utils/reporter');
 const { skipInNonExecutableProcess } = require('../utils/rule');
 
 const { greaterOrEqual } = require('../utils/version');
+const { annotateRule } = require('../helper');
 
 const noErrorRefAllowedVersion = '8.2';
 
@@ -62,9 +63,9 @@ module.exports = skipInNonExecutableProcess(function({ version }) {
     }
   }
 
-  return {
+  return annotateRule('error-reference', {
     check
-  };
+  });
 });
 
 function isNoErrorRefAllowed(node, version) {

--- a/rules/camunda-cloud/escalation-reference.js
+++ b/rules/camunda-cloud/escalation-reference.js
@@ -11,6 +11,7 @@ const {
 const { reportErrors } = require('../utils/reporter');
 
 const { skipInNonExecutableProcess } = require('../utils/rule');
+const { annotateRule } = require('../helper');
 
 module.exports = skipInNonExecutableProcess(function() {
   function check(node, reporter) {
@@ -57,9 +58,9 @@ module.exports = skipInNonExecutableProcess(function() {
     }
   }
 
-  return {
+  return annotateRule('escalation-reference', {
     check
-  };
+  });
 });
 
 function isNoEscalationRefAllowed(node) {

--- a/rules/camunda-cloud/feel.js
+++ b/rules/camunda-cloud/feel.js
@@ -14,6 +14,7 @@ const { reportErrors } = require('../utils/reporter');
 const { ERROR_TYPES } = require('../utils/error-types');
 
 const { skipInNonExecutableProcess } = require('../utils/rule');
+const { annotateRule } = require('../helper');
 
 module.exports = skipInNonExecutableProcess(function() {
   function check(node, reporter) {
@@ -64,9 +65,9 @@ module.exports = skipInNonExecutableProcess(function() {
     }
   }
 
-  return {
+  return annotateRule('feel', {
     check
-  };
+  });
 });
 
 const isFeelProperty = ([ propertyName, value ]) => {

--- a/rules/camunda-cloud/message-reference.js
+++ b/rules/camunda-cloud/message-reference.js
@@ -11,6 +11,7 @@ const {
 const { reportErrors } = require('../utils/reporter');
 
 const { skipInNonExecutableProcess } = require('../utils/rule');
+const { annotateRule } = require('../helper');
 
 module.exports = skipInNonExecutableProcess(function() {
   function check(node, reporter) {
@@ -55,7 +56,7 @@ module.exports = skipInNonExecutableProcess(function() {
     }
   }
 
-  return {
+  return annotateRule('message-reference', {
     check
-  };
+  });
 });

--- a/rules/camunda-cloud/zeebe-user-task.js
+++ b/rules/camunda-cloud/zeebe-user-task.js
@@ -20,6 +20,11 @@ module.exports = skipInNonExecutableProcess(function() {
   }
 
   return {
+    meta: {
+      documentation: {
+        url: 'https://docs.camunda.io/docs/next/apis-tools/migration-manuals/migrate-to-zeebe-user-tasks'
+      }
+    },
     check
   };
 });

--- a/rules/camunda-platform/history-time-to-live.js
+++ b/rules/camunda-platform/history-time-to-live.js
@@ -1,5 +1,7 @@
 const { is } = require('bpmnlint-utils');
 
+const { annotateRule } = require('../helper');
+
 const { skipInNonExecutableProcess } = require('../utils/rule');
 
 module.exports = skipInNonExecutableProcess(function() {
@@ -14,7 +16,7 @@ module.exports = skipInNonExecutableProcess(function() {
     }
   }
 
-  return {
+  return annotateRule('history-time-to-live', {
     check
-  };
+  });
 });

--- a/rules/helper.js
+++ b/rules/helper.js
@@ -1,0 +1,39 @@
+const modelingGuidanceBaseUrl = 'https://docs.camunda.io/docs/next/components/modeler/reference/modeling-guidance/rules';
+
+/**
+ * @typedef { any } RuleDefinition
+ */
+
+/**
+ * Annotate a rule with core information, such as the documentation url.
+ *
+ * @param { string } ruleName
+ * @param { RuleDefinition } options
+ *
+ * @return { RuleDefinition }
+ */
+function annotateRule(ruleName, options) {
+
+  const {
+    meta: {
+      documentation = {},
+      ...restMeta
+    } = {},
+    ...restOptions
+  } = options;
+
+  const documentationUrl = `${modelingGuidanceBaseUrl}/${ruleName}.md`;
+
+  return {
+    meta: {
+      documentation: {
+        url: documentationUrl,
+        ...documentation
+      },
+      ...restMeta
+    },
+    ...restOptions
+  };
+}
+
+module.exports.annotateRule = annotateRule;


### PR DESCRIPTION
### Proposed Changes

Follows up on https://github.com/bpmn-io/bpmnlint/pull/167 to add documentation URL to rules (where it exists). The URL will typically be part of the [Camunda Modeling Guidance](https://docs.camunda.io/docs/next/components/modeler/reference/modeling-guidance/) sites.

After this change is merged and integrated we can safely get rid of the `camunda/linting` URL logic, cf. https://github.com/camunda/linting/pull/129.


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
