### PR TITLE
fix(rules): correct documentation URL location

### DIFF
--- a/rules/helper.js
+++ b/rules/helper.js
@@ -22,7 +22,7 @@ function annotateRule(ruleName, options) {
     ...restOptions
   } = options;
 
-  const documentationUrl = `${modelingGuidanceBaseUrl}/${ruleName}.md`;
+  const documentationUrl = `${modelingGuidanceBaseUrl}/${ruleName}/`;
 
   return {
     meta: {


### PR DESCRIPTION
### Proposed Changes

Rules are stored not with `.md` suffix, but as a "folder", cf. [called-element](https://docs.camunda.io/docs/next/components/modeler/reference/modeling-guidance/rules/called-element/).

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
