### PR TITLE
feat: add rules for ad-hoc subprocess completion configuration

### DIFF
--- a/rules/camunda-cloud/ad-hoc-sub-process.js
+++ b/rules/camunda-cloud/ad-hoc-sub-process.js
@@ -3,25 +3,53 @@ const { is, isAny } = require('bpmnlint-utils');
 const { reportErrors } = require('../utils/reporter');
 
 const { skipInNonExecutableProcess } = require('../utils/rule');
+const { greaterOrEqual } = require('../utils/version');
 
-module.exports = skipInNonExecutableProcess(function() {
+const COMPLETION_ATTRIBUTES_SUPPORT_VERSION = '8.8';
+
+module.exports = skipInNonExecutableProcess(function({ version }) {
   function check(node, reporter) {
     if (!is(node, 'bpmn:AdHocSubProcess')) {
       return;
     }
 
     // Ad-Hoc Sub-Process must contain at least one activity
-    if (node.get('flowElements').some(isActivity)) {
-      return;
+    if (!node.get('flowElements').some(isActivity)) {
+      reportErrors(node, reporter, {
+        message: 'Element of type <bpmn:AdHocSubProcess> must contain at least one activity',
+        data: {
+          node,
+          parentNode: null
+        }
+      });
     }
 
-    reportErrors(node, reporter, {
-      message: 'Element of type <bpmn:AdHocSubProcess> must contain at least one activity',
-      data: {
-        node,
-        parentNode: null
+    if (!greaterOrEqual(version, COMPLETION_ATTRIBUTES_SUPPORT_VERSION)) {
+      if (node.get('completionCondition')) {
+        reportErrors(node, reporter, [
+          {
+            message:  'Element of type <bpmn:completionCondition> within <bpmn:AdHocSubProcess> only allowed by Camunda 8.8 or newer',
+            data: {
+              node,
+              parentNode: null
+            }
+          }
+        ]);
       }
-    });
+
+      // check for property existence here as the attributes defaults to true and a value will always be present
+      if (Object.prototype.hasOwnProperty.call(node, 'cancelRemainingInstances')) {
+        reportErrors(node, reporter, [
+          {
+            message:  'Element of type <bpmn:AdHocSubProcess> with property <cancelRemainingInstances> only allowed by Camunda 8.8 or newer',
+            data: {
+              node,
+              parentNode: null
+            }
+          }
+        ]);
+      }
+    }
   }
 
   return {

--- a/test/camunda-cloud/ad-hoc-sub-process.spec.js
+++ b/test/camunda-cloud/ad-hoc-sub-process.spec.js
@@ -94,10 +94,16 @@ const invalid = [
     `)),
     report: {
       id: 'Subprocess_1',
-      message: 'Element of type <bpmn:completionCondition> within <bpmn:AdHocSubProcess> only allowed by Camunda 8.8 or newer',
+      message: 'Property <completionCondition> only allowed by Camunda 8.8 or newer',
+      path: [
+        'completionCondition'
+      ],
       data: {
+        type: 'camunda.propertyNotAllowed',
         node: 'Subprocess_1',
-        parentNode: null
+        parentNode: null,
+        property: 'completionCondition',
+        allowedVersion: '8.8'
       }
     }
   },
@@ -111,10 +117,16 @@ const invalid = [
     `)),
     report: {
       id: 'Subprocess_1',
-      message: 'Element of type <bpmn:AdHocSubProcess> with property <cancelRemainingInstances> only allowed by Camunda 8.8 or newer',
+      message: 'Property value of <false> only allowed by Camunda 8.8 or newer',
+      path: [
+        'cancelRemainingInstances'
+      ],
       data: {
+        type: 'camunda.propertyValueNotAllowed',
         node: 'Subprocess_1',
-        parentNode: null
+        parentNode: null,
+        property: 'cancelRemainingInstances',
+        allowedVersion: '8.8'
       }
     }
   },

--- a/test/camunda-cloud/ad-hoc-sub-process.spec.js
+++ b/test/camunda-cloud/ad-hoc-sub-process.spec.js
@@ -10,17 +10,48 @@ const {
 const valid = [
   {
     name: 'ad hoc sub process (with task)',
+    config: { version: '8.7' },
     moddleElement: createModdle(createProcess(`
       <bpmn:adHocSubProcess id="Subprocess_1">
         <bpmn:task id="Task_1" />
       </bpmn:adHocSubProcess>
     `))
-  }
+  },
+  {
+    name: 'ad hoc sub process (with completionCondition)',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="Subprocess_1">
+        <bpmn:task id="Task_1" />
+        <bpmn:completionCondition xsi:type="bpmn:tFormalExpression">=myCondition</bpmn:completionCondition>
+      </bpmn:adHocSubProcess>
+    `))
+  },
+  {
+    name: 'ad hoc sub process (with cancelRemainingInstances attribute)',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="Subprocess_1" cancelRemainingInstances="false">
+        <bpmn:task id="Task_1" />
+      </bpmn:adHocSubProcess>
+    `))
+  },
+  {
+    name: 'ad hoc sub process (with completionCondition and cancelRemainingInstances attribute)',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="Subprocess_1" cancelRemainingInstances="false">
+        <bpmn:task id="Task_1" />
+        <bpmn:completionCondition xsi:type="bpmn:tFormalExpression">=myCondition</bpmn:completionCondition>
+      </bpmn:adHocSubProcess>
+    `))
+  },
 ];
 
 const invalid = [
   {
     name: 'ad hoc sub process (empty)',
+    config: { version: '8.7' },
     moddleElement: createModdle(createProcess(`
       <bpmn:adHocSubProcess id="Subprocess_1">
       </bpmn:adHocSubProcess>
@@ -36,6 +67,7 @@ const invalid = [
   },
   {
     name: 'ad hoc sub process (no activity)',
+    config: { version: '8.7' },
     moddleElement: createModdle(createProcess(`
       <bpmn:adHocSubProcess id="Subprocess_1">
         <bpmn:exclusiveGateway id="Gateway_1" />
@@ -50,10 +82,45 @@ const invalid = [
         parentNode: null
       }
     }
-  }
+  },
+  {
+    name: 'ad hoc sub process (with completionCondition)',
+    config: { version: '8.7' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="Subprocess_1">
+        <bpmn:task id="Task_1" />
+        <bpmn:completionCondition xsi:type="bpmn:tFormalExpression">=myCondition</bpmn:completionCondition>
+      </bpmn:adHocSubProcess>
+    `)),
+    report: {
+      id: 'Subprocess_1',
+      message: 'Element of type <bpmn:completionCondition> within <bpmn:AdHocSubProcess> only allowed by Camunda 8.8 or newer',
+      data: {
+        node: 'Subprocess_1',
+        parentNode: null
+      }
+    }
+  },
+  {
+    name: 'ad hoc sub process (with cancelRemainingInstances attribute)',
+    config: { version: '8.7' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="Subprocess_1" cancelRemainingInstances="false">
+        <bpmn:task id="Task_1" />
+      </bpmn:adHocSubProcess>
+    `)),
+    report: {
+      id: 'Subprocess_1',
+      message: 'Element of type <bpmn:AdHocSubProcess> with property <cancelRemainingInstances> only allowed by Camunda 8.8 or newer',
+      data: {
+        node: 'Subprocess_1',
+        parentNode: null
+      }
+    }
+  },
 ];
 
-RuleTester.verify('called-element', rule, {
+RuleTester.verify('ad-hoc-sub-process', rule, {
   valid,
   invalid
 });

--- a/test/camunda-cloud/ad-hoc-sub-process.spec.js
+++ b/test/camunda-cloud/ad-hoc-sub-process.spec.js
@@ -7,6 +7,8 @@ const {
   createProcess
 } = require('../helper');
 
+const { ERROR_TYPES } = require('../../rules/utils/element');
+
 const valid = [
   {
     name: 'ad hoc sub process (with task)',
@@ -99,7 +101,7 @@ const invalid = [
         'completionCondition'
       ],
       data: {
-        type: 'camunda.propertyNotAllowed',
+        type: ERROR_TYPES.PROPERTY_NOT_ALLOWED,
         node: 'Subprocess_1',
         parentNode: null,
         property: 'completionCondition',
@@ -122,7 +124,7 @@ const invalid = [
         'cancelRemainingInstances'
       ],
       data: {
-        type: 'camunda.propertyValueNotAllowed',
+        type: ERROR_TYPES.PROPERTY_VALUE_NOT_ALLOWED,
         node: 'Subprocess_1',
         parentNode: null,
         property: 'cancelRemainingInstances',


### PR DESCRIPTION
The `completionCondition` expression and `cancelRemainingInstances` attribute will only be supported in Camunda 8.8+. This PR adds support to raise an error if one of these properties is set on a lower version.

### Proposed Changes

- If the `cancelRemainingInstances` attribute is set (getting the value is not enough as it is defined to default to `true` in the BPMN spec, so there's always a value): raise an error if the version is < 8.8
- If an `<bpmn:completionCondition />` element exists: raise an error if the version is < 8.8

An example process XML containing both properties:

```xml
  <bpmn:process id="Process_1" isExecutable="true">
    <bpmn:adHocSubProcess id="Activity_186wn7x" cancelRemainingInstances="false">
      <bpmn:task id="Activity_06d3rvb" name="A" />
      <bpmn:task id="Activity_1bkr1i6" name="B" />
      <bpmn:completionCondition xsi:type="bpmn:tFormalExpression">=myCondition</bpmn:completionCondition>
    </bpmn:adHocSubProcess>
  </bpmn:process>
```

Relates to https://github.com/camunda/camunda-modeler/issues/4850.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
