### PR TITLE
fix: allow call activity in ad-hoc subprocess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmnlint-plugin-camunda-compat](https://github.com/camun
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: allow call activity in ad-hoc subprocess
+
 ## 2.33.1
 
 * `FIX`: correct documentation URL ([#194](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/194))

--- a/rules/camunda-cloud/ad-hoc-sub-process.js
+++ b/rules/camunda-cloud/ad-hoc-sub-process.js
@@ -9,7 +9,7 @@ const { reportErrors } = require('../utils/reporter');
 const { skipInNonExecutableProcess } = require('../utils/rule');
 const { greaterOrEqual } = require('../utils/version');
 
-const COMPLETION_ATTRIBUTES_SUPPORT_VERSION = '8.8';
+const COMPLETION_ALLOWED_VERSION = '8.8';
 
 module.exports = skipInNonExecutableProcess(function({ version }) {
   function check(node, reporter) {
@@ -19,7 +19,7 @@ module.exports = skipInNonExecutableProcess(function({ version }) {
 
     const errors = [];
 
-    // Ad-Hoc Sub-Process must contain at least one activity
+    // ad-hoc sub-process must contain at least one activity
     if (!node.get('flowElements').some(isActivity)) {
       errors.push({
         message: 'Element of type <bpmn:AdHocSubProcess> must contain at least one activity',
@@ -32,15 +32,15 @@ module.exports = skipInNonExecutableProcess(function({ version }) {
       });
     }
 
-    if (!greaterOrEqual(version, COMPLETION_ATTRIBUTES_SUPPORT_VERSION)) {
+    if (!greaterOrEqual(version, COMPLETION_ALLOWED_VERSION)) {
       errors.push(...hasProperties(node, {
         completionCondition: {
           allowed: false,
-          allowedVersion: COMPLETION_ATTRIBUTES_SUPPORT_VERSION
+          allowedVersion: COMPLETION_ALLOWED_VERSION
         },
         cancelRemainingInstances: {
           allowed: value => value !== false, // only allow true which is default value
-          allowedVersion: COMPLETION_ATTRIBUTES_SUPPORT_VERSION
+          allowedVersion: COMPLETION_ALLOWED_VERSION
         }
       }, node));
     }

--- a/rules/camunda-cloud/ad-hoc-sub-process.js
+++ b/rules/camunda-cloud/ad-hoc-sub-process.js
@@ -1,4 +1,4 @@
-const { is, isAny } = require('bpmnlint-utils');
+const { is } = require('bpmnlint-utils');
 
 const { hasProperties } = require('../utils/element');
 const { reportErrors } = require('../utils/reporter');
@@ -51,5 +51,5 @@ module.exports = skipInNonExecutableProcess(function({ version }) {
 });
 
 function isActivity(element) {
-  return isAny(element, [ 'bpmn:Task', 'bpmn:SubProcess' ]);
+  return is(element, 'bpmn:Activity');
 }

--- a/rules/camunda-cloud/ad-hoc-sub-process.js
+++ b/rules/camunda-cloud/ad-hoc-sub-process.js
@@ -1,6 +1,9 @@
 const { is } = require('bpmnlint-utils');
 
-const { hasProperties } = require('../utils/element');
+const {
+  ERROR_TYPES,
+  hasProperties
+} = require('../utils/element');
 const { reportErrors } = require('../utils/reporter');
 
 const { skipInNonExecutableProcess } = require('../utils/rule');
@@ -21,8 +24,10 @@ module.exports = skipInNonExecutableProcess(function({ version }) {
       errors.push({
         message: 'Element of type <bpmn:AdHocSubProcess> must contain at least one activity',
         data: {
+          type: ERROR_TYPES.CHILD_ELEMENT_OF_TYPE_REQUIRED,
           node,
-          parentNode: null
+          parentNode: null,
+          requiredType: 'bpmn:Activity'
         }
       });
     }

--- a/rules/camunda-cloud/error-reference.js
+++ b/rules/camunda-cloud/error-reference.js
@@ -15,7 +15,7 @@ const { skipInNonExecutableProcess } = require('../utils/rule');
 const { greaterOrEqual } = require('../utils/version');
 const { annotateRule } = require('../helper');
 
-const noErrorRefAllowedVersion = '8.2';
+const NO_ERROR_REF_ALLOWED_VERSION = '8.2';
 
 module.exports = skipInNonExecutableProcess(function({ version }) {
   function check(node, reporter) {
@@ -69,5 +69,5 @@ module.exports = skipInNonExecutableProcess(function({ version }) {
 });
 
 function isNoErrorRefAllowed(node, version) {
-  return is(node, 'bpmn:CatchEvent') && greaterOrEqual(version, noErrorRefAllowedVersion);
+  return is(node, 'bpmn:CatchEvent') && greaterOrEqual(version, NO_ERROR_REF_ALLOWED_VERSION);
 }

--- a/rules/camunda-cloud/execution-listener.js
+++ b/rules/camunda-cloud/execution-listener.js
@@ -7,7 +7,6 @@ const { reportErrors } = require('../utils/reporter');
 
 const { skipInNonExecutableProcess } = require('../utils/rule');
 
-
 module.exports = skipInNonExecutableProcess(function() {
   function check(node, reporter) {
     const executionListeners = findExtensionElement(node, 'zeebe:ExecutionListeners');

--- a/rules/camunda-cloud/no-version-tag.js
+++ b/rules/camunda-cloud/no-version-tag.js
@@ -6,12 +6,12 @@ const { reportErrors } = require('../utils/reporter');
 
 const { skipInNonExecutableProcess } = require('../utils/rule');
 
-const allowedVersion = '8.6';
+const ALLOWED_VERSION = '8.6';
 
 module.exports = skipInNonExecutableProcess(function() {
   function check(node, reporter) {
     if (is(node, 'bpmn:Process')) {
-      const errors = hasNoExtensionElement(node, 'zeebe:VersionTag', node, allowedVersion);
+      const errors = hasNoExtensionElement(node, 'zeebe:VersionTag', node, ALLOWED_VERSION);
 
       if (errors && errors.length) {
         reportErrors(node, reporter, errors);

--- a/rules/camunda-cloud/start-event-form.js
+++ b/rules/camunda-cloud/start-event-form.js
@@ -16,7 +16,7 @@ const { skipInNonExecutableProcess } = require('../utils/rule');
 
 const { greaterOrEqual } = require('../utils/version');
 
-const allowedVersion = '8.3';
+const ALLOWED_VERSION = '8.3';
 
 module.exports = skipInNonExecutableProcess(function({ version }) {
   function check(node, reporter) {
@@ -25,8 +25,8 @@ module.exports = skipInNonExecutableProcess(function({ version }) {
     }
 
     // Camunda 8.2 and older
-    if (!greaterOrEqual(version, allowedVersion)) {
-      let errors = hasNoExtensionElement(node, 'zeebe:FormDefinition', node, allowedVersion);
+    if (!greaterOrEqual(version, ALLOWED_VERSION)) {
+      let errors = hasNoExtensionElement(node, 'zeebe:FormDefinition', node, ALLOWED_VERSION);
 
       if (errors.length) {
         reportErrors(node, reporter, errors);

--- a/rules/camunda-cloud/task-listener.js
+++ b/rules/camunda-cloud/task-listener.js
@@ -9,7 +9,6 @@ const { reportErrors } = require('../utils/reporter');
 
 const { skipInNonExecutableProcess } = require('../utils/rule');
 
-
 module.exports = skipInNonExecutableProcess(function() {
   function check(node, reporter) {
     if (!is(node, 'bpmn:UserTask')) {

--- a/rules/camunda-cloud/user-task-form.js
+++ b/rules/camunda-cloud/user-task-form.js
@@ -14,7 +14,7 @@ const { skipInNonExecutableProcess } = require('../utils/rule');
 
 const { greaterOrEqual } = require('../utils/version');
 
-const formIdAllowedVersions = {
+const FORM_ID_ALLOWED_VERSIONS = {
   desktop: '8.4',
   web: '8.0'
 };
@@ -55,7 +55,7 @@ module.exports = skipInNonExecutableProcess(function({ modeler = 'desktop', vers
 
     let errors;
 
-    const formIdAllowedVersion = formIdAllowedVersions[ modeler ];
+    const formIdAllowedVersion = FORM_ID_ALLOWED_VERSIONS[ modeler ];
 
     if (isFormIdAllowed(version, formIdAllowedVersion)) {
       errors = hasProperty(formDefinition, [

--- a/rules/utils/error-types.js
+++ b/rules/utils/error-types.js
@@ -1,4 +1,5 @@
 module.exports.ERROR_TYPES = Object.freeze({
+  CHILD_ELEMENT_OF_TYPE_REQUIRED: 'camunda.childElementOfTypeRequired',
   CHILD_ELEMENT_TYPE_NOT_ALLOWED: 'camunda.childElementTypeNotAllowed',
   CONNECTORS_PROPERTY_VALUE_NOT_ALLOWED: 'camunda.connectors.propertyValueNotAllowed',
   ELEMENT_COLLAPSED_NOT_ALLOWED: 'camunda.elementCollapsedNotAllowed',

--- a/test/camunda-cloud/ad-hoc-sub-process.spec.js
+++ b/test/camunda-cloud/ad-hoc-sub-process.spec.js
@@ -80,8 +80,10 @@ const invalid = [
       id: 'Subprocess_1',
       message: 'Element of type <bpmn:AdHocSubProcess> must contain at least one activity',
       data: {
+        type: ERROR_TYPES.CHILD_ELEMENT_OF_TYPE_REQUIRED,
         node: 'Subprocess_1',
-        parentNode: null
+        parentNode: null,
+        requiredType: 'bpmn:Activity'
       }
     }
   },
@@ -98,8 +100,10 @@ const invalid = [
       id: 'Subprocess_1',
       message: 'Element of type <bpmn:AdHocSubProcess> must contain at least one activity',
       data: {
+        type: ERROR_TYPES.CHILD_ELEMENT_OF_TYPE_REQUIRED,
         node: 'Subprocess_1',
-        parentNode: null
+        parentNode: null,
+        requiredType: 'bpmn:Activity'
       }
     }
   },

--- a/test/camunda-cloud/ad-hoc-sub-process.spec.js
+++ b/test/camunda-cloud/ad-hoc-sub-process.spec.js
@@ -20,6 +20,24 @@ const valid = [
     `))
   },
   {
+    name: 'ad hoc sub process (with subprocess)',
+    config: { version: '8.7' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="Subprocess_1">
+        <bpmn:subProcess id="SubProcess" />
+      </bpmn:adHocSubProcess>
+    `))
+  },
+  {
+    name: 'ad hoc sub process (with call activity)',
+    config: { version: '8.7' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="Subprocess_1">
+        <bpmn:callActivity id="CallActivity" />
+      </bpmn:adHocSubProcess>
+    `))
+  },
+  {
     name: 'ad hoc sub process (with completionCondition)',
     config: { version: '8.8' },
     moddleElement: createModdle(createProcess(`


### PR DESCRIPTION
### Proposed Changes

This fixes the validation for ad-hoc subprocess where it keeps reporting missing activity even when call activity is placed inside. We can and should use abstract type in this case.

Ad-hoc subprocess with a single call activity can be successfully deployed to 8.7.

<img width="1896" alt="image" src="https://github.com/user-attachments/assets/5341aa20-1c5c-4adf-972c-3de8d46ca0f7" />

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
