### PR TITLE
Allow boundaryEvent on ad-hoc subprocesses

### DIFF
--- a/rules/camunda-cloud/escalation-boundary-event-attached-to-ref.js
+++ b/rules/camunda-cloud/escalation-boundary-event-attached-to-ref.js
@@ -5,7 +5,6 @@ const {
 
 const {
   getEventDefinition,
-  isAnyExactly
 } = require('../utils/element');
 
 const { ERROR_TYPES } = require('../utils/error-types');

--- a/rules/camunda-cloud/escalation-boundary-event-attached-to-ref.js
+++ b/rules/camunda-cloud/escalation-boundary-event-attached-to-ref.js
@@ -28,7 +28,7 @@ module.exports = skipInNonExecutableProcess(function() {
 
     const attachedToRef = node.get('attachedToRef');
 
-    if (attachedToRef && !isAnyExactly(attachedToRef, [ 'bpmn:CallActivity', 'bpmn:SubProcess' ])) {
+    if (attachedToRef && !isAnyExactly(attachedToRef, [ 'bpmn:CallActivity', 'bpmn:SubProcess', 'bpmn:AdHocSubProcess' ])) {
       reportErrors(node, reporter, {
         message: `Element of type <bpmn:BoundaryEvent> with event definition of type <bpmn:EscalationEventDefinition> is not allowed to be attached to element of type <${ attachedToRef.$type }>`,
         path: null,

--- a/rules/camunda-cloud/escalation-boundary-event-attached-to-ref.js
+++ b/rules/camunda-cloud/escalation-boundary-event-attached-to-ref.js
@@ -28,7 +28,7 @@ module.exports = skipInNonExecutableProcess(function() {
 
     const attachedToRef = node.get('attachedToRef');
 
-    if (attachedToRef && !isAnyExactly(attachedToRef, [ 'bpmn:CallActivity', 'bpmn:SubProcess', 'bpmn:AdHocSubProcess' ])) {
+    if (attachedToRef && is(attachedToRef, 'bpmn:Task')) {
       reportErrors(node, reporter, {
         message: `Element of type <bpmn:BoundaryEvent> with event definition of type <bpmn:EscalationEventDefinition> is not allowed to be attached to element of type <${ attachedToRef.$type }>`,
         path: null,

--- a/test/camunda-cloud/escalation-boundary-event-attached-to-ref.spec.js
+++ b/test/camunda-cloud/escalation-boundary-event-attached-to-ref.spec.js
@@ -21,6 +21,15 @@ const valid = [
   `))
   },
   {
+    name: 'escalation boundary event (attached to ad-hoc sub process)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="AdHocSubProcess_1" />
+      <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="AdHocSubProcess_1">
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_1" />
+      </bpmn:boundaryEvent>
+  `))
+  },
+  {
     name: 'escalation boundary event (attached to sub process)',
     moddleElement: createModdle(createProcess(`
       <bpmn:subProcess id="SubProcess_1" />

--- a/test/camunda-cloud/escalation-boundary-event-attached-to-ref.spec.js
+++ b/test/camunda-cloud/escalation-boundary-event-attached-to-ref.spec.js
@@ -39,6 +39,15 @@ const valid = [
   `))
   },
   {
+    name: 'escalation boundary event (attached to transaction)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:transaction id="Transaction_1" />
+      <bpmn:boundaryEvent id="BoundaryEvent_1" attachedToRef="Transaction_1">
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_1" />
+      </bpmn:boundaryEvent>
+  `))
+  },
+  {
     name: 'task',
     moddleElement: createModdle(createProcess('<bpmn:task id="Task_1" />'))
   },


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/4859

### Proposed Changes

Allow BoundaryEvent on ad-hoc subprocesses. Only Tasks are not allowed to have BoundaryEvents.

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
