### PR TITLE
fix(camunda-cloud): correct zeebe-user-task documentation URL

### DIFF
--- a/rules/camunda-cloud/zeebe-user-task.js
+++ b/rules/camunda-cloud/zeebe-user-task.js
@@ -22,7 +22,7 @@ module.exports = skipInNonExecutableProcess(function() {
   return {
     meta: {
       documentation: {
-        url: 'https://docs.camunda.io/docs/next/apis-tools/migration-manuals/migrate-to-zeebe-user-tasks'
+        url: 'https://docs.camunda.io/docs/next/apis-tools/migration-manuals/migrate-to-camunda-user-tasks'
       }
     },
     check


### PR DESCRIPTION
### Proposed Changes

Now moved to [*camunda naming](https://docs.camunda.io/docs/next/apis-tools/migration-manuals/migrate-to-camunda-user-tasks/).

Related to https://github.com/camunda/camunda-modeler/issues/4873

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
