### PR TITLE
chore: update doc link for history ttl

### DIFF
--- a/rules/camunda-platform/history-time-to-live.js
+++ b/rules/camunda-platform/history-time-to-live.js
@@ -1,7 +1,5 @@
 const { is } = require('bpmnlint-utils');
 
-const { annotateRule } = require('../helper');
-
 const { skipInNonExecutableProcess } = require('../utils/rule');
 
 module.exports = skipInNonExecutableProcess(function() {
@@ -16,7 +14,12 @@ module.exports = skipInNonExecutableProcess(function() {
     }
   }
 
-  return annotateRule('history-time-to-live', {
+  return {
+    meta: {
+      documentation: {
+        url: 'https://docs.camunda.org/manual/latest/modeler/history-time-to-live/'
+      }
+    },
     check
-  });
+  };
 });


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/4957

### Proposed Changes

Because history time to live is the only camunda 7 rule with a doc reference I choose to hard code it directly. I don't think it is likely that we will add more documented camunda 7 rules.

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Visual Demo
<img width="975" alt="image" src="https://github.com/user-attachments/assets/d3bdb248-0ec0-4f00-b1d0-93964692b9c4" />

### Steps to try out
```bash
npx @bpmn-io/sr camunda/linting -l camunda/bpmnlint-plugin-camunda-compat#4957-update-history-ttl-link -c 'npm run start:platform'
```

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [x] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
