### PR TITLE
fix: correct allowed version for input mapping without source

### DIFF
--- a/rules/camunda-cloud/io-mapping.js
+++ b/rules/camunda-cloud/io-mapping.js
@@ -3,7 +3,7 @@ const { reportErrors } = require('../utils/reporter');
 const { skipInNonExecutableProcess } = require('../utils/rule');
 const { greaterOrEqual } = require('../utils/version');
 
-const ALLOWED_VERSION_NO_INPUT_SOURCE = '8.7';
+const ALLOWED_VERSION_NO_INPUT_SOURCE = '8.8';
 
 module.exports = skipInNonExecutableProcess(function({ version }) {
   function check(node, reporter) {

--- a/test/camunda-cloud/integration/io-mapping-errors.bpmn
+++ b/test/camunda-cloud/integration/io-mapping-errors.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1n94o52" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.37.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1n94o52" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.37.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:serviceTask id="Activity_1">
       <bpmn:extensionElements>

--- a/test/camunda-cloud/integration/io-mapping.bpmn
+++ b/test/camunda-cloud/integration/io-mapping.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1n94o52" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.36.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1n94o52" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.36.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:serviceTask id="Activity_1">
       <bpmn:extensionElements>

--- a/test/camunda-cloud/io-mapping.spec.js
+++ b/test/camunda-cloud/io-mapping.spec.js
@@ -9,7 +9,7 @@ const rule = require('../../rules/camunda-cloud/io-mapping');
 const valid = [
   {
     name: 'complete io mapping',
-    config: { version: '8.6' },
+    config: { version: '8.7' },
     moddleElement: createModdle(
       createProcess(`
       <bpmn:serviceTask id="ServiceTask">
@@ -25,8 +25,8 @@ const valid = [
     ),
   },
   {
-    name: 'missing input source (allowed by Camunda >= 8.7)',
-    config: { version: '8.7' },
+    name: 'missing input source (allowed by Camunda >= 8.8)',
+    config: { version: '8.8' },
     moddleElement: createModdle(
       createProcess(`
       <bpmn:serviceTask id="ServiceTask">
@@ -46,7 +46,7 @@ const valid = [
 const invalid = [
   {
     name: 'missing all io mapping properties',
-    config: { version: '8.6' },
+    config: { version: '8.7' },
     moddleElement: createModdle(
       createProcess(`
        <bpmn:serviceTask id="ServiceTask">
@@ -63,14 +63,14 @@ const invalid = [
     report: [
       {
         id: 'ServiceTask',
-        message: 'Element of type <zeebe:Input> without property <source> only allowed by Camunda 8.7 or newer',
+        message: 'Element of type <zeebe:Input> without property <source> only allowed by Camunda 8.8 or newer',
         path: [ 'extensionElements', 'values', 1, 'inputParameters', 0, 'source' ],
         data: {
           type: ERROR_TYPES.PROPERTY_REQUIRED,
           node: 'zeebe:Input',
           parentNode: 'ServiceTask',
           requiredProperty: 'source',
-          allowedVersion: '8.7',
+          allowedVersion: '8.8',
         },
         category: 'error',
       },


### PR DESCRIPTION
Related to https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/207#discussion_r2228000732

### Proposed Changes

increase version by one for io mapping rule as empty input source is only allowed in > 8.7 not >=8.7
<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
