### PR TITLE
feat: validate `outputCollection` and `outputElement` on `zeebe:adHoc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmnlint-plugin-camunda-compat](https://github.com/camun
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: validate `outputCollection` and `outputElement` on `zeebe:adHoc`
+
 ## 2.39.2
 
 * `FIX`: revert inclusion of camunda feel builtins due to performance issues (introduced in v2.38.0) ([#215](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/215))

--- a/test/camunda-cloud/ad-hoc-sub-process.spec.js
+++ b/test/camunda-cloud/ad-hoc-sub-process.spec.js
@@ -66,6 +66,18 @@ const valid = [
       </bpmn:adHocSubProcess>
     `))
   },
+  {
+    name: 'ad hoc sub process (with output collection and output element attributes)',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="Subprocess_1">
+        <bpmn:extensionElements>
+          <zeebe:adHoc outputCollection="myCollection" outputElement="=myElement" />
+        </bpmn:extensionElements>
+        <bpmn:task id="Task_1" />
+      </bpmn:adHocSubProcess>
+    `))
+  }
 ];
 
 const invalid = [
@@ -154,6 +166,100 @@ const invalid = [
       }
     }
   },
+  {
+    name: 'ad hoc sub process (with output collection and output element attributes)',
+    config: { version: '8.7' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="Subprocess_1">
+        <bpmn:extensionElements>
+          <zeebe:adHoc outputCollection="myCollection" outputElement="=myElement" />
+        </bpmn:extensionElements>
+        <bpmn:task id="Task_1" />
+      </bpmn:adHocSubProcess>
+    `)),
+    report: [
+      {
+        id: 'Subprocess_1',
+        message: 'Property <outputCollection> only allowed by Camunda 8.8 or newer',
+        path: [
+          'outputCollection'
+        ],
+        data: {
+          type: ERROR_TYPES.PROPERTY_NOT_ALLOWED,
+          node: 'zeebe:AdHoc',
+          parentNode: null,
+          property: 'outputCollection',
+          allowedVersion: '8.8'
+        }
+      },
+      {
+        id: 'Subprocess_1',
+        message: 'Property <outputElement> only allowed by Camunda 8.8 or newer',
+        path: [
+          'outputElement'
+        ],
+        data: {
+          type: ERROR_TYPES.PROPERTY_NOT_ALLOWED,
+          node: 'zeebe:AdHoc',
+          parentNode: null,
+          property: 'outputElement',
+          allowedVersion: '8.8'
+        }
+      }
+    ]
+  },
+  {
+    name: 'ad hoc sub process (with output collection, without output element)',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="Subprocess_1">
+        <bpmn:extensionElements>
+          <zeebe:adHoc outputCollection="myCollection" />
+        </bpmn:extensionElements>
+        <bpmn:task id="Task_1" />
+      </bpmn:adHocSubProcess>
+    `)),
+    report: {
+      id: 'Subprocess_1',
+      message: 'Element of type <zeebe:AdHoc> must have property <outputElement> if it has property <outputCollection>',
+      path: [
+        'outputElement'
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_DEPENDENT_REQUIRED,
+        node: 'zeebe:AdHoc',
+        parentNode: null,
+        property: 'outputCollection',
+        dependentRequiredProperty: 'outputElement'
+      }
+    }
+  },
+  {
+    name: 'ad hoc sub process (with output element, without output collection)',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="Subprocess_1">
+        <bpmn:extensionElements>
+          <zeebe:adHoc outputElement="=myElement" />
+        </bpmn:extensionElements>
+        <bpmn:task id="Task_1" />
+      </bpmn:adHocSubProcess>
+    `)),
+    report: {
+      id: 'Subprocess_1',
+      message: 'Element of type <zeebe:AdHoc> must have property <outputCollection> if it has property <outputElement>',
+      path: [
+        'outputCollection'
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_DEPENDENT_REQUIRED,
+        node: 'zeebe:AdHoc',
+        parentNode: null,
+        property: 'outputElement',
+        dependentRequiredProperty: 'outputCollection'
+      }
+    }
+  }
 ];
 
 RuleTester.verify('ad-hoc-sub-process', rule, {


### PR DESCRIPTION
Related to https://github.com/camunda/tmp-camunda-modeler-adhoc-subprocess/issues/3

### Proposed Changes

Validation rules for output collection and output element:
* [x] both require Camunda 8.8
* [x] either both or none must be set

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
