### PR TITLE
fix: don't break linter when `priority` is a number

### DIFF
--- a/rules/camunda-cloud/priority-definition.js
+++ b/rules/camunda-cloud/priority-definition.js
@@ -30,7 +30,9 @@ module.exports = skipInNonExecutableProcess(function() {
       errors = [
         ...errors,
         ...hasExpression(priorityDefinition, 'priority', {
-          allowed: value => isValidPriority(value)
+
+          // convert to string for validation, cf. https://github.com/camunda/camunda-modeler/issues/5199
+          allowed: value => isValidPriority(`${value}`)
         }, node)
       ];
     }

--- a/test/camunda-cloud/integration/priority-definition.spec.js
+++ b/test/camunda-cloud/integration/priority-definition.spec.js
@@ -42,6 +42,21 @@ describe('integration - priority definition', function() {
           expect(reports[ 'camunda-compat/priority-definition' ]).not.to.exist;
         });
 
+
+        it('should not have errors for number type', async function() {
+
+          // given
+          const { root } = await readModdle('test/camunda-cloud/integration/priority-definition.bpmn');
+
+          root.rootElements[0].flowElements[0].extensionElements.values[0].priority = 40;
+
+          // when
+          const reports = await linter.lint(root);
+
+          // then
+          expect(reports[ 'camunda-compat/priority-definition' ]).not.to.exist;
+        });
+
       });
 
 
@@ -51,6 +66,21 @@ describe('integration - priority definition', function() {
 
           // given
           const { root } = await readModdle('test/camunda-cloud/integration/priority-definition-errors.bpmn');
+
+          // when
+          const reports = await linter.lint(root);
+
+          // then
+          expect(reports[ 'camunda-compat/priority-definition' ]).to.exist;
+        });
+
+
+        it('should not have errors for number type', async function() {
+
+          // given
+          const { root } = await readModdle('test/camunda-cloud/integration/priority-definition.bpmn');
+
+          root.rootElements[0].flowElements[0].extensionElements.values[0].priority = -40;
 
           // when
           const reports = await linter.lint(root);


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/camunda/camunda-modeler/issues/5092
Workaround until https://github.com/camunda/camunda-modeler/issues/5199

Additional context: [Slack discussion ](https://camunda.slack.com/archives/C0880P1H8UA/p1754396855003659)

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
