### PR TITLE
Validate `bpmn:AdHocSubProcess` implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [bpmnlint-plugin-camunda-compat](https://github.com/camun
 
 ___Note:__ Yet to be released changes appear here._
 
+## 2.41.0
+
+* `FEAT`: validate `bpmn:AdHocSubProcess` implementation ([#214](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/214))
+
 ## 2.40.0
 
 * `FEAT`: lint `zeebe:outputCollection` and `zeebe:outputElement` of `zeebe:adHoc` elements ([#212](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/212))

--- a/rules/camunda-cloud/implementation/config.js
+++ b/rules/camunda-cloud/implementation/config.js
@@ -3,6 +3,7 @@ module.exports = {
     'bpmn:BusinessRuleTask': '1.3'
   },
   taskDefinition: {
+    'bpmn:AdHocSubProcess': '8.8',
     'bpmn:BusinessRuleTask': '1.1',
     'bpmn:IntermediateThrowEvent': {
       'bpmn:MessageEventDefinition': '1.2'

--- a/test/camunda-cloud/implementation.spec.js
+++ b/test/camunda-cloud/implementation.spec.js
@@ -149,6 +149,31 @@ const valid = [
         <bpmn:serviceTask id="ServiceTask_1" />
       </bpmn:process>
     `))
+  },
+  {
+    name: 'ad-hoc subprocess (job worker) (Camunda 8.8)',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="Task_1">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+      </bpmn:adHocSubProcess>
+    `))
+  },
+  {
+    name: 'ad-hoc subprocess (BPMN) (Camunda 8.7)',
+    config: { version: '8.7' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="Task_1" />
+    `))
+  },
+  {
+    name: 'ad-hoc subprocess (BPMN) (Camunda 8.8)',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="Task_1" />
+    `))
   }
 ];
 
@@ -656,7 +681,61 @@ const invalid = [
         requiredProperty: 'resultVariable'
       }
     }
-  }
+  },
+  {
+    name: 'ad-hoc subprocess (no task definition type) (Camunda 8.8)',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="AdHocSubProcess_1">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition />
+        </bpmn:extensionElements>
+      </bpmn:adHocSubProcess>
+    `)),
+    report: {
+      id: 'AdHocSubProcess_1',
+      message: 'Element of type <zeebe:TaskDefinition> must have property <type>',
+      path: [
+        'extensionElements',
+        'values',
+        0,
+        'type'
+      ],
+      data: {
+        type: ERROR_TYPES.PROPERTY_REQUIRED,
+        node: 'zeebe:TaskDefinition',
+        parentNode: 'AdHocSubProcess_1',
+        requiredProperty: 'type'
+      }
+    }
+  },
+  {
+    name: 'ad-hoc subprocess (task definition) (Camunda 8.7)',
+    config: { version: '8.7' },
+    moddleElement: createModdle(createProcess(`
+        <bpmn:adHocSubProcess id="AdHocSubProcess_1">
+          <bpmn:extensionElements>
+            <zeebe:taskDefinition type="job-worker" />
+          </bpmn:extensionElements>
+        </bpmn:adHocSubProcess>
+      `)),
+    report: {
+      id: 'AdHocSubProcess_1',
+      message: 'Extension element of type <zeebe:TaskDefinition> only allowed by Camunda 8.8 or newer',
+      path: [
+        'extensionElements',
+        'values',
+        0
+      ],
+      data: {
+        type: ERROR_TYPES.EXTENSION_ELEMENT_NOT_ALLOWED,
+        node: 'AdHocSubProcess_1',
+        parentNode: null,
+        extensionElement: 'zeebe:TaskDefinition',
+        allowedVersion: '8.8'
+      }
+    }
+  },
 ];
 
 RuleTester.verify('implementation', rule, {

--- a/test/camunda-cloud/integration/no-priority-definition.spec.js
+++ b/test/camunda-cloud/integration/no-priority-definition.spec.js
@@ -58,8 +58,6 @@ describe('integration - no-priority-definition', function() {
           // when
           const reports = await linter.lint(root);
 
-          console.log('reports', reports);
-
           // then
           expect(reports[ 'camunda-compat/no-priority-definition' ]).to.exist;
         });


### PR DESCRIPTION
### Proposed Changes

This PR adds a check for task definition in an ad-hoc subprocess. Since the element can have an implementation without a dedicated extension (`zeebe:AdHoc` can be present for both BPMN and job worker implementation), the logic needed to be adjusted.

Related to https://github.com/camunda/tmp-camunda-modeler-adhoc-subprocess/issues/1

Built on top of https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/212

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->


