### PR TITLE
fix: ignore non-FEEL properties in the FEEL rule

### DIFF
--- a/rules/camunda-cloud/feel.js
+++ b/rules/camunda-cloud/feel.js
@@ -17,6 +17,21 @@ const { ERROR_TYPES } = require('../utils/error-types');
 const { skipInNonExecutableProcess } = require('../utils/rule');
 const { annotateRule } = require('../helper');
 
+// Properties ignored globally
+const IGNORED_PROPERTIES = [
+  'name'
+];
+
+// Properties ignored only for specific element types
+const IGNORED_PROPERTIES_BY_TYPE = {
+  'zeebe:Input': [ 'target' ],
+  'zeebe:Output': [ 'target' ],
+  'zeebe:Header': [ 'key', 'value' ],
+  'zeebe:Property': [ 'name', 'value' ],
+  'zeebe:CalledDecision': [ 'resultVariable' ],
+  'zeebe:Script': [ 'resultVariable' ]
+};
+
 module.exports = skipInNonExecutableProcess(function() {
   function check(node, reporter) {
     if (is(node, 'bpmn:Expression')) {
@@ -36,7 +51,7 @@ module.exports = skipInNonExecutableProcess(function() {
         propertyValue = propertyValue.get('body');
       }
 
-      if (isFeelProperty([ propertyName, propertyValue ])) {
+      if (isFeelProperty(node, propertyName, propertyValue)) {
         const lintErrors = lintExpression(propertyValue.substring(1), {
           parserDialect: 'camunda',
           builtins: camundaReservedNameBuiltins
@@ -74,12 +89,19 @@ module.exports = skipInNonExecutableProcess(function() {
   });
 });
 
-const isFeelProperty = ([ propertyName, value ]) => {
-  return !isIgnoredProperty(propertyName) && isString(value) && value.startsWith('=');
+const isFeelProperty = (node, propertyName, value) => {
+  return !isIgnoredProperty(node, propertyName) && isString(value) && value.startsWith('=');
 };
 
-const isIgnoredProperty = propertyName => {
-  return propertyName.startsWith('$');
+const isIgnoredProperty = (node, propertyName) => {
+  if (propertyName.startsWith('$') || IGNORED_PROPERTIES.includes(propertyName)) {
+    return true;
+  }
+
+  const nodeType = node.$type;
+  const ignoredForType = IGNORED_PROPERTIES_BY_TYPE[nodeType];
+
+  return ignoredForType && ignoredForType.includes(propertyName);
 };
 
 const findParentNode = node => {

--- a/test/camunda-cloud/feel.spec.js
+++ b/test/camunda-cloud/feel.spec.js
@@ -95,6 +95,80 @@ const valid = [
         </bpmn:serviceTask>
       </bpmn:process>
     `))
+  },
+  {
+    name: 'name with FEEL-like expression (ignored)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:task id="Task_1" name="==...foo" />
+    `))
+  },
+  {
+    name: 'input target with FEEL-like expression (ignored)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:serviceTask id="Task_1">
+        <bpmn:extensionElements>
+          <zeebe:ioMapping>
+            <zeebe:input target="=...foo" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    `))
+  },
+  {
+    name: 'output target with FEEL-like expression (ignored)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:serviceTask id="Task_1">
+        <bpmn:extensionElements>
+          <zeebe:ioMapping>
+            <zeebe:output target="=...foo" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    `))
+  },
+  {
+    name: 'task header key and value with FEEL-like expression (ignored)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:serviceTask id="Task_1">
+        <bpmn:extensionElements>
+          <zeebe:taskHeaders>
+            <zeebe:header key="==...foo" value="==...foo" />
+          </zeebe:taskHeaders>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    `))
+  },
+  {
+    name: 'zeebe property name and value with FEEL-like expression (ignored)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:serviceTask id="Task_1">
+        <bpmn:extensionElements>
+          <zeebe:properties>
+            <zeebe:property name="==...foo" value="==...foo" />
+          </zeebe:properties>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    `))
+  },
+  {
+    name: 'called decision resultVariable with FEEL-like expression (ignored)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:businessRuleTask id="Task_1">
+        <bpmn:extensionElements>
+          <zeebe:calledDecision decisionId="myDecision" resultVariable="==...foo" />
+        </bpmn:extensionElements>
+      </bpmn:businessRuleTask>
+    `))
+  },
+  {
+    name: 'script resultVariable with FEEL-like expression (ignored)',
+    moddleElement: createModdle(createProcess(`
+      <bpmn:scriptTask id="Task_1">
+        <bpmn:extensionElements>
+          <zeebe:script expression="=1+1" resultVariable="==...foo" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+    `))
   }
 ];
 


### PR DESCRIPTION
Closes https://github.com/camunda/bpmnlint-plugin-camunda-compat/issues/53

### Proposed Changes

<!--
Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.
--> 

Ignore non-FEEL properties even if they are formatted like a FEEL expression.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
