### PR TITLE
fix: add guard to throw an error when rule config is missing version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to [bpmnlint-plugin-camunda-compat](https://github.com/camun
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: add guard to throw an error when rule config is missing version ([#234](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/234))
+
+
 ## 2.49.0
 
 * `FEAT`: add Camunda 8.10 config ([#233](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/233))

--- a/README.md
+++ b/README.md
@@ -16,14 +16,17 @@ npm install -D bpmnlint bpmnlint-plugin-camunda-compat
 
 Add configuration corresponding to your execution platform and version to your [`.bpmnlintrc` configuration](https://github.com/bpmn-io/bpmnlint#configuration):
 
-```json
+```jsonc
 {
   "extends": [
     "bpmnlint:recommended",
     "plugin:camunda-compat/camunda-cloud-8-0"
   ],
   "rules": {
-    "camunda-compat/timer": "off"
+    "camunda-compat/called-element": "off",
+
+    // some rules require a config with version to be provided
+    "camunda-compat/timer": ["warn", { "version": "8.0" }]
   }
 }
 ```

--- a/rules/utils/version.js
+++ b/rules/utils/version.js
@@ -1,5 +1,11 @@
 const cmp = require('semver-compare');
 
-module.exports.greaterOrEqual = function(a, b) {
-  return cmp(a, b) !== -1;
+module.exports.greaterOrEqual = function(version, allowedVersion) {
+  if (!version) {
+    throw new Error(
+      'Rule requires { version } config, e.g. [ "warn", { "version": "8.0" } ]'
+    );
+  }
+
+  return cmp(version, allowedVersion) !== -1;
 };

--- a/test/camunda-cloud/integration/custom-config.spec.js
+++ b/test/camunda-cloud/integration/custom-config.spec.js
@@ -1,0 +1,90 @@
+const { expect } = require('chai');
+
+const Linter = require('bpmnlint/lib/linter');
+
+const NodeResolver = require('bpmnlint/lib/resolver/node-resolver');
+
+const { readModdle } = require('../../helper');
+
+describe('integration - custom config', function() {
+
+  describe('without version config', function() {
+
+    it('should report rule-error for rules that require version', async function() {
+
+      // given
+      const linter = new Linter({
+        config: {
+          extends: 'plugin:camunda-compat/camunda-cloud-8-0',
+          rules: {
+            'camunda-compat/timer': 'warn',
+          }
+        },
+        resolver: new NodeResolver()
+      });
+
+      const { root } = await readModdle('test/camunda-cloud/integration/camunda-cloud-8-0-timer.bpmn');
+
+      // when
+      const reports = await linter.lint(root);
+
+      // then
+      expect(reports[ 'camunda-compat/timer' ][0].category).to.equal('rule-error');
+      expect(reports[ 'camunda-compat/timer' ][0].message).to.equal(
+        'Rule requires { version } config, e.g. [ "warn", { "version": "8.0" } ]'
+      );
+    });
+
+
+    it('should not affect rules that do not require version', async function() {
+
+      // given
+      const linter = new Linter({
+        config: {
+          extends: 'plugin:camunda-compat/camunda-cloud-8-0',
+          rules: {
+            'camunda-compat/called-element': 'warn'
+          }
+        },
+        resolver: new NodeResolver()
+      });
+
+      const { root } = await readModdle('test/camunda-cloud/integration/called-element.bpmn');
+
+      // when
+      const reports = await linter.lint(root);
+
+      // then
+      expect(reports[ 'camunda-compat/called-element' ]).not.to.exist;
+    });
+
+  });
+
+
+  describe('with version config', function() {
+
+    it('should work when severity is overridden with version', async function() {
+
+      // given
+      const linter = new Linter({
+        config: {
+          extends: 'plugin:camunda-compat/camunda-cloud-8-0',
+          rules: {
+            'camunda-compat/timer': [ 'warn', { version: '8.0' } ]
+          }
+        },
+        resolver: new NodeResolver()
+      });
+
+      const { root } = await readModdle('test/camunda-cloud/integration/camunda-cloud-8-0-timer.bpmn');
+
+      // when
+      const reports = await linter.lint(root);
+
+      // then
+      expect(reports[ 'camunda-compat/timer' ]).not.to.exist;
+    });
+
+  });
+
+});


### PR DESCRIPTION
Closes https://github.com/camunda/bpmnlint-plugin-camunda-compat/issues/227

### Proposed Changes

Added guard to throw an error when rule config is missing version.
Updated `README.md` to have an example of custom rule with version config

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [x] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
