### PR TITLE
fix: report missing `zeebe:userTask` as warning in 8.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [bpmnlint-plugin-camunda-compat](https://github.com/camun
 
 ___Note:__ Yet to be released changes appear here._
 
+## 2.49.2
+
+* `FIX`: report missing zeebe:UserTask as warning again in 8.10 ([#236](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/236))
+
 ## 2.49.1
 
 * `FIX`: add guard to throw an error when rule config is missing version ([#234](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/234))

--- a/index.js
+++ b/index.js
@@ -116,8 +116,7 @@ const camundaCloud89Rules = withConfig({
 
 const camundaCloud810Rules = withConfig({
   ...omit(camundaCloud89Rules, [ 'no-execution-listener-headers' ]),
-  'duplicate-execution-listener-headers': 'error',
-  'zeebe-user-task': 'error'
+  'duplicate-execution-listener-headers': 'error'
 }, { version: '8.10' });
 
 const camundaPlatform719Rules = withConfig({

--- a/test/config/configs.spec.js
+++ b/test/config/configs.spec.js
@@ -598,7 +598,7 @@ describe('configs', function() {
     'no-loop': [ 'error', { version: '8.10' } ],
     'no-multiple-none-start-events' : [ 'error', { version: '8.10' } ],
     'priority-definition': [ 'error', { version: '8.10' } ],
-    'zeebe-user-task': [ 'error', { version: '8.10' } ],
+    'zeebe-user-task': [ 'warn', { version: '8.10' } ],
     'secrets': [ 'warn', { version: '8.10' } ],
     'sequence-flow-condition': [ 'error', { version: '8.10' } ],
     'signal-reference': [ 'error', { version: '8.10' } ],


### PR DESCRIPTION


### Proposed Changes

This changes the `zeebe-user-task` level again to `warning`. 

The extension is not mandatory in 8.10 but only its behavior changes as no Tasklist v1 API is present.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
