### PR TITLE
Expose `path` or `paths` for every report

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -133,3 +133,17 @@ and never reconstructs an entry id itself:
 
 A finding that legitimately spans several fields (e.g. duplicate keys) carries a
 plural `paths` — one moddle location per field — and each resolves the same way.
+
+Resolution is **best-effort on both ends**. A rule emits the most specific
+location its element allows: a scalar leaf when the offending value exists,
+otherwise the nearest existing anchor — a property (`documentation`) or a
+container (`outputParameters`). The panel then resolves the most specific entry
+it renders, **walking outward** when the location is not itself a field: a scalar
+leaf → its field entry; a container → the group that renders it (e.g.
+`zeebe:IoMapping` `outputParameters` → the _Output_ group). When a finding has
+no location to point at at all, the rule emits **no path** and it degrades to
+plain element selection — no fabricated leaf, no entry id, no element-level
+resolution pushed back into `@camunda/linting`. The `getEntryId` listeners fire
+in reverse render order and each **defers** (returns nothing) for locations it
+does not own, so the standard provider still answers once a template provider
+declines.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -62,7 +62,12 @@ Two contributions:
    only on template-bound elements — unknown/missing template, per-property
    constraints, engine-version compatibility, available updates. It is
    **dynamic** (depends on the loaded templates), so the host injects it into
-   `@camunda/linting` at runtime as a plugin.
+   `@camunda/linting` at runtime as a plugin. This rule set is the **one
+   deliberate exemption** from the render-agnostic `path` contract below: its
+   findings are template-specific by construction (they never apply to a standard
+   field) and often target a required-but-_missing_ property that has no moddle
+   location to resolve, so it emits the `custom-entry-*` `entryIds` directly via
+   ET's own `getPropertyEntryId` — resolving where the knowledge already lives.
 2. **The properties-panel provider** that renders template-bound fields — and
    therefore resolves a moddle `path` to the entry it renders for those fields.
 

--- a/docs/RULE_AUTHORING.md
+++ b/docs/RULE_AUTHORING.md
@@ -204,7 +204,8 @@ location, built with `getPath` / `pathConcat` from
 properties panel resolves it to the entry it renders — the standard field, or an
 element-template field when the element is template-bound — so the same rule
 lights up the right entry in both cases. A missing path silently loses inline
-errors and click-to-focus.
+errors and click-to-focus (which is sometimes the right, graceful outcome — see
+[Best-effort paths](#best-effort-paths-element-level--missing-findings) below).
 
 - **One offending field:** emit a single `path`.
 - **Several offending fields** (e.g. duplicate keys across a list): emit a plural
@@ -214,6 +215,39 @@ errors and click-to-focus.
   you; for a field on a _referenced_ element use the exported `getReferencePath`,
   which stitches a path _through_ a moddle reference (e.g. an event's `messageRef`)
   so it still resolves locally from the reported element.
+
+### Best-effort paths (element-level & missing findings)
+
+Not every finding sits on a scalar field. A finding may be about a _missing_
+value (there is no field yet), or about an element/group as a whole. Emit the
+**most specific path the element's configuration allows**, and let the panel do
+the rest — resolution is best-effort on both ends:
+
+- **Offending value exists →** point at its scalar leaf (the normal case above).
+- **No single offending value, but a container/property exists →** point at that
+  **anchor** (a property such as `documentation`, or a collection such as
+  `outputParameters`). The panel resolves a container **outward** to the group
+  that renders it (e.g. `zeebe:IoMapping` `outputParameters` → the _Output_
+  group), so navigation still lands in the right section.
+- **Nothing exists to point at →** emit **no path**. The finding degrades to
+  plain element selection. This is a deliberate, graceful outcome — never
+  fabricate a leaf or an anchor just to have a path.
+
+Two rules of thumb keep this honest:
+
+- **Never construct an entry id**, not even for element-level findings. Where the
+  offending location cannot be a field, resolve to a group (panel-side) or degrade
+  to the element — do not smuggle a `propertiesPanel.entryIds` back in.
+- **Build the path with `pathConcat`**, which encodes the degrade for free:
+  `pathConcat(base, leaf)` returns `null` (→ element selection) when `base` is
+  nil, and `pathConcat(base || [], leaf)` anchors on the property name even at the
+  element root (the legacy `[ leaf ]` fallback). Prefer these over a raw
+  `[ ...base, leaf ]` spread, which throws on a nil `base`.
+
+`agent-tool-documentation` (anchors on the `documentation` property) and
+`agent-tool-output-key` (a concrete output leaf when a write exists, the
+`outputParameters` container when the tool returns nothing, no path when there is
+no output mapping at all) are the reference examples.
 
 ## Detecting Camunda concepts (encode the contract once)
 

--- a/rules/camunda-cloud/agent-fromai-contract.js
+++ b/rules/camunda-cloud/agent-fromai-contract.js
@@ -1,5 +1,7 @@
 const { is } = require('bpmnlint-utils');
 
+const { getPath, pathConcat } = require('@bpmn-io/moddle-utils');
+
 const { findExtensionElement, findAncestorAdHocSubProcess, isAgenticAdHocSubProcess } = require('../utils/element');
 const { CORRECT_NAME, NAME_ALIASES, findFunctionInvocations, getPositionalArgs } = require('./utils/feel');
 const { reportErrors } = require('../utils/reporter');
@@ -156,12 +158,11 @@ module.exports = skipInNonExecutableProcess(function(config = {}) {
       return;
     }
 
-    // Properties-panel entry for this input parameter, so clicking the report
-    // opens the right mapping (id convention: {elementId}-input-{index}-source).
-    const inputIndex = (node.$parent.get('inputParameters') || []).indexOf(node);
-    const propertiesPanel = {
-      entryIds: [ `${ task.get('id') }-input-${ inputIndex }-source` ]
-    };
+    // Moddle path to this input parameter's source, so a single downstream
+    // resolver maps it to the entry the modeler actually renders — the standard
+    // input mapping, or a template's custom entry. The rule stays agnostic to
+    // the id scheme.
+    const path = pathConcat(getPath(node, task), 'source');
 
     const ahsp = findAncestorAdHocSubProcess(task);
 
@@ -169,7 +170,7 @@ module.exports = skipInNonExecutableProcess(function(config = {}) {
       reportErrors(task, reporter, invocations.map(() => ({
         message: 'fromAi() should only be used inside an agentic sub-process.',
         data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
-        propertiesPanel,
+        path,
       })));
       return;
     }
@@ -179,7 +180,7 @@ module.exports = skipInNonExecutableProcess(function(config = {}) {
       reportErrors(task, reporter, invocations.map(() => ({
         message: `The "${ahspLabel}" sub-process is not marked as agentic, so fromAi() has no effect.`,
         data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
-        propertiesPanel,
+        path,
       })));
       return;
     }
@@ -194,7 +195,7 @@ module.exports = skipInNonExecutableProcess(function(config = {}) {
       reportErrors(task, reporter, invocations.map(() => ({
         message: 'fromAi() is ignored here: only the tool\'s entry element defines AI inputs. Define it there and read the toolCall variable directly.',
         data: { type: ERROR_TYPES.AGENT_FEEL_NON_ENTRY_ELEMENT },
-        propertiesPanel,
+        path,
       })));
       return;
     }
@@ -237,7 +238,7 @@ module.exports = skipInNonExecutableProcess(function(config = {}) {
     }
 
     if (errors.length) {
-      reportErrors(task, reporter, errors.map(error => ({ ...error, propertiesPanel })));
+      reportErrors(task, reporter, errors.map(error => ({ ...error, path })));
     }
   }
 
@@ -273,7 +274,7 @@ module.exports = skipInNonExecutableProcess(function(config = {}) {
       return;
     }
 
-    const keyCounts = {};
+    const keyOccurrences = {};
 
     for (const input of ioMapping.get('inputParameters') || []) {
       const source = input.get('source');
@@ -286,18 +287,18 @@ module.exports = skipInNonExecutableProcess(function(config = {}) {
         const args = getPositionalArgs(inv.node, expr);
         const key = args[ 0 ];
         if (key && key.type === 'PathExpression' && key.text.startsWith('toolCall.')) {
-          keyCounts[ key.text ] = (keyCounts[ key.text ] || 0) + 1;
+          (keyOccurrences[ key.text ] = keyOccurrences[ key.text ] || []).push(input);
         }
       }
     }
 
-    const duplicates = Object.keys(keyCounts).filter(key => keyCounts[ key ] > 1);
+    const duplicates = Object.keys(keyOccurrences).filter(key => keyOccurrences[ key ].length > 1);
 
     if (duplicates.length) {
       reportErrors(task, reporter, duplicates.map(key => ({
         message: `fromAi() key ${ key } is declared more than once in this tool. Declare it once and reference it directly elsewhere.`,
         data: { type: ERROR_TYPES.AGENT_FEEL_KEY_DUPLICATE },
-        propertiesPanel: { entryIds: [ 'inputs' ] },
+        paths: keyOccurrences[ key ].map(input => pathConcat(getPath(input, task), 'source')),
       })));
     }
   }
@@ -330,15 +331,12 @@ module.exports = skipInNonExecutableProcess(function(config = {}) {
       return;
     }
 
-    const outputIndex = (node.$parent.get('outputParameters') || []).indexOf(node);
-    const propertiesPanel = {
-      entryIds: [ `${ task.get('id') }-output-${ outputIndex }-source` ]
-    };
+    const path = pathConcat(getPath(node, task), 'source');
 
     reportErrors(task, reporter, invocations.map(() => ({
       message: 'fromAi() defines a tool input and has no effect in an output mapping. Define it in an input mapping on the tool\'s entry element.',
       data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
-      propertiesPanel,
+      path,
     })));
   }
 
@@ -368,7 +366,7 @@ module.exports = skipInNonExecutableProcess(function(config = {}) {
     reportErrors(node, reporter, invocations.map(() => ({
       message: 'fromAi() defines a tool input and cannot be used in a sequence flow condition. Define it in an input mapping on the tool\'s entry element.',
       data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
-      propertiesPanel: { entryIds: [ 'conditionExpression' ] },
+      path: getPath(condition, node),
     })));
   }
 });

--- a/rules/camunda-cloud/agent-tool-documentation.js
+++ b/rules/camunda-cloud/agent-tool-documentation.js
@@ -29,7 +29,7 @@ module.exports = skipInNonExecutableProcess(function(config = {}) {
         {
           message: 'Tool documentation is missing.',
           data: { type: ERROR_TYPES.AGENT_TOOL_DOCUMENTATION_MISSING },
-          propertiesPanel: { entryIds: [ 'documentation' ] },
+          path: [ 'documentation' ],
         },
       ]);
     }

--- a/rules/camunda-cloud/agent-tool-output-key.js
+++ b/rules/camunda-cloud/agent-tool-output-key.js
@@ -1,5 +1,7 @@
 const { is } = require('bpmnlint-utils');
 
+const { getPath, pathConcat } = require('@bpmn-io/moddle-utils');
+
 const { isAgenticToolElement } = require('../utils/element');
 const { reportErrors, getName } = require('../utils/reporter');
 const { ERROR_TYPES } = require('../utils/error-types');
@@ -38,7 +40,7 @@ module.exports = skipInNonExecutableProcess(function(config = {}) {
       reportErrors(node, reporter, {
         message: 'Tool returns nothing to the agent. Set a "toolCallResult" (at minimum, note the task completed).',
         data: { type: ERROR_TYPES.AGENT_TOOL_RESULT_MISSING },
-        propertiesPanel: { entryIds: [ 'outputs' ] },
+        path: getOutputsPath(node),
       });
       return;
     }
@@ -51,7 +53,7 @@ module.exports = skipInNonExecutableProcess(function(config = {}) {
         reportErrors(casingMismatch.element, reporter, {
           message: `Wrong casing "${getCasingMismatchText(casingMismatch)}": use toolCallResult (case-sensitive).`,
           data: { type: ERROR_TYPES.AGENT_TOOL_OUTPUT_KEY_CASING_INVALID },
-          propertiesPanel: { entryIds: [ 'outputs' ] },
+          path: getChannelPath(casingMismatch),
         });
         return;
       }
@@ -63,7 +65,7 @@ module.exports = skipInNonExecutableProcess(function(config = {}) {
       reportErrors(misdirected.element, reporter, {
         message: '"toolCallResult" output is not mapped.',
         data: { type: ERROR_TYPES.AGENT_TOOL_OUTPUT_KEY_INVALID },
-        propertiesPanel: { entryIds: [ 'outputs' ] },
+        path: getChannelPath(misdirected),
       });
       return;
     }
@@ -96,7 +98,7 @@ module.exports = skipInNonExecutableProcess(function(config = {}) {
         reportErrors(overwriter.element, reporter, {
           message: `This overwrites the "toolCallResult" value set on "${overwrittenLabel}".`,
           data: { type: ERROR_TYPES.AGENT_TOOL_OUTPUT_KEY_OVERWRITE },
-          propertiesPanel: { entryIds: [ 'outputs' ] },
+          path: getChannelPath(overwriter),
         });
       }
     }
@@ -120,8 +122,9 @@ module.exports = skipInNonExecutableProcess(function(config = {}) {
  *
  * @param {ModdleElement} entry
  *
- * @returns {Object} { channels, linear } — channels as { kind, value, element }
- * (element being whichever element in the flow actually wrote this channel),
+ * @returns {Object} { channels, linear } — channels as { kind, value, element,
+ * node, property } (element being whichever element in the flow actually wrote
+ * this channel; node/property the moddle leaf that carries the offending value),
  * and linear being true when the flow is a single non-branching chain
  */
 function collectResultChannels(entry) {
@@ -191,14 +194,14 @@ function collectElementChannels(element, channels) {
   for (const value of extensionElements.get('values')) {
     if (is(value, 'zeebe:IoMapping')) {
       for (const output of value.get('outputParameters') || []) {
-        channels.push({ kind: 'output', value: output.get('target') || '', source: output.get('source'), element });
+        channels.push({ kind: 'output', value: output.get('target') || '', source: output.get('source'), element, node: output, property: 'target' });
       }
     }
 
     if (is(value, 'zeebe:Script') || is(value, 'zeebe:CalledDecision')) {
       const resultVariable = value.get('resultVariable');
       if (resultVariable) {
-        channels.push({ kind: 'resultVariable', value: resultVariable, element });
+        channels.push({ kind: 'resultVariable', value: resultVariable, element, node: value, property: 'resultVariable' });
       }
     }
 
@@ -212,14 +215,43 @@ function collectElementChannels(element, channels) {
       for (const header of value.get('values') || []) {
         const key = header.get('key');
         if (key === 'resultVariable') {
-          channels.push({ kind: 'resultVariable', value: header.get('value') || '', element });
+          channels.push({ kind: 'resultVariable', value: header.get('value') || '', element, node: header, property: 'value' });
         }
         if (key === 'resultExpression') {
-          channels.push({ kind: 'resultExpression', value: header.get('value') || '', element });
+          channels.push({ kind: 'resultExpression', value: header.get('value') || '', element, node: header, property: 'value' });
         }
       }
     }
   }
+}
+
+// The moddle leaf path to the write that actually carries the offending value
+// (an output target, a script/decision resultVariable, a connector header
+// value), relative to the element the finding is reported on. The panel
+// resolves this render-agnostically to the concrete field — a standard output
+// entry, or the matching element-template field when the tool is template
+// bound. Degrades to null (element selection) if the node is detached.
+function getChannelPath(channel) {
+  return pathConcat(getPath(channel.node, channel.element), channel.property);
+}
+
+// Best-effort location for a "tool returns nothing" finding: the tool's output
+// mapping collection, which the panel resolves outward to the outputs group.
+// When the tool has no output mapping at all there is nothing to point at, so
+// the finding degrades to element selection (null path) rather than fabricate a
+// target.
+function getOutputsPath(element) {
+  const extensionElements = element.get('extensionElements');
+  if (!extensionElements) {
+    return null;
+  }
+
+  const ioMapping = (extensionElements.get('values') || []).find(value => is(value, 'zeebe:IoMapping'));
+  if (!ioMapping) {
+    return null;
+  }
+
+  return pathConcat(getPath(ioMapping, element), 'outputParameters');
 }
 
 function isToolCallResultChannel({ kind, value }) {

--- a/rules/camunda-cloud/before-all-execution-listener.js
+++ b/rules/camunda-cloud/before-all-execution-listener.js
@@ -1,6 +1,6 @@
 const { is } = require('bpmnlint-utils');
 
-const { getPath } = require('@bpmn-io/moddle-utils');
+const { getPath, pathConcat } = require('@bpmn-io/moddle-utils');
 
 const {
   ERROR_TYPES,
@@ -33,7 +33,7 @@ module.exports = skipInNonExecutableProcess(function() {
       return [
         {
           message: 'Property <eventType> of <zeebe:ExecutionListener> with value <beforeAll> only allowed on multi-instance elements',
-          path: [ ...getPath(listener, node), 'eventType' ],
+          path: pathConcat(getPath(listener, node), 'eventType'),
           data: {
             type: ERROR_TYPES.PROPERTY_VALUE_NOT_ALLOWED,
             node: listener,

--- a/rules/camunda-cloud/connector-properties/config.js
+++ b/rules/camunda-cloud/connector-properties/config.js
@@ -1,4 +1,4 @@
-const { getPath } = require('@bpmn-io/moddle-utils');
+const { getPath, pathConcat } = require('@bpmn-io/moddle-utils');
 
 const { findExtensionElement } = require('../../utils/element');
 
@@ -75,7 +75,7 @@ function getInboundConnectorError(node, propertyName, allowedVersion) {
 
   return {
     message: `Connector property <name> with value <${ propertyName }> only allowed by Camunda ${ allowedVersion } or newer.`,
-    path: path ? [ ...path, 'name' ] : [ 'name' ],
+    path: pathConcat(path || [], 'name'),
     data: {
       type: ERROR_TYPES.CONNECTORS_PROPERTY_VALUE_NOT_ALLOWED,
       node: property,

--- a/rules/camunda-cloud/error-reference.js
+++ b/rules/camunda-cloud/error-reference.js
@@ -5,6 +5,7 @@ const {
 
 const {
   getEventDefinition,
+  getReferencePath,
   hasProperties
 } = require('../utils/element');
 
@@ -52,11 +53,19 @@ module.exports = skipInNonExecutableProcess(function({ version }) {
       return;
     }
 
+    const nodePath = getReferencePath({
+      element: node,
+      referenceHolder: eventDefinition,
+      referenceProperty: 'errorRef',
+      referencedRoot: errorRef,
+      node: errorRef
+    });
+
     errors = hasProperties(errorRef, {
       errorCode: {
         required: true
       }
-    }, node);
+    }, node, nodePath);
 
     if (errors.length) {
       reportErrors(node, reporter, errors);

--- a/rules/camunda-cloud/escalation-reference.js
+++ b/rules/camunda-cloud/escalation-reference.js
@@ -5,6 +5,7 @@ const {
 
 const {
   getEventDefinition,
+  getReferencePath,
   hasProperties
 } = require('../utils/element');
 
@@ -47,11 +48,19 @@ module.exports = skipInNonExecutableProcess(function() {
       return;
     }
 
+    const nodePath = getReferencePath({
+      element: node,
+      referenceHolder: eventDefinition,
+      referenceProperty: 'escalationRef',
+      referencedRoot: escalationRef,
+      node: escalationRef
+    });
+
     errors = hasProperties(escalationRef, {
       escalationCode: {
         required: true
       }
-    }, node);
+    }, node, nodePath);
 
     if (errors.length) {
       reportErrors(node, reporter, errors);

--- a/rules/camunda-cloud/feel-compatibility.js
+++ b/rules/camunda-cloud/feel-compatibility.js
@@ -1,6 +1,6 @@
 const { is } = require('bpmnlint-utils');
 
-const { getPath } = require('@bpmn-io/moddle-utils');
+const { getPath, pathConcat } = require('@bpmn-io/moddle-utils');
 const { camundaBuiltins, camundaReservedNameBuiltins } = require('@camunda/feel-builtins');
 
 const { FeelAnalyzer } = require('@bpmn-io/feel-analyzer');
@@ -77,9 +77,7 @@ module.exports = skipInNonExecutableProcess(function(config = {}) {
 
         errors.push({
           message: `FEEL function <${ builtin.name }> requires Camunda ${ builtin.engines.camunda }`,
-          path: path
-            ? [ ...path, propertyName ]
-            : [ propertyName ],
+          path: pathConcat(path || [], propertyName),
           data: {
             type: ERROR_TYPES.FEEL_EXPRESSION_UNSUPPORTED_FUNCTION,
             node,

--- a/rules/camunda-cloud/feel.js
+++ b/rules/camunda-cloud/feel.js
@@ -1,6 +1,6 @@
 const { is } = require('bpmnlint-utils');
 
-const { getPath } = require('@bpmn-io/moddle-utils');
+const { getPath, pathConcat } = require('@bpmn-io/moddle-utils');
 
 const { FeelAnalyzer } = require('@bpmn-io/feel-analyzer');
 
@@ -52,9 +52,7 @@ module.exports = skipInNonExecutableProcess(function() {
 
         errors.push({
           message: `Property <${ propertyName }> is not a valid FEEL expression`,
-          path: path
-            ? [ ...path, propertyName ]
-            : [ propertyName ],
+          path: pathConcat(path || [], propertyName),
           data: {
             type: ERROR_TYPES.FEEL_EXPRESSION_INVALID,
             node,

--- a/rules/camunda-cloud/link-event.js
+++ b/rules/camunda-cloud/link-event.js
@@ -1,4 +1,4 @@
-const { getPath } = require('@bpmn-io/moddle-utils');
+const { getPath, pathConcat } = require('@bpmn-io/moddle-utils');
 
 const {
   is,
@@ -72,9 +72,7 @@ module.exports = skipInNonExecutableProcess(function() {
 
             reportErrors(linkCatchEvent, reporter, {
               message: `Property of type <bpmn:LinkEventDefinition> has property <name> with duplicate value of <${ name }>`,
-              path: path
-                ? [ ...path, 'name' ]
-                : [ 'name' ],
+              path: pathConcat(path || [], 'name'),
               data: {
                 type: ERROR_TYPES.ELEMENT_PROPERTY_VALUE_DUPLICATED,
                 node: linkEventDefinition,

--- a/rules/camunda-cloud/message-reference.js
+++ b/rules/camunda-cloud/message-reference.js
@@ -5,6 +5,7 @@ const {
 
 const {
   getEventDefinition,
+  getReferencePath,
   hasProperties
 } = require('../utils/element');
 
@@ -45,11 +46,19 @@ module.exports = skipInNonExecutableProcess(function() {
 
     const messageRef = eventDefinitionOrReceiveTask.get('messageRef');
 
+    const nodePath = getReferencePath({
+      element: node,
+      referenceHolder: eventDefinitionOrReceiveTask,
+      referenceProperty: 'messageRef',
+      referencedRoot: messageRef,
+      node: messageRef
+    });
+
     errors = hasProperties(messageRef, {
       name: {
         required: true
       }
-    }, node);
+    }, node, nodePath);
 
     if (errors && errors.length) {
       reportErrors(node, reporter, errors);

--- a/rules/camunda-cloud/no-before-all-execution-listener.js
+++ b/rules/camunda-cloud/no-before-all-execution-listener.js
@@ -1,4 +1,4 @@
-const { getPath } = require('@bpmn-io/moddle-utils');
+const { getPath, pathConcat } = require('@bpmn-io/moddle-utils');
 
 const {
   findExtensionElement
@@ -30,7 +30,7 @@ module.exports = skipInNonExecutableProcess(function() {
       return [
         {
           message: `Property <eventType> of <zeebe:ExecutionListener> with value <beforeAll> only allowed by Camunda ${ ALLOWED_VERSION } or newer`,
-          path: [ ...getPath(listener, node), 'eventType' ],
+          path: pathConcat(getPath(listener, node), 'eventType'),
           data: {
             type: ERROR_TYPES.PROPERTY_VALUE_NOT_ALLOWED,
             node: listener,

--- a/rules/camunda-cloud/no-expression.js
+++ b/rules/camunda-cloud/no-expression.js
@@ -2,7 +2,7 @@ const {
   is
 } = require('bpmnlint-utils');
 
-const { getPath } = require('@bpmn-io/moddle-utils');
+const { getPath, pathConcat } = require('@bpmn-io/moddle-utils');
 
 const {
   ERROR_TYPES,
@@ -103,9 +103,7 @@ function noExpression(node, propertyName, parentNode, allowedVersion) {
 
   return {
     message,
-    path: path
-      ? [ ...path, propertyName ]
-      : [ propertyName ],
+    path: pathConcat(path || [], propertyName),
     data
   };
 }

--- a/rules/camunda-cloud/no-task-schedule.js
+++ b/rules/camunda-cloud/no-task-schedule.js
@@ -1,3 +1,5 @@
+const { getPath, pathConcat } = require('@bpmn-io/moddle-utils');
+
 const { hasNoExtensionElement } = require('../utils/element');
 
 const { reportErrors } = require('../utils/reporter');
@@ -9,6 +11,29 @@ module.exports = skipInNonExecutableProcess(function() {
     const errors = hasNoExtensionElement(node, 'zeebe:TaskSchedule', node, '8.2');
 
     if (errors && errors.length) {
+
+      // add one leaf path per offending schedule field that is set, so consumers
+      // resolve entry ids render-agnostically
+      errors.forEach(error => {
+        const { extensionElement: taskSchedule } = error.data;
+
+        const path = getPath(taskSchedule, node);
+
+        const paths = [];
+
+        if (path && taskSchedule.get('dueDate')) {
+          paths.push(pathConcat(path, 'dueDate'));
+        }
+
+        if (path && taskSchedule.get('followUpDate')) {
+          paths.push(pathConcat(path, 'followUpDate'));
+        }
+
+        if (paths.length) {
+          error.paths = paths;
+        }
+      });
+
       reportErrors(node, reporter, errors);
     }
   }

--- a/rules/camunda-cloud/no-zeebe-properties.js
+++ b/rules/camunda-cloud/no-zeebe-properties.js
@@ -1,3 +1,5 @@
+const { getPath, pathConcat } = require('@bpmn-io/moddle-utils');
+
 const { hasNoExtensionElement } = require('../utils/element');
 
 const { reportErrors } = require('../utils/reporter');
@@ -9,6 +11,22 @@ module.exports = skipInNonExecutableProcess(function() {
     const errors = hasNoExtensionElement(node, 'zeebe:Properties', node, '8.1');
 
     if (errors && errors.length) {
+
+      // add one leaf path per offending property `name` field, so consumers
+      // resolve entry ids render-agnostically
+      errors.forEach(error => {
+        const { extensionElement } = error.data;
+
+        const paths = extensionElement.get('properties')
+          .map(property => getPath(property, node))
+          .filter(path => path)
+          .map(path => pathConcat(path, 'name'));
+
+        if (paths.length) {
+          error.paths = paths;
+        }
+      });
+
       reportErrors(node, reporter, errors);
     }
   }

--- a/rules/camunda-cloud/secrets.js
+++ b/rules/camunda-cloud/secrets.js
@@ -2,7 +2,7 @@ const { isString } = require('min-dash');
 
 const { is } = require('bpmnlint-utils');
 
-const { getPath } = require('@bpmn-io/moddle-utils');
+const { getPath, pathConcat } = require('@bpmn-io/moddle-utils');
 
 const {
   findExtensionElement,
@@ -99,9 +99,7 @@ function getReport(propertyName, node, parentNode) {
 
   return {
     message: `Property <${ propertyName }> uses deprecated secret expression format`,
-    path: path
-      ? [ ...getPath(node, parentNode), propertyName ]
-      : [ propertyName ],
+    path: pathConcat(path || [], propertyName),
     data: {
       type: ERROR_TYPES.SECRET_EXPRESSION_FORMAT_DEPRECATED,
       node,

--- a/rules/camunda-cloud/signal-reference.js
+++ b/rules/camunda-cloud/signal-reference.js
@@ -5,6 +5,7 @@ const {
 
 const {
   getEventDefinition,
+  getReferencePath,
   hasProperties
 } = require('../utils/element');
 
@@ -48,11 +49,19 @@ module.exports = skipInNonExecutableProcess(function() {
       return;
     }
 
+    const nodePath = getReferencePath({
+      element: node,
+      referenceHolder: eventDefinition,
+      referenceProperty: 'signalRef',
+      referencedRoot: signalRef,
+      node: signalRef
+    });
+
     errors = hasProperties(signalRef, {
       name: {
         required: true
       }
-    }, node);
+    }, node, nodePath);
 
     if (errors.length) {
       reportErrors(node, reporter, errors);

--- a/rules/camunda-cloud/subscription.js
+++ b/rules/camunda-cloud/subscription.js
@@ -6,6 +6,7 @@ const {
 const {
   findExtensionElement,
   getEventDefinition,
+  getReferencePath,
   hasExtensionElement,
   hasProperties
 } = require('../utils/element');
@@ -49,11 +50,19 @@ module.exports = skipInNonExecutableProcess(function() {
 
     const subscription = findExtensionElement(messageRef, 'zeebe:Subscription');
 
+    const nodePath = getReferencePath({
+      element: node,
+      referenceHolder: eventDefinitionOrReceiveTask,
+      referenceProperty: 'messageRef',
+      referencedRoot: messageRef,
+      node: subscription
+    });
+
     errors = hasProperties(subscription, {
       correlationKey: {
         required: true
       }
-    }, node);
+    }, node, nodePath);
 
     if (errors && errors.length) {
       reportErrors(node, reporter, errors);

--- a/rules/utils/element.js
+++ b/rules/utils/element.js
@@ -16,13 +16,66 @@ const {
   isAny
 } = require('bpmnlint-utils');
 
-const { getPath } = require('@bpmn-io/moddle-utils');
+const { getPath, pathConcat } = require('@bpmn-io/moddle-utils');
 
 const { ERROR_TYPES } = require('./error-types');
 
 const { greaterOrEqual } = require('./version');
 
 module.exports.ERROR_TYPES = ERROR_TYPES;
+
+/**
+ * Build the `{ paths }` fragment for a multi-field finding: one leaf moddle path
+ * per offending node, rooted at `parentNode`. Nodes whose path can't be resolved
+ * are dropped; the fragment is empty when none resolve, so the `paths` key is
+ * only present when it carries usable locations.
+ *
+ * @param {Array<Object>} nodes
+ * @param {string} propertyName leaf property appended to each node's path
+ * @param {Object} [parentNode]
+ *
+ * @returns {{ paths?: Array<Array<string|number>> }}
+ */
+function leafPaths(nodes, propertyName, parentNode = null) {
+  const paths = nodes
+    .map(node => getPath(node, parentNode))
+    .filter(path => isArray(path))
+    .map(path => pathConcat(path, propertyName));
+
+  return paths.length ? { paths } : {};
+}
+
+/**
+ * Build a moddle path that locates `node` relative to `element` by following a
+ * single reference edge.
+ *
+ * `getPath` (from @bpmn-io/moddle-utils) only walks containment (`$parent`), so
+ * it roots any referenced node at `bpmn:Definitions` — a path that cannot be
+ * resolved starting from `element`. This helper instead stitches together
+ *
+ *   getPath(referenceHolder, element) + referenceProperty + getPath(node, referencedRoot)
+ *
+ * yielding a path that resolves locally from `element`, because moddle
+ * `get(referenceProperty)` transparently follows the reference.
+ *
+ * @param {Object} options
+ * @param {Object} options.element root element the path is relative to
+ * @param {Object} options.referenceHolder node holding the reference (contained in `element`)
+ * @param {string} options.referenceProperty name of the reference property
+ * @param {Object} options.referencedRoot referenced root element
+ * @param {Object} options.node checked node (contained in `referencedRoot`)
+ *
+ * @returns {Array<string|number>|null} null when a segment can't be resolved
+ */
+function getReferencePath({ element, referenceHolder, referenceProperty, referencedRoot, node }) {
+  return pathConcat(
+    getPath(referenceHolder, element),
+    referenceProperty,
+    getPath(node, referencedRoot)
+  );
+}
+
+module.exports.getReferencePath = getReferencePath;
 
 function getEventDefinition(node) {
   const eventDefinitions = node.get('eventDefinitions');
@@ -121,6 +174,10 @@ module.exports.hasDuplicatedPropertyValues = function(node, propertiesName, prop
       return {
         message: `Properties of type <${ duplicateProperties[ 0 ].$type }> have property <${ propertyName }> with duplicate value of <${ duplicate }>`,
         path: null,
+
+        // one leaf path per offending field, so consumers resolve entry ids
+        // render-agnostically (template field vs. standard field)
+        ...leafPaths(duplicateProperties, propertyName, parentNode),
         data: {
           type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
           node,
@@ -169,6 +226,11 @@ module.exports.hasDuplicatedPropertiesValues = function(node, containerPropertyN
       return {
         message: `Properties of type <${ duplicate.$type }> have properties with duplicate values (${ duplicatesSummary })`,
         path: null,
+
+        // one leaf path per offending location; `type` is the field that
+        // represents the duplicated element in the properties panel, so
+        // consumers resolve its entry id render-agnostically
+        ...leafPaths(duplicateProperties, 'type', parentNode),
         data: {
           type: ERROR_TYPES.PROPERTY_VALUES_DUPLICATED,
           node,
@@ -184,13 +246,13 @@ module.exports.hasDuplicatedPropertiesValues = function(node, containerPropertyN
   return [];
 };
 
-module.exports.hasProperties = function(node, properties, parentNode = null) {
+module.exports.hasProperties = function(node, properties, parentNode = null, nodePath) {
   return Object.entries(properties).reduce((results, property) => {
     const [ propertyName, propertyChecks ] = property;
 
     const { allowedVersion = null } = propertyChecks;
 
-    const path = getPath(node, parentNode);
+    const path = nodePath === undefined ? getPath(node, parentNode) : nodePath;
 
     const propertyValue = node.get(propertyName);
 
@@ -201,9 +263,7 @@ module.exports.hasProperties = function(node, properties, parentNode = null) {
           message: allowedVersion
             ? `Element of type <${ node.$type }> without property <${ propertyName }> only allowed by Camunda ${ allowedVersion } or newer`
             : `Element of type <${ node.$type }> must have property <${ propertyName }>`,
-          path: path
-            ? [ ...path, propertyName ]
-            : [ propertyName ],
+          path: pathConcat(path || [], propertyName),
           data: addAllowedVersion({
             type: ERROR_TYPES.PROPERTY_REQUIRED,
             node,
@@ -222,9 +282,7 @@ module.exports.hasProperties = function(node, properties, parentNode = null) {
           ...results,
           {
             message: `Element of type <${ node.$type }> must have property <${ propertyName }> if it has property <${ propertyChecks.dependentRequired }>`,
-            path: path
-              ? [ ...path, propertyName ]
-              : [ propertyName ],
+            path: pathConcat(path || [], propertyName),
             data: {
               type: ERROR_TYPES.PROPERTY_DEPENDENT_REQUIRED,
               node,
@@ -252,9 +310,7 @@ module.exports.hasProperties = function(node, properties, parentNode = null) {
           message: allowedVersion
             ? `Property <${ propertyName }> of type <${ propertyValue.$type }> only allowed by Camunda ${ allowedVersion } or newer`
             : `Property <${ propertyName }> of type <${ propertyValue.$type }> not allowed`,
-          path: path
-            ? [ ...path, propertyName ]
-            : [ propertyName ],
+          path: pathConcat(path || [], propertyName),
           data: addAllowedVersion({
             type: ERROR_TYPES.PROPERTY_TYPE_NOT_ALLOWED,
             node,
@@ -271,9 +327,7 @@ module.exports.hasProperties = function(node, properties, parentNode = null) {
         ...results,
         {
           message: `Property <${ propertyName }> must have value of <${ propertyChecks.value }>`,
-          path: path
-            ? [ ...path, propertyName ]
-            : [ propertyName ],
+          path: pathConcat(path || [], propertyName),
           data: {
             type: ERROR_TYPES.PROPERTY_VALUE_REQUIRED,
             node,
@@ -292,9 +346,7 @@ module.exports.hasProperties = function(node, properties, parentNode = null) {
           message: allowedVersion
             ? `Property <${ propertyName }> only allowed by Camunda ${ allowedVersion } or newer`
             : `Property <${ propertyName }> not allowed`,
-          path: path
-            ? [ ...path, propertyName ]
-            : [ propertyName ],
+          path: pathConcat(path || [], propertyName),
           data: addAllowedVersion({
             type: ERROR_TYPES.PROPERTY_NOT_ALLOWED,
             node,
@@ -312,9 +364,7 @@ module.exports.hasProperties = function(node, properties, parentNode = null) {
           message: allowedVersion
             ? `Property value of <${ truncate(propertyValue) }> only allowed by Camunda ${ allowedVersion } or newer`
             : `Property value of <${ truncate(propertyValue) }> not allowed`,
-          path: path
-            ? [ ...path, propertyName ]
-            : [ propertyName ],
+          path: pathConcat(path || [], propertyName),
           data: addAllowedVersion({
             type: ERROR_TYPES.PROPERTY_VALUE_NOT_ALLOWED,
             node,
@@ -432,9 +482,7 @@ module.exports.hasExpression = function(node, propertyName, check, parentNode = 
       return [
         {
           message: `Property <${ propertyName }> must have expression value`,
-          path: path
-            ? [ ...path, propertyName ]
-            : null,
+          path: pathConcat(path, propertyName),
           data: {
             type: ERROR_TYPES.EXPRESSION_REQUIRED,
             node: is(expression, 'bpmn:Expression') ? expression : node,
@@ -462,9 +510,7 @@ module.exports.hasExpression = function(node, propertyName, check, parentNode = 
         message: allowedVersion
           ? `Expression value of <${ propertyValue }> only allowed by Camunda ${ allowedVersion }`
           : `Expression value of <${ propertyValue }> not allowed`,
-        path: path
-          ? [ ...path, propertyName ]
-          : null,
+        path: pathConcat(path, propertyName),
         data: addAllowedVersion({
           type: ERROR_TYPES.EXPRESSION_VALUE_NOT_ALLOWED,
           node: is(expression, 'bpmn:Expression') ? expression : node,

--- a/test/camunda-cloud/agent-fromai-contract.spec.js
+++ b/test/camunda-cloud/agent-fromai-contract.spec.js
@@ -126,7 +126,7 @@ const invalid = [
       id: 'Task_1',
       message: 'fromAi() key must be a FEEL path, not a string literal. Remove the quotes around "toolCall.url".',
       data: { type: ERROR_TYPES.AGENT_FEEL_KEY_TYPE_INVALID },
-      propertiesPanel: { entryIds: [ 'Task_1-input-0-source' ] }
+      path: [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ]
     }
   },
   {
@@ -139,7 +139,7 @@ const invalid = [
       id: 'Task_1',
       message: 'fromAi() key must be a FEEL path starting with "toolCall.", not null.',
       data: { type: ERROR_TYPES.AGENT_FEEL_KEY_TYPE_INVALID },
-      propertiesPanel: { entryIds: [ 'Task_1-input-0-source' ] }
+      path: [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ]
     }
   },
   {
@@ -152,7 +152,7 @@ const invalid = [
       id: 'Task_1',
       message: 'fromAi() key must be a FEEL path starting with "toolCall.", not a number.',
       data: { type: ERROR_TYPES.AGENT_FEEL_KEY_TYPE_INVALID },
-      propertiesPanel: { entryIds: [ 'Task_1-input-0-source' ] }
+      path: [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ]
     }
   },
   {
@@ -165,7 +165,7 @@ const invalid = [
       id: 'Task_1',
       message: 'fromAi() key must be a FEEL path starting with "toolCall.", not an arithmetic expression.',
       data: { type: ERROR_TYPES.AGENT_FEEL_KEY_TYPE_INVALID },
-      propertiesPanel: { entryIds: [ 'Task_1-input-0-source' ] }
+      path: [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ]
     }
   },
   {
@@ -178,7 +178,7 @@ const invalid = [
       id: 'Task_1',
       message: 'fromAi() key must use dot notation, not bracket notation. Use toolCall.name instead of toolCall["name"].',
       data: { type: ERROR_TYPES.AGENT_FEEL_KEY_TYPE_INVALID },
-      propertiesPanel: { entryIds: [ 'Task_1-input-0-source' ] }
+      path: [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ]
     }
   },
   {
@@ -191,7 +191,7 @@ const invalid = [
       id: 'Task_1',
       message: 'fromAi() key must start with "toolCall.". Use toolCall.url instead of a bare name.',
       data: { type: ERROR_TYPES.AGENT_FEEL_KEY_PREFIX_MISSING },
-      propertiesPanel: { entryIds: [ 'Task_1-input-0-source' ] }
+      path: [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ]
     }
   },
   {
@@ -204,7 +204,7 @@ const invalid = [
       id: 'Task_1',
       message: 'fromAi() key must start with "toolCall.". Got context.url.',
       data: { type: ERROR_TYPES.AGENT_FEEL_KEY_PREFIX_MISSING },
-      propertiesPanel: { entryIds: [ 'Task_1-input-0-source' ] }
+      path: [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ]
     }
   },
   {
@@ -217,7 +217,7 @@ const invalid = [
       id: 'Task_1',
       message: 'fromAi() key must be a single name under toolCall. Use toolCall.query instead of toolCall.params.query.',
       data: { type: ERROR_TYPES.AGENT_FEEL_KEY_SEGMENTS_INVALID },
-      propertiesPanel: { entryIds: [ 'Task_1-input-0-source' ] }
+      path: [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ]
     }
   },
   {
@@ -230,7 +230,7 @@ const invalid = [
       id: 'Task_1',
       message: 'fromAi() key must be a FEEL path starting with "toolCall.", not a conditional expression. The connector requires a plain reference regardless of which branch would apply at runtime.',
       data: { type: ERROR_TYPES.AGENT_FEEL_KEY_TYPE_INVALID },
-      propertiesPanel: { entryIds: [ 'Task_1-input-0-source' ] }
+      path: [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ]
     }
   },
   {
@@ -241,7 +241,7 @@ const invalid = [
       id: 'Task_1',
       message: 'fromAi() requires a key argument: a FEEL path like toolCall.url.',
       data: { type: ERROR_TYPES.AGENT_FEEL_KEY_MISSING },
-      propertiesPanel: { entryIds: [ 'Task_1-input-0-source' ] }
+      path: [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ]
     }
   },
 
@@ -263,7 +263,7 @@ const invalid = [
       id: 'Task_1',
       message: 'fromAi() description must be a string literal: a quoted string describing what the agent should provide.',
       data: { type: ERROR_TYPES.AGENT_FEEL_DESCRIPTION_TYPE_INVALID },
-      propertiesPanel: { entryIds: [ 'Task_1-input-0-source' ] }
+      path: [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ]
     }
   },
   {
@@ -274,7 +274,7 @@ const invalid = [
       id: 'Task_1',
       message: 'fromAi() description must be a string literal: a quoted string describing what the agent should provide.',
       data: { type: ERROR_TYPES.AGENT_FEEL_DESCRIPTION_TYPE_INVALID },
-      propertiesPanel: { entryIds: [ 'Task_1-input-0-source' ] }
+      path: [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ]
     }
   },
   {
@@ -285,7 +285,7 @@ const invalid = [
       id: 'Task_1',
       message: 'fromAi() description must be a string literal: a quoted string describing what the agent should provide.',
       data: { type: ERROR_TYPES.AGENT_FEEL_DESCRIPTION_TYPE_INVALID },
-      propertiesPanel: { entryIds: [ 'Task_1-input-0-source' ] }
+      path: [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ]
     }
   },
 
@@ -315,7 +315,7 @@ const invalid = [
       id: 'Task_1',
       message: 'fromAi() key toolCall.a is declared more than once in this tool. Declare it once and reference it directly elsewhere.',
       data: { type: ERROR_TYPES.AGENT_FEEL_KEY_DUPLICATE },
-      propertiesPanel: { entryIds: [ 'inputs' ] }
+      paths: [ [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ], [ 'extensionElements', 'values', 0, 'inputParameters', 1, 'source' ] ]
     }
   },
 
@@ -331,7 +331,7 @@ const invalid = [
       id: 'Task_1',
       message: 'Wrong function name "fromai". Use fromAi (case-sensitive).',
       data: { type: ERROR_TYPES.AGENT_FEEL_FUNCTION_NAME_INVALID },
-      propertiesPanel: { entryIds: [ 'Task_1-input-0-source' ] }
+      path: [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ]
     }
   },
 
@@ -347,7 +347,7 @@ const invalid = [
       id: 'Task_1',
       message: 'fromAi() should only be used inside an agentic sub-process.',
       data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
-      propertiesPanel: { entryIds: [ 'Task_1-input-0-source' ] }
+      path: [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ]
     }
   },
   {
@@ -360,7 +360,7 @@ const invalid = [
       id: 'Task_1',
       message: 'The "AHSP_1" sub-process is not marked as agentic, so fromAi() has no effect.',
       data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
-      propertiesPanel: { entryIds: [ 'Task_1-input-0-source' ] }
+      path: [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ]
     }
   },
   {
@@ -381,7 +381,7 @@ const invalid = [
       id: 'Task_1',
       message: 'The "Delivery Tools" sub-process is not marked as agentic, so fromAi() has no effect.',
       data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
-      propertiesPanel: { entryIds: [ 'Task_1-input-0-source' ] }
+      path: [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ]
     }
   },
   {
@@ -417,7 +417,7 @@ const invalid = [
       id: 'Task_2',
       message: 'fromAi() is ignored here: only the tool\'s entry element defines AI inputs. Define it there and read the toolCall variable directly.',
       data: { type: ERROR_TYPES.AGENT_FEEL_NON_ENTRY_ELEMENT },
-      propertiesPanel: { entryIds: [ 'Task_2-input-0-source' ] }
+      path: [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ]
     }
   },
   {
@@ -445,7 +445,7 @@ const invalid = [
       id: 'Inner_1',
       message: 'fromAi() is ignored here: only the tool\'s entry element defines AI inputs. Define it there and read the toolCall variable directly.',
       data: { type: ERROR_TYPES.AGENT_FEEL_NON_ENTRY_ELEMENT },
-      propertiesPanel: { entryIds: [ 'Inner_1-input-0-source' ] }
+      path: [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ]
     }
   },
   {
@@ -471,7 +471,7 @@ const invalid = [
       id: 'Task_1',
       message: 'fromAi() defines a tool input and has no effect in an output mapping. Define it in an input mapping on the tool\'s entry element.',
       data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
-      propertiesPanel: { entryIds: [ 'Task_1-output-0-source' ] }
+      path: [ 'extensionElements', 'values', 0, 'outputParameters', 0, 'source' ]
     }
   },
   {
@@ -499,7 +499,7 @@ const invalid = [
       id: 'Flow_1',
       message: 'fromAi() defines a tool input and cannot be used in a sequence flow condition. Define it in an input mapping on the tool\'s entry element.',
       data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
-      propertiesPanel: { entryIds: [ 'conditionExpression' ] }
+      path: [ 'conditionExpression' ]
     }
   },
 
@@ -524,7 +524,7 @@ const invalid = [
       id: 'Task_1',
       message: 'fromAi() key toolCall.a is declared more than once in this tool. Declare it once and reference it directly elsewhere.',
       data: { type: ERROR_TYPES.AGENT_FEEL_KEY_DUPLICATE },
-      propertiesPanel: { entryIds: [ 'inputs' ] }
+      paths: [ [ 'extensionElements', 'values', 0, 'inputParameters', 0, 'source' ], [ 'extensionElements', 'values', 0, 'inputParameters', 1, 'source' ] ]
     }
   },
   {
@@ -545,7 +545,7 @@ const invalid = [
       id: 'Task_1',
       message: 'fromAi() defines a tool input and has no effect in an output mapping. Define it in an input mapping on the tool\'s entry element.',
       data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
-      propertiesPanel: { entryIds: [ 'Task_1-output-0-source' ] }
+      path: [ 'extensionElements', 'values', 0, 'outputParameters', 0, 'source' ]
     }
   },
   {
@@ -568,7 +568,7 @@ const invalid = [
       id: 'Flow_1',
       message: 'fromAi() defines a tool input and cannot be used in a sequence flow condition. Define it in an input mapping on the tool\'s entry element.',
       data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
-      propertiesPanel: { entryIds: [ 'conditionExpression' ] }
+      path: [ 'conditionExpression' ]
     }
   }
 ];

--- a/test/camunda-cloud/agent-tool-documentation.spec.js
+++ b/test/camunda-cloud/agent-tool-documentation.spec.js
@@ -196,7 +196,7 @@ const invalid = [
       id: 'Task_1',
       message: 'Tool documentation is missing.',
       data: { type: ERROR_TYPES.AGENT_TOOL_DOCUMENTATION_MISSING },
-      propertiesPanel: { entryIds: [ 'documentation' ] }
+      path: [ 'documentation' ]
     }
   },
   {
@@ -211,7 +211,7 @@ const invalid = [
       id: 'Task_1',
       message: 'Tool documentation is missing.',
       data: { type: ERROR_TYPES.AGENT_TOOL_DOCUMENTATION_MISSING },
-      propertiesPanel: { entryIds: [ 'documentation' ] }
+      path: [ 'documentation' ]
     }
   },
   {
@@ -224,7 +224,7 @@ const invalid = [
       id: 'Task_1',
       message: 'Tool documentation is missing.',
       data: { type: ERROR_TYPES.AGENT_TOOL_DOCUMENTATION_MISSING },
-      propertiesPanel: { entryIds: [ 'documentation' ] }
+      path: [ 'documentation' ]
     }
   },
   {
@@ -239,7 +239,7 @@ const invalid = [
       id: 'Task_1',
       message: 'Tool documentation is missing.',
       data: { type: ERROR_TYPES.AGENT_TOOL_DOCUMENTATION_MISSING },
-      propertiesPanel: { entryIds: [ 'documentation' ] }
+      path: [ 'documentation' ]
     }
   },
   {
@@ -253,7 +253,7 @@ const invalid = [
       id: 'Task_1',
       message: 'Tool documentation is missing.',
       data: { type: ERROR_TYPES.AGENT_TOOL_DOCUMENTATION_MISSING },
-      propertiesPanel: { entryIds: [ 'documentation' ] }
+      path: [ 'documentation' ]
     }
   },
   {
@@ -266,7 +266,7 @@ const invalid = [
       id: 'Task_1',
       message: 'Tool documentation is missing.',
       data: { type: ERROR_TYPES.AGENT_TOOL_DOCUMENTATION_MISSING },
-      propertiesPanel: { entryIds: [ 'documentation' ] }
+      path: [ 'documentation' ]
     }
   },
   {
@@ -281,7 +281,7 @@ const invalid = [
       id: 'Task_1',
       message: 'Tool documentation is missing.',
       data: { type: ERROR_TYPES.AGENT_TOOL_DOCUMENTATION_MISSING },
-      propertiesPanel: { entryIds: [ 'documentation' ] }
+      path: [ 'documentation' ]
     }
   }
 ];

--- a/test/camunda-cloud/agent-tool-output-key.spec.js
+++ b/test/camunda-cloud/agent-tool-output-key.spec.js
@@ -11,6 +11,11 @@ const { ERROR_TYPES } = require('../../rules/utils/error-types');
 
 const WARN_MESSAGE = '"toolCallResult" output is not mapped.';
 
+const OUTPUT_TARGET_PATH = [ 'extensionElements', 'values', 0, 'outputParameters', 0, 'target' ];
+const HEADER_VALUE_PATH = [ 'extensionElements', 'values', 0, 'values', 0, 'value' ];
+const RESULT_VARIABLE_PATH = [ 'extensionElements', 'values', 0, 'resultVariable' ];
+const OUTPUTS_ANCHOR_PATH = [ 'extensionElements', 'values', 0, 'outputParameters' ];
+
 function agenticToolTask(outputXml = '') {
   return createProcess(`
     <bpmn:adHocSubProcess id="AHSP_1">
@@ -375,7 +380,7 @@ const invalid = [
       id: 'Task_1',
       message: WARN_MESSAGE,
       data: { type: ERROR_TYPES.AGENT_TOOL_OUTPUT_KEY_INVALID },
-      propertiesPanel: { entryIds: [ 'outputs' ] }
+      path: OUTPUT_TARGET_PATH
     }
   },
   {
@@ -388,7 +393,7 @@ const invalid = [
       id: 'Task_1',
       message: WARN_MESSAGE,
       data: { type: ERROR_TYPES.AGENT_TOOL_OUTPUT_KEY_INVALID },
-      propertiesPanel: { entryIds: [ 'outputs' ] }
+      path: OUTPUT_TARGET_PATH
     }
   },
   {
@@ -401,7 +406,7 @@ const invalid = [
       id: 'Task_1',
       message: WARN_MESSAGE,
       data: { type: ERROR_TYPES.AGENT_TOOL_OUTPUT_KEY_INVALID },
-      propertiesPanel: { entryIds: [ 'outputs' ] }
+      path: OUTPUT_TARGET_PATH
     }
   },
   {
@@ -414,7 +419,7 @@ const invalid = [
       id: 'Task_1',
       message: 'Wrong casing "toolcallresult": use toolCallResult (case-sensitive).',
       data: { type: ERROR_TYPES.AGENT_TOOL_OUTPUT_KEY_CASING_INVALID },
-      propertiesPanel: { entryIds: [ 'outputs' ] }
+      path: OUTPUT_TARGET_PATH
     }
   },
   {
@@ -440,7 +445,7 @@ const invalid = [
       id: 'Task_1',
       message: 'Wrong casing "toolcallresult": use toolCallResult (case-sensitive).',
       data: { type: ERROR_TYPES.AGENT_TOOL_OUTPUT_KEY_CASING_INVALID },
-      propertiesPanel: { entryIds: [ 'outputs' ] }
+      path: HEADER_VALUE_PATH
     }
   },
   {
@@ -454,7 +459,7 @@ const invalid = [
       id: 'Task_1',
       message: WARN_MESSAGE,
       data: { type: ERROR_TYPES.AGENT_TOOL_OUTPUT_KEY_INVALID },
-      propertiesPanel: { entryIds: [ 'outputs' ] }
+      path: OUTPUT_TARGET_PATH
     }
   },
   {
@@ -485,7 +490,7 @@ const invalid = [
       id: 'Task_2',
       message: WARN_MESSAGE,
       data: { type: ERROR_TYPES.AGENT_TOOL_OUTPUT_KEY_INVALID },
-      propertiesPanel: { entryIds: [ 'outputs' ] }
+      path: OUTPUT_TARGET_PATH
     }
   },
   {
@@ -516,7 +521,7 @@ const invalid = [
       id: 'Task_2',
       message: 'Wrong casing "toolcallresult": use toolCallResult (case-sensitive).',
       data: { type: ERROR_TYPES.AGENT_TOOL_OUTPUT_KEY_CASING_INVALID },
-      propertiesPanel: { entryIds: [ 'outputs' ] }
+      path: OUTPUT_TARGET_PATH
     }
   },
   {
@@ -527,7 +532,7 @@ const invalid = [
       id: 'Task_1',
       message: 'Tool returns nothing to the agent. Set a "toolCallResult" (at minimum, note the task completed).',
       data: { type: ERROR_TYPES.AGENT_TOOL_RESULT_MISSING },
-      propertiesPanel: { entryIds: [ 'outputs' ] }
+      path: OUTPUTS_ANCHOR_PATH
     }
   },
   {
@@ -551,7 +556,7 @@ const invalid = [
       id: 'Task_1',
       message: WARN_MESSAGE,
       data: { type: ERROR_TYPES.AGENT_TOOL_OUTPUT_KEY_INVALID },
-      propertiesPanel: { entryIds: [ 'outputs' ] }
+      path: RESULT_VARIABLE_PATH
     }
   },
   {
@@ -587,7 +592,7 @@ const invalid = [
       id: 'Task_2',
       message: 'This overwrites the "toolCallResult" value set on "Fetch data".',
       data: { type: ERROR_TYPES.AGENT_TOOL_OUTPUT_KEY_OVERWRITE },
-      propertiesPanel: { entryIds: [ 'outputs' ] },
+      path: HEADER_VALUE_PATH,
       name: 'Re-send'
     }
   },
@@ -610,7 +615,7 @@ const invalid = [
       id: 'Task_1',
       message: WARN_MESSAGE,
       data: { type: ERROR_TYPES.AGENT_TOOL_OUTPUT_KEY_INVALID },
-      propertiesPanel: { entryIds: [ 'outputs' ] }
+      path: OUTPUT_TARGET_PATH
     }
   },
   {
@@ -657,13 +662,13 @@ const invalid = [
         id: 'Task_2',
         message: 'This overwrites the "toolCallResult" value set on "Task_1".',
         data: { type: ERROR_TYPES.AGENT_TOOL_OUTPUT_KEY_OVERWRITE },
-        propertiesPanel: { entryIds: [ 'outputs' ] }
+        path: OUTPUT_TARGET_PATH
       },
       {
         id: 'Task_3',
         message: 'This overwrites the "toolCallResult" value set on "Task_2".',
         data: { type: ERROR_TYPES.AGENT_TOOL_OUTPUT_KEY_OVERWRITE },
-        propertiesPanel: { entryIds: [ 'outputs' ] }
+        path: OUTPUT_TARGET_PATH
       }
     ]
   }

--- a/test/camunda-cloud/duplicate-execution-listener-headers.spec.js
+++ b/test/camunda-cloud/duplicate-execution-listener-headers.spec.js
@@ -110,6 +110,10 @@ const invalid = [
       id: 'ServiceTask_1',
       message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <authToken>',
       path: null,
+      paths: [
+        [ 'extensionElements', 'values', 0, 'listeners', 0, 'headers', 'values', 0, 'key' ],
+        [ 'extensionElements', 'values', 0, 'listeners', 0, 'headers', 'values', 1, 'key' ]
+      ],
       data: {
         type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
         node: 'zeebe:TaskHeaders',
@@ -147,6 +151,10 @@ const invalid = [
         id: 'ServiceTask_1',
         message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <authToken>',
         path: null,
+        paths: [
+          [ 'extensionElements', 'values', 0, 'listeners', 0, 'headers', 'values', 0, 'key' ],
+          [ 'extensionElements', 'values', 0, 'listeners', 0, 'headers', 'values', 1, 'key' ]
+        ],
         data: {
           type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
           node: 'zeebe:TaskHeaders',
@@ -164,6 +172,10 @@ const invalid = [
         id: 'ServiceTask_1',
         message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <endpoint>',
         path: null,
+        paths: [
+          [ 'extensionElements', 'values', 0, 'listeners', 0, 'headers', 'values', 2, 'key' ],
+          [ 'extensionElements', 'values', 0, 'listeners', 0, 'headers', 'values', 3, 'key' ]
+        ],
         data: {
           type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
           node: 'zeebe:TaskHeaders',

--- a/test/camunda-cloud/duplicate-execution-listeners.spec.js
+++ b/test/camunda-cloud/duplicate-execution-listeners.spec.js
@@ -128,6 +128,10 @@ const invalid = [
       id: 'ServiceTask_1',
       message: 'Properties of type <zeebe:ExecutionListener> have properties with duplicate values (property <eventType> with duplicate value of <start>, property <type> with duplicate value of <duplicate>)',
       path: null,
+      paths: [
+        [ 'extensionElements', 'values', 0, 'listeners', 0, 'type' ],
+        [ 'extensionElements', 'values', 0, 'listeners', 1, 'type' ]
+      ],
       data: {
         type: ERROR_TYPES.PROPERTY_VALUES_DUPLICATED,
         node: 'zeebe:ExecutionListeners',
@@ -162,6 +166,11 @@ const invalid = [
         id: 'ServiceTask_1',
         message: 'Properties of type <zeebe:ExecutionListener> have properties with duplicate values (property <eventType> with duplicate value of <start>, property <type> with duplicate value of <duplicate>)',
         path: null,
+        paths: [
+          [ 'extensionElements', 'values', 0, 'listeners', 0, 'type' ],
+          [ 'extensionElements', 'values', 0, 'listeners', 1, 'type' ],
+          [ 'extensionElements', 'values', 0, 'listeners', 2, 'type' ]
+        ],
         data: {
           type: ERROR_TYPES.PROPERTY_VALUES_DUPLICATED,
           node: 'zeebe:ExecutionListeners',
@@ -182,6 +191,11 @@ const invalid = [
         id: 'ServiceTask_1',
         message: 'Properties of type <zeebe:ExecutionListener> have properties with duplicate values (property <eventType> with duplicate value of <start>, property <type> with duplicate value of <duplicate>)',
         path: null,
+        paths: [
+          [ 'extensionElements', 'values', 0, 'listeners', 0, 'type' ],
+          [ 'extensionElements', 'values', 0, 'listeners', 1, 'type' ],
+          [ 'extensionElements', 'values', 0, 'listeners', 2, 'type' ]
+        ],
         data: {
           type: ERROR_TYPES.PROPERTY_VALUES_DUPLICATED,
           node: 'zeebe:ExecutionListeners',
@@ -219,6 +233,10 @@ const invalid = [
         id: 'ServiceTask_1',
         message: 'Properties of type <zeebe:ExecutionListener> have properties with duplicate values (property <eventType> with duplicate value of <start>, property <type> with duplicate value of <duplicate>)',
         path: null,
+        paths: [
+          [ 'extensionElements', 'values', 0, 'listeners', 0, 'type' ],
+          [ 'extensionElements', 'values', 0, 'listeners', 1, 'type' ]
+        ],
         data: {
           type: ERROR_TYPES.PROPERTY_VALUES_DUPLICATED,
           node: 'zeebe:ExecutionListeners',
@@ -238,6 +256,10 @@ const invalid = [
         id: 'ServiceTask_1',
         message: 'Properties of type <zeebe:ExecutionListener> have properties with duplicate values (property <eventType> with duplicate value of <start>, property <type> with duplicate value of <duplicate_2>)',
         path: null,
+        paths: [
+          [ 'extensionElements', 'values', 0, 'listeners', 2, 'type' ],
+          [ 'extensionElements', 'values', 0, 'listeners', 3, 'type' ]
+        ],
         data: {
           type: ERROR_TYPES.PROPERTY_VALUES_DUPLICATED,
           node: 'zeebe:ExecutionListeners',
@@ -271,6 +293,10 @@ const invalid = [
       id: 'ServiceTask_1',
       message: 'Properties of type <zeebe:ExecutionListener> have properties with duplicate values (property <eventType> with duplicate value of <start>, property <type> with duplicate value of <>)',
       path: null,
+      paths: [
+        [ 'extensionElements', 'values', 0, 'listeners', 0, 'type' ],
+        [ 'extensionElements', 'values', 0, 'listeners', 1, 'type' ]
+      ],
       data: {
         type: ERROR_TYPES.PROPERTY_VALUES_DUPLICATED,
         node: 'zeebe:ExecutionListeners',

--- a/test/camunda-cloud/duplicate-task-headers.spec.js
+++ b/test/camunda-cloud/duplicate-task-headers.spec.js
@@ -126,6 +126,10 @@ const invalid = [
       id: 'ServiceTask_1',
       message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <foo>',
       path: null,
+      paths: [
+        [ 'extensionElements', 'values', 0, 'values', 0, 'key' ],
+        [ 'extensionElements', 'values', 0, 'values', 1, 'key' ]
+      ],
       data: {
         type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
         node: 'zeebe:TaskHeaders',
@@ -158,6 +162,11 @@ const invalid = [
         id: 'ServiceTask_1',
         message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <foo>',
         path: null,
+        paths: [
+          [ 'extensionElements', 'values', 0, 'values', 0, 'key' ],
+          [ 'extensionElements', 'values', 0, 'values', 1, 'key' ],
+          [ 'extensionElements', 'values', 0, 'values', 2, 'key' ]
+        ],
         data: {
           type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
           node: 'zeebe:TaskHeaders',
@@ -193,6 +202,10 @@ const invalid = [
         id: 'ServiceTask_1',
         message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <foo>',
         path: null,
+        paths: [
+          [ 'extensionElements', 'values', 0, 'values', 0, 'key' ],
+          [ 'extensionElements', 'values', 0, 'values', 1, 'key' ]
+        ],
         data: {
           type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
           node: 'zeebe:TaskHeaders',
@@ -210,6 +223,10 @@ const invalid = [
         id: 'ServiceTask_1',
         message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <bar>',
         path: null,
+        paths: [
+          [ 'extensionElements', 'values', 0, 'values', 2, 'key' ],
+          [ 'extensionElements', 'values', 0, 'values', 3, 'key' ]
+        ],
         data: {
           type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
           node: 'zeebe:TaskHeaders',
@@ -241,6 +258,10 @@ const invalid = [
       id: 'ServiceTask_1',
       message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <undefined>',
       path: null,
+      paths: [
+        [ 'extensionElements', 'values', 0, 'values', 0, 'key' ],
+        [ 'extensionElements', 'values', 0, 'values', 1, 'key' ]
+      ],
       data: {
         type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
         node: 'zeebe:TaskHeaders',
@@ -271,6 +292,10 @@ const invalid = [
       id: 'SendTask_1',
       message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <foo>',
       path: null,
+      paths: [
+        [ 'extensionElements', 'values', 0, 'values', 0, 'key' ],
+        [ 'extensionElements', 'values', 0, 'values', 1, 'key' ]
+      ],
       data: {
         type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
         node: 'zeebe:TaskHeaders',
@@ -301,6 +326,10 @@ const invalid = [
       id: 'UserTask_1',
       message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <foo>',
       path: null,
+      paths: [
+        [ 'extensionElements', 'values', 0, 'values', 0, 'key' ],
+        [ 'extensionElements', 'values', 0, 'values', 1, 'key' ]
+      ],
       data: {
         type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
         node: 'zeebe:TaskHeaders',
@@ -332,6 +361,10 @@ const invalid = [
       id: 'BusinessRuleTask_1',
       message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <foo>',
       path: null,
+      paths: [
+        [ 'extensionElements', 'values', 1, 'values', 0, 'key' ],
+        [ 'extensionElements', 'values', 1, 'values', 1, 'key' ]
+      ],
       data: {
         type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
         node: 'zeebe:TaskHeaders',
@@ -362,6 +395,10 @@ const invalid = [
       id: 'ScriptTask_1',
       message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <foo>',
       path: null,
+      paths: [
+        [ 'extensionElements', 'values', 0, 'values', 0, 'key' ],
+        [ 'extensionElements', 'values', 0, 'values', 1, 'key' ]
+      ],
       data: {
         type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
         node: 'zeebe:TaskHeaders',
@@ -393,6 +430,10 @@ const invalid = [
       id: 'MessageEvent_1',
       message: 'Properties of type <zeebe:Header> have property <key> with duplicate value of <foo>',
       path: null,
+      paths: [
+        [ 'extensionElements', 'values', 0, 'values', 0, 'key' ],
+        [ 'extensionElements', 'values', 0, 'values', 1, 'key' ]
+      ],
       data: {
         type: ERROR_TYPES.PROPERTY_VALUE_DUPLICATED,
         node: 'zeebe:TaskHeaders',

--- a/test/camunda-cloud/error-reference.spec.js
+++ b/test/camunda-cloud/error-reference.spec.js
@@ -106,8 +106,9 @@ const invalid = [
       id: 'EndEvent_1',
       message: 'Element of type <bpmn:Error> must have property <errorCode>',
       path: [
-        'rootElements',
-        1,
+        'eventDefinitions',
+        0,
+        'errorRef',
         'errorCode'
       ],
       data: {
@@ -133,8 +134,9 @@ const invalid = [
       id: 'EndEvent_1',
       message: 'Element of type <bpmn:Error> must have property <errorCode>',
       path: [
-        'rootElements',
-        1,
+        'eventDefinitions',
+        0,
+        'errorRef',
         'errorCode'
       ],
       data: {
@@ -187,8 +189,9 @@ const invalid = [
       id: 'BoundaryEvent_1',
       message: 'Element of type <bpmn:Error> must have property <errorCode>',
       path: [
-        'rootElements',
-        1,
+        'eventDefinitions',
+        0,
+        'errorRef',
         'errorCode'
       ],
       data: {

--- a/test/camunda-cloud/escalation-reference.spec.js
+++ b/test/camunda-cloud/escalation-reference.spec.js
@@ -97,8 +97,9 @@ const invalid = [
       id: 'EndEvent_1',
       message: 'Element of type <bpmn:Escalation> must have property <escalationCode>',
       path: [
-        'rootElements',
-        1,
+        'eventDefinitions',
+        0,
+        'escalationRef',
         'escalationCode'
       ],
       data: {

--- a/test/camunda-cloud/message-reference.spec.js
+++ b/test/camunda-cloud/message-reference.spec.js
@@ -98,8 +98,9 @@ const invalid = [
       id: 'StartEvent_1',
       message: 'Element of type <bpmn:Message> must have property <name>',
       path: [
-        'rootElements',
-        1,
+        'eventDefinitions',
+        0,
+        'messageRef',
         'name'
       ],
       data: {
@@ -141,8 +142,7 @@ const invalid = [
       id: 'ReceiveTask_1',
       message: 'Element of type <bpmn:Message> must have property <name>',
       path: [
-        'rootElements',
-        1,
+        'messageRef',
         'name'
       ],
       data: {

--- a/test/camunda-cloud/no-task-schedule.spec.js
+++ b/test/camunda-cloud/no-task-schedule.spec.js
@@ -56,7 +56,10 @@ const invalid = [
         parentNode: null,
         extensionElement: 'zeebe:TaskSchedule',
         allowedVersion: '8.2'
-      }
+      },
+      paths: [
+        [ 'extensionElements', 'values', 0, 'dueDate' ]
+      ]
     }
   }
 ];

--- a/test/camunda-cloud/no-zeebe-properties.spec.js
+++ b/test/camunda-cloud/no-zeebe-properties.spec.js
@@ -60,7 +60,10 @@ const invalid = [
         parentNode: null,
         extensionElement: 'zeebe:Properties',
         allowedVersion: '8.1'
-      }
+      },
+      paths: [
+        [ 'extensionElements', 'values', 0, 'properties', 0, 'name' ]
+      ]
     }
   }
 ];

--- a/test/camunda-cloud/signal-reference.spec.js
+++ b/test/camunda-cloud/signal-reference.spec.js
@@ -122,8 +122,9 @@ const invalid = [
       id: 'StartEvent_1',
       message: 'Element of type <bpmn:Signal> must have property <name>',
       path: [
-        'rootElements',
-        1,
+        'eventDefinitions',
+        0,
+        'signalRef',
         'name'
       ],
       data: {
@@ -171,8 +172,9 @@ const invalid = [
       id: 'IntermediateThrowEvent_1',
       message: 'Element of type <bpmn:Signal> must have property <name>',
       path: [
-        'rootElements',
-        1,
+        'eventDefinitions',
+        0,
+        'signalRef',
         'name'
       ],
       data: {
@@ -220,8 +222,9 @@ const invalid = [
       id: 'EndEvent_1',
       message: 'Element of type <bpmn:Signal> must have property <name>',
       path: [
-        'rootElements',
-        1,
+        'eventDefinitions',
+        0,
+        'signalRef',
         'name'
       ],
       data: {

--- a/test/camunda-cloud/subscription.spec.js
+++ b/test/camunda-cloud/subscription.spec.js
@@ -132,8 +132,9 @@ const invalid = [
       id: 'StartEvent_1',
       message: 'Element of type <zeebe:Subscription> must have property <correlationKey>',
       path: [
-        'rootElements',
-        1,
+        'eventDefinitions',
+        0,
+        'messageRef',
         'extensionElements',
         'values',
         0,
@@ -186,8 +187,7 @@ const invalid = [
       id: 'ReceiveTask_1',
       message: 'Element of type <zeebe:Subscription> must have property <correlationKey>',
       path: [
-        'rootElements',
-        1,
+        'messageRef',
         'extensionElements',
         'values',
         0,


### PR DESCRIPTION
### Proposed Changes

This is the first step towards https://github.com/bpmn-io/internal-docs/issues/1355 - by exposing `path` or `paths` in reports, downstream infrastructure can resolve error messages to UI --- in a way that this library does not _need to know_.

This PR:

* Ensures every report provides `path` or `paths` data to downstream integrators (`@camunda/linting`)
* Ensures that no `getEntryId` (UI entry ID) construction is happening - out of scope of this library.

Child of https://github.com/bpmn-io/internal-docs/issues/1355 we 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
