### PR TITLE
refactor(agent-fromai-contract): replace type dispatch with a property sweep

### DIFF
--- a/rules/camunda-cloud/agent-fromai-contract.js
+++ b/rules/camunda-cloud/agent-fromai-contract.js
@@ -2,8 +2,20 @@ const { is } = require('bpmnlint-utils');
 
 const { getPath, pathConcat } = require('@bpmn-io/moddle-utils');
 
-const { findExtensionElement, findAncestorAdHocSubProcess, isAgenticAdHocSubProcess } = require('../utils/element');
-const { CORRECT_NAME, NAME_ALIASES, findFunctionInvocations, getPositionalArgs } = require('./utils/feel');
+const {
+  findExtensionElement,
+  findAncestorAdHocSubProcess,
+  isAgenticAdHocSubProcess,
+  findParentNode
+} = require('../utils/element');
+const {
+  CORRECT_NAME,
+  NAME_ALIASES,
+  findFunctionInvocations,
+  getPositionalArgs,
+  isFeelBearingProperty,
+  unwrapExpression
+} = require('./utils/feel');
 const { reportErrors } = require('../utils/reporter');
 const { ERROR_TYPES } = require('../utils/error-types');
 const { skipInNonExecutableProcess } = require('../utils/rule');
@@ -34,6 +46,12 @@ const { annotateRule } = require('../helper');
  *
  * A description that is simply absent (no argument, or an empty string) is
  * valid: the fromAi() description is optional, so neither rule reports it.
+ *
+ * check() walks every FEEL-bearing property of every node (the same
+ * mechanism as the `feel` syntax rule), not just the three surfaces this
+ * rule currently reports on. That breadth is deliberate groundwork: the
+ * property sweep already sees every candidate site, checkSite() below just
+ * doesn't have a message for most of them yet.
  */
 // ─── Constraint validators ────────────────────────────────────────────────────
 
@@ -121,68 +139,118 @@ function validateDescriptionTypeInvalid(arg) {
 
 module.exports = skipInNonExecutableProcess(function(config = {}) {
   const { version } = config;
+
   function check(node, reporter) {
+
+    // Expression wrappers (conditionExpression, completionCondition, timer
+    // definitions) are swept from their owner via unwrapExpression instead;
+    // visiting them again here would double-report the same call.
+    if (is(node, 'bpmn:Expression')) {
+      return;
+    }
+
     if (is(node, 'bpmn:Activity')) {
+
+      // No early return: an activity (e.g. an ad-hoc sub-process with a
+      // completionCondition) can also carry FEEL-bearing properties of its
+      // own, which the sweep below still needs to see.
       checkDuplicateKeys(node, reporter);
+    }
+
+    const owner = findParentNode(node);
+    if (!owner) {
       return;
     }
 
-    if (is(node, 'zeebe:Output')) {
-      checkOutputSurface(node, reporter);
-      return;
+    const errors = [];
+
+    for (const site of collectFromAiSites(node, owner)) {
+      errors.push(...checkSite(site, owner));
     }
 
-    if (is(node, 'bpmn:SequenceFlow')) {
-      checkConditionSurface(node, reporter);
-      return;
+    if (errors.length) {
+      reportErrors(owner, reporter, errors);
+    }
+  }
+
+  return annotateRule('agent-fromai-contract', {
+    check
+  });
+
+  /**
+   * Every own property of `node` that carries a parseable fromAi()
+   * invocation, with the moddle path to report it against already resolved.
+   */
+  function collectFromAiSites(node, owner) {
+    const sites = [];
+
+    Object.entries(node).forEach(([ propertyName, rawValue ]) => {
+      const value = unwrapExpression(rawValue);
+
+      if (!isFeelBearingProperty(node, propertyName, value)) {
+        return;
+      }
+
+      const expr = value.substring(1).trim();
+      const invocations = findFunctionInvocations(expr);
+      if (!invocations.length) {
+        return;
+      }
+
+      sites.push({
+        node,
+        propertyName,
+        expr,
+        invocations,
+        path: pathConcat(getPath(node, owner) || [], propertyName)
+      });
+    });
+
+    return sites;
+  }
+
+  /**
+   * Dispatches a site to its surface-specific check. This PR only recognizes
+   * the three surfaces the rule already reports on; every other site the
+   * sweep finds (e.g. a fromAi() in a task's Retries field) is silently
+   * ignored for now. See the module docblock.
+   */
+  function checkSite(site, owner) {
+    if (is(site.node, 'zeebe:Input') && site.propertyName === 'source') {
+      return checkInputSite(site, owner);
     }
 
-    if (!is(node, 'zeebe:Input')) {
-      return;
+    if (is(site.node, 'zeebe:Output') && site.propertyName === 'source') {
+      return checkOutputSite(site, owner);
     }
 
-    const source = node.get('source');
-    if (!source || !source.startsWith('=')) {
-      return;
+    if (is(site.node, 'bpmn:SequenceFlow') && site.propertyName === 'conditionExpression') {
+      return checkConditionSite(site, owner);
     }
 
-    const expr = source.substring(1).trim();
-    const invocations = findFunctionInvocations(expr);
-    if (invocations.length === 0) {
-      return;
-    }
+    return [];
+  }
 
-    // Walk from zeebe:Input → zeebe:IoMapping → bpmn:ExtensionElements → task
-    const task = node.$parent && node.$parent.$parent && node.$parent.$parent.$parent;
-    if (!task || !is(task, 'bpmn:FlowNode')) {
-      return;
-    }
-
-    // Moddle path to this input parameter's source, so a single downstream
-    // resolver maps it to the entry the modeler actually renders — the standard
-    // input mapping, or a template's custom entry. The rule stays agnostic to
-    // the id scheme.
-    const path = pathConcat(getPath(node, task), 'source');
+  function checkInputSite(site, task) {
+    const { invocations, expr, path } = site;
 
     const ahsp = findAncestorAdHocSubProcess(task);
 
     if (!ahsp) {
-      reportErrors(task, reporter, invocations.map(() => ({
+      return invocations.map(() => ({
         message: 'fromAi() should only be used inside an agentic sub-process.',
         data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
         path,
-      })));
-      return;
+      }));
     }
 
     if (!isAgenticAdHocSubProcess(ahsp, version)) {
       const ahspLabel = ahsp.get('name') || ahsp.get('id');
-      reportErrors(task, reporter, invocations.map(() => ({
+      return invocations.map(() => ({
         message: `The "${ahspLabel}" sub-process is not marked as agentic, so fromAi() has no effect.`,
         data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
         path,
-      })));
-      return;
+      }));
     }
 
     // The connector resolves fromAi() only on the tool's entry element: the
@@ -192,12 +260,11 @@ module.exports = skipInNonExecutableProcess(function(config = {}) {
     // sub-process tool, whose parent is the sub-process, not the AHSP).
     const incoming = task.get('incoming') || [];
     if (incoming.length > 0 || task.$parent !== ahsp) {
-      reportErrors(task, reporter, invocations.map(() => ({
+      return invocations.map(() => ({
         message: 'fromAi() is ignored here: only the tool\'s entry element defines AI inputs. Define it there and read the toolCall variable directly.',
         data: { type: ERROR_TYPES.AGENT_FEEL_NON_ENTRY_ELEMENT },
         path,
-      })));
-      return;
+      }));
     }
 
     // Inside agentic AHSP, on the entry element: run structural checks.
@@ -237,14 +304,49 @@ module.exports = skipInNonExecutableProcess(function(config = {}) {
       }
     }
 
-    if (errors.length) {
-      reportErrors(task, reporter, errors.map(error => ({ ...error, path })));
-    }
+    return errors.map(error => ({ ...error, path }));
   }
 
-  return annotateRule('agent-fromai-contract', {
-    check
-  });
+  /**
+   * fromAi() only defines tool inputs; the connector reads it from input
+   * mappings and never populates toolCall on the output side, so a fromAi()
+   * call in an output source silently resolves to null. Scoped to agentic
+   * ad-hoc sub-processes to avoid firing on unrelated diagrams.
+   */
+  function checkOutputSite(site, task) {
+    const { invocations, path } = site;
+
+    const ahsp = findAncestorAdHocSubProcess(task);
+    if (!ahsp || !isAgenticAdHocSubProcess(ahsp, version)) {
+      return [];
+    }
+
+    return invocations.map(() => ({
+      message: 'fromAi() defines a tool input and has no effect in an output mapping. Define it in an input mapping on the tool\'s entry element.',
+      data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
+      path,
+    }));
+  }
+
+  /**
+   * The toolCall context is only populated for a tool's inputs, so fromAi() in
+   * a sequence flow condition resolves to null and the branch never behaves as
+   * intended. Scoped to agentic ad-hoc sub-processes.
+   */
+  function checkConditionSite(site, flow) {
+    const { invocations, path } = site;
+
+    const ahsp = findAncestorAdHocSubProcess(flow);
+    if (!ahsp || !isAgenticAdHocSubProcess(ahsp, version)) {
+      return [];
+    }
+
+    return invocations.map(() => ({
+      message: 'fromAi() defines a tool input and cannot be used in a sequence flow condition. Define it in an input mapping on the tool\'s entry element.',
+      data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
+      path,
+    }));
+  }
 
   /**
    * The connector combines all fromAi() definitions of the tool's entry
@@ -301,72 +403,5 @@ module.exports = skipInNonExecutableProcess(function(config = {}) {
         paths: keyOccurrences[ key ].map(input => pathConcat(getPath(input, task), 'source')),
       })));
     }
-  }
-
-  /**
-   * fromAi() only defines tool inputs; the connector reads it from input
-   * mappings and never populates toolCall on the output side, so a fromAi()
-   * call in an output source silently resolves to null. Scoped to agentic
-   * ad-hoc sub-processes to avoid firing on unrelated diagrams.
-   */
-  function checkOutputSurface(node, reporter) {
-    const source = node.get('source');
-    if (!source || !source.startsWith('=')) {
-      return;
-    }
-
-    const expr = source.substring(1).trim();
-    const invocations = findFunctionInvocations(expr);
-    if (!invocations.length) {
-      return;
-    }
-
-    const task = node.$parent && node.$parent.$parent && node.$parent.$parent.$parent;
-    if (!task || !is(task, 'bpmn:FlowNode')) {
-      return;
-    }
-
-    const ahsp = findAncestorAdHocSubProcess(task);
-    if (!ahsp || !isAgenticAdHocSubProcess(ahsp, version)) {
-      return;
-    }
-
-    const path = pathConcat(getPath(node, task), 'source');
-
-    reportErrors(task, reporter, invocations.map(() => ({
-      message: 'fromAi() defines a tool input and has no effect in an output mapping. Define it in an input mapping on the tool\'s entry element.',
-      data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
-      path,
-    })));
-  }
-
-  /**
-   * The toolCall context is only populated for a tool's inputs, so fromAi() in
-   * a sequence flow condition resolves to null and the branch never behaves as
-   * intended. Scoped to agentic ad-hoc sub-processes.
-   */
-  function checkConditionSurface(node, reporter) {
-    const condition = node.get('conditionExpression');
-    const body = condition && condition.get('body');
-    if (!body || !body.startsWith('=')) {
-      return;
-    }
-
-    const expr = body.substring(1).trim();
-    const invocations = findFunctionInvocations(expr);
-    if (!invocations.length) {
-      return;
-    }
-
-    const ahsp = findAncestorAdHocSubProcess(node);
-    if (!ahsp || !isAgenticAdHocSubProcess(ahsp, version)) {
-      return;
-    }
-
-    reportErrors(node, reporter, invocations.map(() => ({
-      message: 'fromAi() defines a tool input and cannot be used in a sequence flow condition. Define it in an input mapping on the tool\'s entry element.',
-      data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
-      path: getPath(condition, node),
-    })));
   }
 });

--- a/rules/camunda-cloud/utils/feel.js
+++ b/rules/camunda-cloud/utils/feel.js
@@ -1,5 +1,7 @@
 const { isString } = require('min-dash');
 
+const { is } = require('bpmnlint-utils');
+
 const { parser } = require('@bpmn-io/lezer-feel');
 
 // Properties ignored globally
@@ -35,6 +37,57 @@ const isFeelProperty = (node, propertyName, value) => {
 // ─── fromAi() lezer helpers ─────────────────────────────────────────────────
 // Used by agent-fromai-contract to locate fromAi() calls and read their
 // positional arguments.
+
+/**
+ * Unwrap a bpmn:Expression-valued property (conditionExpression,
+ * completionCondition, timer definitions, loopCardinality) to its FEEL body,
+ * so a semantic sweep can treat it the same as a plain string attribute.
+ */
+function unwrapExpression(value) {
+  if (value && is(value, 'bpmn:Expression')) {
+    return value.get('body');
+  }
+  return value;
+}
+
+// Properties ignored for the SEMANTIC sweep (agent-fromai-contract), as
+// opposed to IGNORED_PROPERTIES_BY_TYPE above, which is tuned for the FEEL
+// SYNTAX rule. Deliberate differences:
+//
+// - zeebe:Header key/value and zeebe:Property name/value are NOT ignored
+//   here. Connector templates put resultExpression/errorExpression in
+//   zeebe:taskHeader, and zeebe:property is a first-class element-template
+//   binding, so a fromAi() call there is a real (and broken) surface. The
+//   syntax rule skips them to avoid flagging non-FEEL strings that happen to
+//   start with "=", a concern that does not apply here: the caller
+//   additionally requires a parsed fromAi() invocation before reporting.
+// - bpmn:Documentation text IS ignored here: tool documentation legitimately
+//   discusses fromAi() in prose.
+const SEMANTIC_IGNORED_PROPERTIES_BY_TYPE = {
+  'zeebe:Input': [ 'target' ],
+  'zeebe:Output': [ 'target' ],
+  'zeebe:CalledDecision': [ 'resultVariable' ],
+  'zeebe:Script': [ 'resultVariable' ],
+  'bpmn:Documentation': [ 'text' ]
+};
+
+const isSemanticIgnoredProperty = (node, propertyName) => {
+  if (propertyName.startsWith('$') || IGNORED_PROPERTIES.includes(propertyName)) {
+    return true;
+  }
+
+  const ignoredForType = SEMANTIC_IGNORED_PROPERTIES_BY_TYPE[node.$type];
+
+  return ignoredForType && ignoredForType.includes(propertyName);
+};
+
+/**
+ * A FEEL-bearing property for the agent-fromai-contract sweep. `value` must
+ * already be unwrapped via unwrapExpression.
+ */
+const isFeelBearingProperty = (node, propertyName, value) => {
+  return !isSemanticIgnoredProperty(node, propertyName) && isString(value) && value.startsWith('=');
+};
 
 const CORRECT_NAME = 'fromAi';
 const NAME_ALIASES = [ 'fromai', 'fromAI' ];
@@ -84,6 +137,8 @@ function getPositionalArgs(invocationNode, expr) {
 
 module.exports = {
   isFeelProperty,
+  unwrapExpression,
+  isFeelBearingProperty,
   CORRECT_NAME,
   NAME_ALIASES,
   findFunctionInvocations,

--- a/test/camunda-cloud/utils/feel.spec.js
+++ b/test/camunda-cloud/utils/feel.spec.js
@@ -1,0 +1,134 @@
+const { expect } = require('chai');
+
+const {
+  unwrapExpression,
+  isFeelBearingProperty
+} = require('../../../rules/camunda-cloud/utils/feel');
+
+const { createElement } = require('../../helper');
+
+describe('camunda-cloud/utils/feel', function() {
+
+  describe('#unwrapExpression', function() {
+
+    it('unwraps a bpmn:Expression to its body', function() {
+
+      // given
+      const expression = createElement('bpmn:FormalExpression', { body: '=1 + 1' });
+
+      // then
+      expect(unwrapExpression(expression)).to.eql('=1 + 1');
+    });
+
+
+    it('passes through a plain string', function() {
+      expect(unwrapExpression('=1 + 1')).to.eql('=1 + 1');
+    });
+
+
+    it('passes through null and undefined', function() {
+      expect(unwrapExpression(null)).to.eql(null);
+      expect(unwrapExpression(undefined)).to.eql(undefined);
+    });
+
+  });
+
+
+  describe('#isFeelBearingProperty', function() {
+
+    it('accepts a FEEL-looking string', function() {
+
+      // given
+      const node = createElement('zeebe:TaskDefinition', { retries: '=fromAi(toolCall.retries)' });
+
+      // then
+      expect(isFeelBearingProperty(node, 'retries', '=fromAi(toolCall.retries)')).to.be.true;
+    });
+
+
+    it('rejects a non-string value', function() {
+
+      // given
+      const node = createElement('bpmn:SequenceFlow', {});
+
+      // then
+      expect(isFeelBearingProperty(node, 'incoming', [])).to.be.false;
+    });
+
+
+    it('rejects a string that is not a FEEL expression', function() {
+
+      // given
+      const node = createElement('zeebe:TaskDefinition', { type: 'search' });
+
+      // then
+      expect(isFeelBearingProperty(node, 'type', 'search')).to.be.false;
+    });
+
+
+    it('rejects the globally ignored "name" property', function() {
+
+      // given
+      const node = createElement('bpmn:AdHocSubProcess', { name: '=fromAi(toolCall.x)' });
+
+      // then
+      expect(isFeelBearingProperty(node, 'name', '=fromAi(toolCall.x)')).to.be.false;
+    });
+
+
+    it('rejects zeebe:Input target and zeebe:Output target', function() {
+
+      // given
+      const input = createElement('zeebe:Input', { target: '=fromAi(toolCall.x)' });
+      const output = createElement('zeebe:Output', { target: '=fromAi(toolCall.x)' });
+
+      // then
+      expect(isFeelBearingProperty(input, 'target', '=fromAi(toolCall.x)')).to.be.false;
+      expect(isFeelBearingProperty(output, 'target', '=fromAi(toolCall.x)')).to.be.false;
+    });
+
+
+    it('rejects zeebe:CalledDecision and zeebe:Script resultVariable', function() {
+
+      // given
+      const calledDecision = createElement('zeebe:CalledDecision', { resultVariable: '=fromAi(toolCall.x)' });
+      const script = createElement('zeebe:Script', { resultVariable: '=fromAi(toolCall.x)' });
+
+      // then
+      expect(isFeelBearingProperty(calledDecision, 'resultVariable', '=fromAi(toolCall.x)')).to.be.false;
+      expect(isFeelBearingProperty(script, 'resultVariable', '=fromAi(toolCall.x)')).to.be.false;
+    });
+
+
+    it('rejects bpmn:Documentation text', function() {
+
+      // given
+      const node = createElement('bpmn:Documentation', { text: '=fromAi(toolCall.x)' });
+
+      // then
+      expect(isFeelBearingProperty(node, 'text', '=fromAi(toolCall.x)')).to.be.false;
+    });
+
+
+    it('accepts zeebe:Header value, unlike the FEEL syntax rule', function() {
+
+      // given
+      const node = createElement('zeebe:Header', { key: 'resultExpression', value: '=fromAi(toolCall.x)' });
+
+      // then
+      expect(isFeelBearingProperty(node, 'value', '=fromAi(toolCall.x)')).to.be.true;
+    });
+
+
+    it('accepts zeebe:Property value, unlike the FEEL syntax rule', function() {
+
+      // given
+      const node = createElement('zeebe:Property', { name: 'custom', value: '=fromAi(toolCall.x)' });
+
+      // then
+      expect(isFeelBearingProperty(node, 'value', '=fromAi(toolCall.x)')).to.be.true;
+    });
+
+  });
+
+});


### PR DESCRIPTION
### Proposed Changes

PR 1 of 2 for #256. `agent-fromai-contract`'s `check()` dispatched on exactly four hardcoded moddle node types (`bpmn:Activity`, `zeebe:Output`, `bpmn:SequenceFlow`, `zeebe:Input`), so `fromAi()` in any other property, for example a task's Retries field or a call activity's process ID expression, was invisible to the rule.

This PR replaces that dispatch with a generic sweep of every FEEL-bearing property, modeled on the `feel` syntax rule's `Object.entries()` walk. It adds `unwrapExpression` and `isFeelBearingProperty` to `rules/camunda-cloud/utils/feel.js`, a semantic-sweep counterpart to the existing `isFeelProperty` (tuned for FEEL syntax checking, not "does this property matter to `fromAi()`").

**Zero behavior change.** `checkSite()` only recognizes the three surfaces the rule already reports on (input mapping source, output mapping source, sequence flow condition); every other site the sweep now finds is silently ignored, for now. All 33 existing test cases pass with identical messages and moddle paths, plus 12 new unit tests for the two new predicates.

The point of landing this separately: it's a real refactor of the rule's core dispatch mechanism, and it's worth reviewing and being able to revert independently from the new detection logic. PR 2 will add the key-aware check for `fromAi()` in non-input properties (the actual fix for #256), reusing the sweep this PR introduces.

### Try out

```
npm test
```

All 33 `agent-fromai-contract` cases and the new `feel` utils spec pass; `npm run all` is green.

Closes nothing, refs #256.