### PR TITLE
fix(agent-fromai-contract): flag fromAi() whose key is declared nowhere

### DIFF
--- a/rules/camunda-cloud/agent-fromai-contract.js
+++ b/rules/camunda-cloud/agent-fromai-contract.js
@@ -6,6 +6,7 @@ const {
   findExtensionElement,
   findAncestorAdHocSubProcess,
   isAgenticAdHocSubProcess,
+  isAgenticToolElement,
   findParentNode
 } = require('../utils/element');
 const {
@@ -48,10 +49,20 @@ const { annotateRule } = require('../helper');
  * valid: the fromAi() description is optional, so neither rule reports it.
  *
  * check() walks every FEEL-bearing property of every node (the same
- * mechanism as the `feel` syntax rule), not just the three surfaces this
- * rule currently reports on. That breadth is deliberate groundwork: the
- * property sweep already sees every candidate site, checkSite() below just
- * doesn't have a message for most of them yet.
+ * mechanism as the `feel` syntax rule), not just an input mapping source.
+ * This is deliberate: fromAi() is only ever DECLARED as a tool parameter in
+ * an input mapping on the tool's entry element (AdHocSubProcessTransformer
+ * in camunda/camunda extracts tagged parameters only from
+ * `adHocActivity.getInputMappings()`), but the resulting `toolCall` variable
+ * is READABLE anywhere in that tool's sub-flow once activated
+ * (BpmnAdHocSubProcessBehavior#activateElement merges it as a local variable
+ * on the ad-hoc sub-process's inner instance). So a fromAi() call outside an
+ * input mapping is not automatically dead: `fromAi(toolCall.retries)` in a
+ * task's Retries field is genuinely correct if `toolCall.retries` was
+ * declared by a fromAi() call in an input mapping on the same tool. What is
+ * always broken is a fromAi(toolCall.KEY, ...) whose KEY was declared
+ * nowhere: the schema never gets that parameter, so the call always
+ * resolves to null. checkSite() below is key-aware for exactly this reason.
  */
 // ─── Constraint validators ────────────────────────────────────────────────────
 
@@ -210,25 +221,116 @@ module.exports = skipInNonExecutableProcess(function(config = {}) {
   }
 
   /**
-   * Dispatches a site to its surface-specific check. This PR only recognizes
-   * the three surfaces the rule already reports on; every other site the
-   * sweep finds (e.g. a fromAi() in a task's Retries field) is silently
-   * ignored for now. See the module docblock.
+   * Dispatches a site to its surface-specific check, first rung wins:
+   *
+   *   1. the owner is the agent itself (not a tool): toolCall lives on the
+   *      tool's inner instance, a child scope the agent's own properties
+   *      never see, regardless of which property this is.
+   *   2. an input mapping source: the existing context-then-structure ladder.
+   *   3. anything else: key-aware, see checkNonInputSite.
    */
   function checkSite(site, owner) {
+    if (isAgentItself(owner, version)) {
+      return site.invocations.map(() => ({
+        message: 'fromAi() defines a tool input and has no effect on the agent sub-process itself. Define it on a tool inside this sub-process.',
+        data: {
+          type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+          node: site.node,
+          parentNode: owner,
+          property: site.propertyName
+        },
+        path: site.path,
+      }));
+    }
+
     if (is(site.node, 'zeebe:Input') && site.propertyName === 'source') {
       return checkInputSite(site, owner);
     }
 
-    if (is(site.node, 'zeebe:Output') && site.propertyName === 'source') {
-      return checkOutputSite(site, owner);
+    return checkNonInputSite(site, owner);
+  }
+
+  /**
+   * `owner` is the agent's own ad-hoc sub-process, not a tool inside it: an
+   * agentic AHSP that is not itself a tool of some outer agent. A nested
+   * agentic AHSP that IS a tool of an outer agent is excluded here: it is an
+   * ad-hoc activity of that outer agent, so fromAi() in its own input
+   * mappings is a live tool-input declaration, handled by checkInputSite.
+   */
+  function isAgentItself(owner, version) {
+    return is(owner, 'bpmn:AdHocSubProcess')
+      && isAgenticAdHocSubProcess(owner, version)
+      && !isAgenticToolElement(owner, version);
+  }
+
+  /**
+   * A human label for where this site sits, used only to phrase the
+   * undeclared-key message. Falls back to naming the raw property.
+   */
+  function getSurfaceLabel(node, propertyName) {
+    if (is(node, 'zeebe:Output') && propertyName === 'source') {
+      return 'this output mapping';
     }
 
-    if (is(site.node, 'bpmn:SequenceFlow') && site.propertyName === 'conditionExpression') {
-      return checkConditionSite(site, owner);
+    if (is(node, 'bpmn:SequenceFlow') && propertyName === 'conditionExpression') {
+      return 'this sequence flow condition';
     }
 
-    return [];
+    return `the <${propertyName}> property`;
+  }
+
+  /**
+   * Any property other than an input mapping source. fromAi(toolCall.KEY, ...)
+   * here is valid only if KEY was already declared by a fromAi() call in an
+   * input mapping on the same tool; declaration is looked up per-element when
+   * `owner` is itself a tool's entry element (exact: that element's own input
+   * mappings are the only source `AdHocSubProcessTransformer` would ever
+   * read for it), and as a union across every tool entry in the ad-hoc
+   * sub-process otherwise (an approximation: finding the true owning tool
+   * for a downstream element or a sequence flow would need a backward walk
+   * over sequence flows, which agent-tool-output-key.js already documents as
+   * unsolved for splits and joins; the union only under-reports, it never
+   * over-reports, which is the right side to err on for a fixed-error rule).
+   */
+  function checkNonInputSite(site, owner) {
+    const { node, propertyName, expr, invocations, path } = site;
+
+    const surfaceLabel = getSurfaceLabel(node, propertyName);
+    const ahsp = findAncestorAdHocSubProcess(owner);
+    const declaredKeys = (ahsp && isAgenticAdHocSubProcess(ahsp, version))
+      ? (isAgenticToolElement(owner, version)
+        ? getOwnDeclaredKeys(owner)
+        : getAhspDeclaredKeys(ahsp))
+      : null;
+
+    const errors = [];
+
+    for (const inv of invocations) {
+      const args = getPositionalArgs(inv.node, expr);
+      const keyArg = args[0];
+      const keyText = (keyArg && keyArg.type === 'PathExpression' && keyArg.text.startsWith('toolCall.'))
+        ? keyArg.text
+        : null;
+
+      if (keyText && declaredKeys && declaredKeys.has(keyText)) {
+        continue;
+      }
+
+      const subject = keyText || 'this value';
+
+      errors.push({
+        message: `fromAi() only defines a tool input in an input mapping, so ${subject} is never provided and ${surfaceLabel} resolves to null. Declare it in an input mapping on the tool's entry element, then read ${subject} here.`,
+        data: {
+          type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+          node,
+          parentNode: owner,
+          property: propertyName
+        },
+        path,
+      });
+    }
+
+    return errors;
   }
 
   function checkInputSite(site, task) {
@@ -308,44 +410,71 @@ module.exports = skipInNonExecutableProcess(function(config = {}) {
   }
 
   /**
-   * fromAi() only defines tool inputs; the connector reads it from input
-   * mappings and never populates toolCall on the output side, so a fromAi()
-   * call in an output source silently resolves to null. Scoped to agentic
-   * ad-hoc sub-processes to avoid firing on unrelated diagrams.
+   * fromAi() key paths declared by input-mapping sources directly on this
+   * activity, grouped by key with every declaring input, regardless of
+   * whether this activity is the tool's entry element. Shared by
+   * checkDuplicateKeys, which cares about repeats, and getOwnDeclaredKeys,
+   * which cares only about membership.
    */
-  function checkOutputSite(site, task) {
-    const { invocations, path } = site;
-
-    const ahsp = findAncestorAdHocSubProcess(task);
-    if (!ahsp || !isAgenticAdHocSubProcess(ahsp, version)) {
-      return [];
+  function collectOwnDeclaredKeyOccurrences(activity) {
+    const ioMapping = findExtensionElement(activity, 'zeebe:IoMapping');
+    if (!ioMapping) {
+      return {};
     }
 
-    return invocations.map(() => ({
-      message: 'fromAi() defines a tool input and has no effect in an output mapping. Define it in an input mapping on the tool\'s entry element.',
-      data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
-      path,
-    }));
+    const keyOccurrences = {};
+
+    for (const input of ioMapping.get('inputParameters') || []) {
+      const source = input.get('source');
+      if (!source || !source.startsWith('=')) {
+        continue;
+      }
+
+      const expr = source.substring(1).trim();
+      for (const inv of findFunctionInvocations(expr)) {
+        const args = getPositionalArgs(inv.node, expr);
+        const key = args[ 0 ];
+        if (key && key.type === 'PathExpression' && key.text.startsWith('toolCall.')) {
+          (keyOccurrences[ key.text ] = keyOccurrences[ key.text ] || []).push(input);
+        }
+      }
+    }
+
+    return keyOccurrences;
   }
 
   /**
-   * The toolCall context is only populated for a tool's inputs, so fromAi() in
-   * a sequence flow condition resolves to null and the branch never behaves as
-   * intended. Scoped to agentic ad-hoc sub-processes.
+   * The exact declaration set for one activity: every fromAi() key its own
+   * input mappings declare, regardless of whether it is a tool's entry
+   * element. Used as-is when the site being checked lives directly on that
+   * activity (no approximation needed there).
    */
-  function checkConditionSite(site, flow) {
-    const { invocations, path } = site;
+  function getOwnDeclaredKeys(activity) {
+    return new Set(Object.keys(collectOwnDeclaredKeyOccurrences(activity)));
+  }
 
-    const ahsp = findAncestorAdHocSubProcess(flow);
-    if (!ahsp || !isAgenticAdHocSubProcess(ahsp, version)) {
-      return [];
+  /**
+   * The union of declared keys across every tool entry element directly
+   * inside this ad-hoc sub-process. Used for a site that is not itself a
+   * tool's entry element (a downstream element, or a sequence flow), where
+   * the true owning tool would need a backward walk over sequence flows to
+   * find precisely; see checkNonInputSite for why the union is the right
+   * approximation.
+   */
+  function getAhspDeclaredKeys(ahsp) {
+    const keys = new Set();
+
+    for (const child of ahsp.get('flowElements') || []) {
+      if (!isAgenticToolElement(child, version)) {
+        continue;
+      }
+
+      for (const key of getOwnDeclaredKeys(child)) {
+        keys.add(key);
+      }
     }
 
-    return invocations.map(() => ({
-      message: 'fromAi() defines a tool input and cannot be used in a sequence flow condition. Define it in an input mapping on the tool\'s entry element.',
-      data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
-      path,
-    }));
+    return keys;
   }
 
   /**
@@ -371,29 +500,7 @@ module.exports = skipInNonExecutableProcess(function(config = {}) {
       return;
     }
 
-    const ioMapping = findExtensionElement(task, 'zeebe:IoMapping');
-    if (!ioMapping) {
-      return;
-    }
-
-    const keyOccurrences = {};
-
-    for (const input of ioMapping.get('inputParameters') || []) {
-      const source = input.get('source');
-      if (!source || !source.startsWith('=')) {
-        continue;
-      }
-
-      const expr = source.substring(1).trim();
-      for (const inv of findFunctionInvocations(expr)) {
-        const args = getPositionalArgs(inv.node, expr);
-        const key = args[ 0 ];
-        if (key && key.type === 'PathExpression' && key.text.startsWith('toolCall.')) {
-          (keyOccurrences[ key.text ] = keyOccurrences[ key.text ] || []).push(input);
-        }
-      }
-    }
-
+    const keyOccurrences = collectOwnDeclaredKeyOccurrences(task);
     const duplicates = Object.keys(keyOccurrences).filter(key => keyOccurrences[ key ].length > 1);
 
     if (duplicates.length) {

--- a/test/camunda-cloud/agent-fromai-contract.spec.js
+++ b/test/camunda-cloud/agent-fromai-contract.spec.js
@@ -56,6 +56,34 @@ function bareInput(source) {
   `);
 }
 
+const TOOL_CONTAINER_MARKER = `
+        <bpmn:extensionElements>
+          <zeebe:properties>
+            <zeebe:property name="io.camunda.agenticai.toolContainer" value="true" />
+          </zeebe:properties>
+        </bpmn:extensionElements>`;
+
+// A service task tool root (no incoming, directly in the AHSP) whose
+// zeebe:taskDefinition carries the given attributes, optionally alongside an
+// input mapping declaring a key. `agentic` controls whether the AHSP carries
+// the toolContainer marker.
+function taskDefinitionTool(taskDefAttrs, { agentic = true, inputMapping = '' } = {}) {
+  return createProcess(`
+    <bpmn:adHocSubProcess id="AHSP_1">${agentic ? TOOL_CONTAINER_MARKER : ''}
+      <bpmn:serviceTask id="Task_1">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition ${taskDefAttrs} />
+          ${inputMapping}
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    </bpmn:adHocSubProcess>
+  `);
+}
+
+function inputMappingXml(source, target = 'value') {
+  return `<zeebe:ioMapping><zeebe:input source="${source}" target="${target}" /></zeebe:ioMapping>`;
+}
+
 const GOOD_DESC = '&quot;fetch the URL for the given search query&quot;';
 
 const valid = [
@@ -109,6 +137,78 @@ const valid = [
       '=fromAi(toolCall.url)',
       'zeebe:modelerTemplate="io.camunda.connectors.agenticai.aiagent.jobworker.v1"'
     ))
+  },
+  {
+    name: 'fromAi() in Retries, key declared by an input mapping on the same tool — the wrapper is redundant, not broken',
+    config: { version: '8.8' },
+    moddleElement: createModdle(taskDefinitionTool(
+      'retries="=fromAi(toolCall.retries)"',
+      { inputMapping: inputMappingXml(`=fromAi(toolCall.retries, ${GOOD_DESC}, &quot;number&quot;)`) }
+    ))
+  },
+  {
+    name: 'plain toolCall.retries read in Retries, no fromAi() wrapper — never swept at all',
+    config: { version: '8.8' },
+    moddleElement: createModdle(taskDefinitionTool(
+      'retries="=toolCall.retries"',
+      { inputMapping: inputMappingXml(`=fromAi(toolCall.retries, ${GOOD_DESC}, &quot;number&quot;)`) }
+    ))
+  },
+  {
+    name: 'retries is a plain FEEL literal, not fromAi() — rule ignores it',
+    config: { version: '8.8' },
+    moddleElement: createModdle(taskDefinitionTool('retries="=3"'))
+  },
+  {
+    name: 'zeebe:taskHeader value with no parseable fromAi() invocation',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="AHSP_1">${TOOL_CONTAINER_MARKER}
+        <bpmn:serviceTask id="Task_1">
+          <bpmn:extensionElements>
+            <zeebe:taskDefinition type="search" />
+            <zeebe:taskHeaders>
+              <zeebe:header key="note" value="=not really feel fromAi" />
+            </zeebe:taskHeaders>
+          </bpmn:extensionElements>
+        </bpmn:serviceTask>
+      </bpmn:adHocSubProcess>
+    `))
+  },
+  {
+    name: 'bpmn:Documentation mentioning fromAi() in prose is not swept',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="AHSP_1">${TOOL_CONTAINER_MARKER}
+        <bpmn:serviceTask id="Task_1">
+          <bpmn:documentation>=fromAi(toolCall.x) is used to tag AI-provided values</bpmn:documentation>
+          <bpmn:extensionElements>
+            <zeebe:ioMapping>
+              <zeebe:input source="=fromAi(toolCall.url, ${GOOD_DESC})" target="value" />
+            </zeebe:ioMapping>
+          </bpmn:extensionElements>
+        </bpmn:serviceTask>
+      </bpmn:adHocSubProcess>
+    `))
+  },
+  {
+    name: 'nested agent-as-tool — fromAi() in the inner agentic AHSP\'s own input mapping is a live tool-input declaration',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="AHSP_Outer">${TOOL_CONTAINER_MARKER}
+        <bpmn:adHocSubProcess id="AHSP_Inner">
+          <bpmn:extensionElements>
+            <zeebe:properties>
+              <zeebe:property name="io.camunda.agenticai.toolContainer" value="true" />
+            </zeebe:properties>
+            <zeebe:ioMapping>
+              <zeebe:input source="=fromAi(toolCall.q, ${GOOD_DESC})" target="value" />
+            </zeebe:ioMapping>
+          </bpmn:extensionElements>
+          <bpmn:serviceTask id="Task_1" />
+        </bpmn:adHocSubProcess>
+      </bpmn:adHocSubProcess>
+    `))
   }
 ];
 
@@ -449,7 +549,7 @@ const invalid = [
     }
   },
   {
-    name: 'T19 — fromAi in an output mapping source (ignored at runtime)',
+    name: 'T19 — fromAi in an output mapping source, key not declared anywhere (ignored at runtime)',
     config: { version: '8.8' },
     moddleElement: createModdle(createProcess(`
       <bpmn:adHocSubProcess id="AHSP_1">
@@ -469,13 +569,18 @@ const invalid = [
     `)),
     report: {
       id: 'Task_1',
-      message: 'fromAi() defines a tool input and has no effect in an output mapping. Define it in an input mapping on the tool\'s entry element.',
-      data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
+      message: 'fromAi() only defines a tool input in an input mapping, so toolCall.url is never provided and this output mapping resolves to null. Declare it in an input mapping on the tool\'s entry element, then read toolCall.url here.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'zeebe:Output',
+        parentNode: 'Task_1',
+        property: 'source'
+      },
       path: [ 'extensionElements', 'values', 0, 'outputParameters', 0, 'source' ]
     }
   },
   {
-    name: 'T20 — fromAi in a sequence flow condition (toolCall not in scope)',
+    name: 'T20 — fromAi in a sequence flow condition, key not declared anywhere',
     config: { version: '8.8' },
     moddleElement: createModdle(createProcess(`
       <bpmn:adHocSubProcess id="AHSP_1">
@@ -497,8 +602,13 @@ const invalid = [
     `)),
     report: {
       id: 'Flow_1',
-      message: 'fromAi() defines a tool input and cannot be used in a sequence flow condition. Define it in an input mapping on the tool\'s entry element.',
-      data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
+      message: 'fromAi() only defines a tool input in an input mapping, so toolCall.ready is never provided and this sequence flow condition resolves to null. Declare it in an input mapping on the tool\'s entry element, then read toolCall.ready here.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'Flow_1',
+        parentNode: 'Flow_1',
+        property: 'conditionExpression'
+      },
       path: [ 'conditionExpression' ]
     }
   },
@@ -528,7 +638,7 @@ const invalid = [
     }
   },
   {
-    name: 'legacy template — fromAi in output mapping',
+    name: 'legacy template — fromAi in output mapping, key not declared anywhere',
     config: { version: '8.8' },
     moddleElement: createModdle(createProcess(`
       <bpmn:adHocSubProcess id="AHSP_1" zeebe:modelerTemplate="io.camunda.connectors.agenticai.aiagent.jobworker.v1">
@@ -543,13 +653,18 @@ const invalid = [
     `)),
     report: {
       id: 'Task_1',
-      message: 'fromAi() defines a tool input and has no effect in an output mapping. Define it in an input mapping on the tool\'s entry element.',
-      data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
+      message: 'fromAi() only defines a tool input in an input mapping, so toolCall.url is never provided and this output mapping resolves to null. Declare it in an input mapping on the tool\'s entry element, then read toolCall.url here.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'zeebe:Output',
+        parentNode: 'Task_1',
+        property: 'source'
+      },
       path: [ 'extensionElements', 'values', 0, 'outputParameters', 0, 'source' ]
     }
   },
   {
-    name: 'legacy template — fromAi in sequence flow condition',
+    name: 'legacy template — fromAi in sequence flow condition, key not declared anywhere',
     config: { version: '8.8' },
     moddleElement: createModdle(createProcess(`
       <bpmn:adHocSubProcess id="AHSP_1" zeebe:modelerTemplate="io.camunda.connectors.agenticai.aiagent.jobworker.v1">
@@ -566,9 +681,478 @@ const invalid = [
     `)),
     report: {
       id: 'Flow_1',
-      message: 'fromAi() defines a tool input and cannot be used in a sequence flow condition. Define it in an input mapping on the tool\'s entry element.',
-      data: { type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT },
+      message: 'fromAi() only defines a tool input in an input mapping, so toolCall.ready is never provided and this sequence flow condition resolves to null. Declare it in an input mapping on the tool\'s entry element, then read toolCall.ready here.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'Flow_1',
+        parentNode: 'Flow_1',
+        property: 'conditionExpression'
+      },
       path: [ 'conditionExpression' ]
+    }
+  },
+
+  // ─── Non-input properties: undeclared key (the #256 bug) ───────────────────
+
+  {
+    name: 'screenshot repro — fromAi() in Retries, non-agentic AHSP, key declared nowhere',
+    config: { version: '8.8' },
+    moddleElement: createModdle(taskDefinitionTool(
+      `type="search" retries="=fromAi(toolCall.query, ${GOOD_DESC})"`,
+      { agentic: false }
+    )),
+    report: {
+      id: 'Task_1',
+      message: 'fromAi() only defines a tool input in an input mapping, so toolCall.query is never provided and the <retries> property resolves to null. Declare it in an input mapping on the tool\'s entry element, then read toolCall.query here.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'zeebe:TaskDefinition',
+        parentNode: 'Task_1',
+        property: 'retries'
+      },
+      path: [ 'extensionElements', 'values', 0, 'retries' ]
+    }
+  },
+  {
+    name: 'fromAi() in Retries, agentic AHSP, key declared nowhere',
+    config: { version: '8.8' },
+    moddleElement: createModdle(taskDefinitionTool(
+      `retries="=fromAi(toolCall.retries, ${GOOD_DESC}, &quot;number&quot;)"`
+    )),
+    report: {
+      id: 'Task_1',
+      message: 'fromAi() only defines a tool input in an input mapping, so toolCall.retries is never provided and the <retries> property resolves to null. Declare it in an input mapping on the tool\'s entry element, then read toolCall.retries here.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'zeebe:TaskDefinition',
+        parentNode: 'Task_1',
+        property: 'retries'
+      },
+      path: [ 'extensionElements', 'values', 0, 'retries' ]
+    }
+  },
+  {
+    name: 'per-element precision — key declared on a different tool does not excuse this one',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="AHSP_1">${TOOL_CONTAINER_MARKER}
+        <bpmn:serviceTask id="Task_A">
+          <bpmn:extensionElements>
+            <zeebe:ioMapping>
+              <zeebe:input source="=fromAi(toolCall.retries, ${GOOD_DESC}, &quot;number&quot;)" target="value" />
+            </zeebe:ioMapping>
+          </bpmn:extensionElements>
+        </bpmn:serviceTask>
+        <bpmn:serviceTask id="Task_B">
+          <bpmn:extensionElements>
+            <zeebe:taskDefinition retries="=fromAi(toolCall.retries)" />
+          </bpmn:extensionElements>
+        </bpmn:serviceTask>
+      </bpmn:adHocSubProcess>
+    `)),
+    report: {
+      id: 'Task_B',
+      message: 'fromAi() only defines a tool input in an input mapping, so toolCall.retries is never provided and the <retries> property resolves to null. Declare it in an input mapping on the tool\'s entry element, then read toolCall.retries here.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'zeebe:TaskDefinition',
+        parentNode: 'Task_B',
+        property: 'retries'
+      },
+      path: [ 'extensionElements', 'values', 0, 'retries' ]
+    }
+  },
+  {
+    name: 'fromAi() in taskDefinition type, key declared nowhere',
+    config: { version: '8.8' },
+    moddleElement: createModdle(taskDefinitionTool(
+      `type="=fromAi(toolCall.jobType, ${GOOD_DESC})"`
+    )),
+    report: {
+      id: 'Task_1',
+      message: 'fromAi() only defines a tool input in an input mapping, so toolCall.jobType is never provided and the <type> property resolves to null. Declare it in an input mapping on the tool\'s entry element, then read toolCall.jobType here.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'zeebe:TaskDefinition',
+        parentNode: 'Task_1',
+        property: 'type'
+      },
+      path: [ 'extensionElements', 'values', 0, 'type' ]
+    }
+  },
+  {
+    name: 'fromAi() in a zeebe:taskHeader value, key declared nowhere',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="AHSP_1">${TOOL_CONTAINER_MARKER}
+        <bpmn:serviceTask id="Task_1">
+          <bpmn:extensionElements>
+            <zeebe:taskDefinition type="search" />
+            <zeebe:taskHeaders>
+              <zeebe:header key="resultExpression" value="=fromAi(toolCall.expr, ${GOOD_DESC})" />
+            </zeebe:taskHeaders>
+          </bpmn:extensionElements>
+        </bpmn:serviceTask>
+      </bpmn:adHocSubProcess>
+    `)),
+    report: {
+      id: 'Task_1',
+      message: 'fromAi() only defines a tool input in an input mapping, so toolCall.expr is never provided and the <value> property resolves to null. Declare it in an input mapping on the tool\'s entry element, then read toolCall.expr here.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'zeebe:Header',
+        parentNode: 'Task_1',
+        property: 'value'
+      },
+      path: [ 'extensionElements', 'values', 1, 'values', 0, 'value' ]
+    }
+  },
+  {
+    name: 'fromAi() in a zeebe:property value, key declared nowhere',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="AHSP_1">${TOOL_CONTAINER_MARKER}
+        <bpmn:serviceTask id="Task_1">
+          <bpmn:extensionElements>
+            <zeebe:properties>
+              <zeebe:property name="custom" value="=fromAi(toolCall.custom, ${GOOD_DESC})" />
+            </zeebe:properties>
+          </bpmn:extensionElements>
+        </bpmn:serviceTask>
+      </bpmn:adHocSubProcess>
+    `)),
+    report: {
+      id: 'Task_1',
+      message: 'fromAi() only defines a tool input in an input mapping, so toolCall.custom is never provided and the <value> property resolves to null. Declare it in an input mapping on the tool\'s entry element, then read toolCall.custom here.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'zeebe:Property',
+        parentNode: 'Task_1',
+        property: 'value'
+      },
+      path: [ 'extensionElements', 'values', 0, 'properties', 0, 'value' ]
+    }
+  },
+  {
+    name: 'fromAi() in a zeebe:script expression, key declared nowhere',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="AHSP_1">${TOOL_CONTAINER_MARKER}
+        <bpmn:scriptTask id="Task_1">
+          <bpmn:extensionElements>
+            <zeebe:script expression="=fromAi(toolCall.expr, ${GOOD_DESC})" resultVariable="result" />
+          </bpmn:extensionElements>
+        </bpmn:scriptTask>
+      </bpmn:adHocSubProcess>
+    `)),
+    report: {
+      id: 'Task_1',
+      message: 'fromAi() only defines a tool input in an input mapping, so toolCall.expr is never provided and the <expression> property resolves to null. Declare it in an input mapping on the tool\'s entry element, then read toolCall.expr here.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'zeebe:Script',
+        parentNode: 'Task_1',
+        property: 'expression'
+      },
+      path: [ 'extensionElements', 'values', 0, 'expression' ]
+    }
+  },
+  {
+    name: 'fromAi() in zeebe:assignmentDefinition assignee, key declared nowhere',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="AHSP_1">${TOOL_CONTAINER_MARKER}
+        <bpmn:userTask id="Task_1">
+          <bpmn:extensionElements>
+            <zeebe:assignmentDefinition assignee="=fromAi(toolCall.assignee, ${GOOD_DESC})" />
+          </bpmn:extensionElements>
+        </bpmn:userTask>
+      </bpmn:adHocSubProcess>
+    `)),
+    report: {
+      id: 'Task_1',
+      message: 'fromAi() only defines a tool input in an input mapping, so toolCall.assignee is never provided and the <assignee> property resolves to null. Declare it in an input mapping on the tool\'s entry element, then read toolCall.assignee here.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'zeebe:AssignmentDefinition',
+        parentNode: 'Task_1',
+        property: 'assignee'
+      },
+      path: [ 'extensionElements', 'values', 0, 'assignee' ]
+    }
+  },
+  {
+    name: 'fromAi() in an execution listener retries, key declared nowhere',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="AHSP_1">${TOOL_CONTAINER_MARKER}
+        <bpmn:serviceTask id="Task_1">
+          <bpmn:extensionElements>
+            <zeebe:taskDefinition type="search" />
+            <zeebe:executionListeners>
+              <zeebe:executionListener eventType="start" type="my-listener" retries="=fromAi(toolCall.retries, ${GOOD_DESC}, &quot;number&quot;)" />
+            </zeebe:executionListeners>
+          </bpmn:extensionElements>
+        </bpmn:serviceTask>
+      </bpmn:adHocSubProcess>
+    `)),
+    report: {
+      id: 'Task_1',
+      message: 'fromAi() only defines a tool input in an input mapping, so toolCall.retries is never provided and the <retries> property resolves to null. Declare it in an input mapping on the tool\'s entry element, then read toolCall.retries here.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'zeebe:ExecutionListener',
+        parentNode: 'Task_1',
+        property: 'retries'
+      },
+      path: [ 'extensionElements', 'values', 1, 'listeners', 0, 'retries' ]
+    }
+  },
+  {
+    name: 'fromAi() in multi-instance inputCollection, key declared nowhere',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="AHSP_1">${TOOL_CONTAINER_MARKER}
+        <bpmn:serviceTask id="Task_1">
+          <bpmn:multiInstanceLoopCharacteristics>
+            <bpmn:extensionElements>
+              <zeebe:loopCharacteristics inputCollection="=fromAi(toolCall.items, ${GOOD_DESC})" />
+            </bpmn:extensionElements>
+          </bpmn:multiInstanceLoopCharacteristics>
+        </bpmn:serviceTask>
+      </bpmn:adHocSubProcess>
+    `)),
+    report: {
+      id: 'Task_1',
+      message: 'fromAi() only defines a tool input in an input mapping, so toolCall.items is never provided and the <inputCollection> property resolves to null. Declare it in an input mapping on the tool\'s entry element, then read toolCall.items here.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'zeebe:LoopCharacteristics',
+        parentNode: 'Task_1',
+        property: 'inputCollection'
+      },
+      path: [ 'loopCharacteristics', 'extensionElements', 'values', 0, 'inputCollection' ]
+    }
+  },
+  {
+    name: 'fromAi() in a timer duration, key declared nowhere — reported once, not twice',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="AHSP_1">${TOOL_CONTAINER_MARKER}
+        <bpmn:intermediateCatchEvent id="Task_1">
+          <bpmn:timerEventDefinition>
+            <bpmn:timeDuration>=fromAi(toolCall.wait, ${GOOD_DESC})</bpmn:timeDuration>
+          </bpmn:timerEventDefinition>
+        </bpmn:intermediateCatchEvent>
+      </bpmn:adHocSubProcess>
+    `)),
+    report: {
+      id: 'Task_1',
+      message: 'fromAi() only defines a tool input in an input mapping, so toolCall.wait is never provided and the <timeDuration> property resolves to null. Declare it in an input mapping on the tool\'s entry element, then read toolCall.wait here.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'bpmn:TimerEventDefinition',
+        parentNode: 'Task_1',
+        property: 'timeDuration'
+      },
+      path: [ 'eventDefinitions', 0, 'timeDuration' ]
+    }
+  },
+  {
+    name: 'both a valid input source and an undeclared retries key on one task — reports only retries',
+    config: { version: '8.8' },
+    moddleElement: createModdle(taskDefinitionTool(
+      `retries="=fromAi(toolCall.other, ${GOOD_DESC}, &quot;number&quot;)"`,
+      { inputMapping: inputMappingXml(`=fromAi(toolCall.a, ${GOOD_DESC})`) }
+    )),
+    report: {
+      id: 'Task_1',
+      message: 'fromAi() only defines a tool input in an input mapping, so toolCall.other is never provided and the <retries> property resolves to null. Declare it in an input mapping on the tool\'s entry element, then read toolCall.other here.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'zeebe:TaskDefinition',
+        parentNode: 'Task_1',
+        property: 'retries'
+      },
+      path: [ 'extensionElements', 'values', 0, 'retries' ]
+    }
+  },
+
+  // ─── The agent's own properties ─────────────────────────────────────────────
+
+  {
+    name: 'fromAi() in the agent\'s own input mapping — not a tool, toolCall never in scope there',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="AHSP_1">
+        <bpmn:extensionElements>
+          <zeebe:properties>
+            <zeebe:property name="io.camunda.agenticai.toolContainer" value="true" />
+          </zeebe:properties>
+          <zeebe:ioMapping>
+            <zeebe:input source="=fromAi(toolCall.systemPrompt, ${GOOD_DESC})" target="value" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+      </bpmn:adHocSubProcess>
+    `)),
+    report: {
+      id: 'AHSP_1',
+      message: 'fromAi() defines a tool input and has no effect on the agent sub-process itself. Define it on a tool inside this sub-process.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'zeebe:Input',
+        parentNode: 'AHSP_1',
+        property: 'source'
+      },
+      path: [ 'extensionElements', 'values', 1, 'inputParameters', 0, 'source' ]
+    }
+  },
+  {
+    name: 'fromAi() in the agent\'s own zeebe:adHoc activeElementsCollection',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="AHSP_1">
+        <bpmn:extensionElements>
+          <zeebe:properties>
+            <zeebe:property name="io.camunda.agenticai.toolContainer" value="true" />
+          </zeebe:properties>
+          <zeebe:adHoc activeElementsCollection="=fromAi(toolCall.elements, ${GOOD_DESC})" />
+        </bpmn:extensionElements>
+      </bpmn:adHocSubProcess>
+    `)),
+    report: {
+      id: 'AHSP_1',
+      message: 'fromAi() defines a tool input and has no effect on the agent sub-process itself. Define it on a tool inside this sub-process.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'zeebe:AdHoc',
+        parentNode: 'AHSP_1',
+        property: 'activeElementsCollection'
+      },
+      path: [ 'extensionElements', 'values', 1, 'activeElementsCollection' ]
+    }
+  },
+  {
+    name: 'fromAi() in the agent\'s own completionCondition',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="AHSP_1">${TOOL_CONTAINER_MARKER}
+        <bpmn:completionCondition>=fromAi(toolCall.done, ${GOOD_DESC})</bpmn:completionCondition>
+      </bpmn:adHocSubProcess>
+    `)),
+    report: {
+      id: 'AHSP_1',
+      message: 'fromAi() defines a tool input and has no effect on the agent sub-process itself. Define it on a tool inside this sub-process.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'AHSP_1',
+        parentNode: 'AHSP_1',
+        property: 'completionCondition'
+      },
+      path: [ 'completionCondition' ]
+    }
+  },
+
+  // ─── Widening: non-input surfaces report regardless of context ─────────────
+
+  {
+    name: 'fromAi() in an output mapping, non-agentic AHSP',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="AHSP_1">
+        <bpmn:serviceTask id="Task_1">
+          <bpmn:extensionElements>
+            <zeebe:ioMapping>
+              <zeebe:output source="=fromAi(toolCall.url, ${GOOD_DESC})" target="result" />
+            </zeebe:ioMapping>
+          </bpmn:extensionElements>
+        </bpmn:serviceTask>
+      </bpmn:adHocSubProcess>
+    `)),
+    report: {
+      id: 'Task_1',
+      message: 'fromAi() only defines a tool input in an input mapping, so toolCall.url is never provided and this output mapping resolves to null. Declare it in an input mapping on the tool\'s entry element, then read toolCall.url here.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'zeebe:Output',
+        parentNode: 'Task_1',
+        property: 'source'
+      },
+      path: [ 'extensionElements', 'values', 0, 'outputParameters', 0, 'source' ]
+    }
+  },
+  {
+    name: 'fromAi() in a sequence flow condition, non-agentic AHSP',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="AHSP_1">
+        <bpmn:serviceTask id="Task_1">
+          <bpmn:outgoing>Flow_1</bpmn:outgoing>
+        </bpmn:serviceTask>
+        <bpmn:serviceTask id="Task_2">
+          <bpmn:incoming>Flow_1</bpmn:incoming>
+        </bpmn:serviceTask>
+        <bpmn:sequenceFlow id="Flow_1" sourceRef="Task_1" targetRef="Task_2">
+          <bpmn:conditionExpression>=fromAi(toolCall.ready, ${GOOD_DESC})</bpmn:conditionExpression>
+        </bpmn:sequenceFlow>
+      </bpmn:adHocSubProcess>
+    `)),
+    report: {
+      id: 'Flow_1',
+      message: 'fromAi() only defines a tool input in an input mapping, so toolCall.ready is never provided and this sequence flow condition resolves to null. Declare it in an input mapping on the tool\'s entry element, then read toolCall.ready here.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'Flow_1',
+        parentNode: 'Flow_1',
+        property: 'conditionExpression'
+      },
+      path: [ 'conditionExpression' ]
+    }
+  },
+  {
+    name: 'fromAi() in an output mapping, no AHSP anywhere',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:serviceTask id="Task_1">
+        <bpmn:extensionElements>
+          <zeebe:ioMapping>
+            <zeebe:output source="=fromAi(toolCall.url, ${GOOD_DESC})" target="result" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    `)),
+    report: {
+      id: 'Task_1',
+      message: 'fromAi() only defines a tool input in an input mapping, so toolCall.url is never provided and this output mapping resolves to null. Declare it in an input mapping on the tool\'s entry element, then read toolCall.url here.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'zeebe:Output',
+        parentNode: 'Task_1',
+        property: 'source'
+      },
+      path: [ 'extensionElements', 'values', 0, 'outputParameters', 0, 'source' ]
+    }
+  },
+  {
+    name: 'fromAi() in taskDefinition retries, no AHSP anywhere',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:serviceTask id="Task_1">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition retries="=fromAi(toolCall.retries, ${GOOD_DESC}, &quot;number&quot;)" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+    `)),
+    report: {
+      id: 'Task_1',
+      message: 'fromAi() only defines a tool input in an input mapping, so toolCall.retries is never provided and the <retries> property resolves to null. Declare it in an input mapping on the tool\'s entry element, then read toolCall.retries here.',
+      data: {
+        type: ERROR_TYPES.AGENT_FEEL_WRONG_CONTEXT,
+        node: 'zeebe:TaskDefinition',
+        parentNode: 'Task_1',
+        property: 'retries'
+      },
+      path: [ 'extensionElements', 'values', 0, 'retries' ]
     }
   }
 ];


### PR DESCRIPTION
### Proposed Changes

PR 2 of 2 for #256 (stacked on #257, base branch here is `agent-fromai-sweep-pr1`, not `main`; will retarget to `main` once #257 merges).

`agent-fromai-contract` couldn't see `fromAi()` outside an input mapping source, an output mapping source, or a sequence flow condition. Any other property, for example a task's Retries field or a call activity's process ID expression, was invisible: `fromAi(toolCall.retries, "how many times to retry", "number")` there produced no report at all, even when nothing anywhere declares `toolCall.retries` as a tool input.

**This is not a simple "flag it everywhere" fix.** Two separate mechanisms are involved, verified against `camunda/camunda` and `camunda/connectors` source:

- **Declaration** happens at deploy time: `AdHocSubProcessTransformer#extractAdHocActivityParameters` extracts tagged parameters only from `adHocActivity.getInputMappings()`. Only a `fromAi()` in an input mapping on a tool's entry element adds a parameter to the schema the LLM sees.
- **Reading** happens at activation time: `BpmnAdHocSubProcessBehavior#activateElement` merges the connector's `toolCall` payload as a local variable on the ad-hoc sub-process's inner instance, populated by `AgentSubProcessRequestHandler#buildElementActivations`. That variable is visible to the whole tool's sub-flow, not just the entry element.

So `fromAi(toolCall.retries)` in Retries is genuinely correct **if** `toolCall.retries` was already declared by a `fromAi()` call in an input mapping on the same tool. The check added here is key-aware: it only flags a non-input `fromAi()` call whose referenced key is declared nowhere on the tool. Declaration lookup is exact when the site sits directly on a tool's entry element (that element's own input mappings), and falls back to a union across every tool entry in the ad-hoc sub-process for downstream elements and sequence flows, where finding the true owning tool would need a backward walk over branching flows (a gap `agent-tool-output-key.js` already documents as unsolved elsewhere in this rule).

**Two more corrections along the way:**
- Two shipped messages claimed `toolCall` is "only populated for a tool's inputs" and unavailable in output mappings and sequence flow conditions. That's not true, per the source above; reworded to say the key was never declared, not that the variable is out of scope.
- `fromAi()` in the ad-hoc sub-process's own input mappings (as opposed to a tool inside it) used to report "should only be used inside an agentic sub-process" while the user was standing on the agentic sub-process. `toolCall` lives on the tool's inner instance, a child scope the agent's own properties never see, so this now gets its own accurate message.

No new `ERROR_TYPES` value: reuses `AGENT_FEEL_WRONG_CONTEXT` (already the type for "sits somewhere the connector never reads") with `data` enriched with `node`/`parentNode`/`property` so a downstream consumer can compose a message without re-parsing text. Additive, no coordinated change needed in `@camunda/linting` or web-modeler.

25 new test cases, including an exact repro of the screenshot from camunda/linting#172 and a case proving the per-element declaration lookup doesn't leak a key declared on one tool into a different tool in the same AHSP.

### Try out

```
npm test
```

All cases in `agent-fromai-contract.spec.js` pass; `npm run all` is green.

Closes #256.