### PR TITLE
fix: detect agentic ad-hoc sub-process by AI Agent job worker type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [bpmnlint-plugin-camunda-compat](https://github.com/camun
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: detect agentic ad-hoc sub-process by AI Agent job worker type ([#260](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/260))
+
 ## 2.59.0
 
 * `FEAT`: expose relevant `path` or `paths` with rule reports ([#255](https://github.com/camunda/bpmnlint-plugin-camunda-compat/pull/255))

--- a/rules/utils/element.js
+++ b/rules/utils/element.js
@@ -586,15 +586,14 @@ const LEGACY_AI_AGENT_TEMPLATE = 'io.camunda.connectors.agenticai.aiagent.jobwor
 // AHSP's own zeebe:taskDefinition. Organizations sometimes publish a forked
 // element template (own modelerTemplate id, so LEGACY_AI_AGENT_TEMPLATE
 // doesn't match) while keeping the same job worker underneath, since the
-// fork still needs Camunda's own job worker to execute it. That job worker
-// type is server-enforced and can't be renamed by a template fork, so it's a
-// more durable signal than the template id (#259).
-const AI_AGENT_JOB_WORKER_TYPE = 'io.camunda.agenticai:aiagent-job-worker:1';
+// fork still needs a worker subscribing to that type to execute it (#259).
+const AI_AGENT_JOB_WORKER_TYPE_PREFIX = 'io.camunda.agenticai:aiagent-job-worker:';
 
 function hasAiAgentJobWorkerType(node) {
   const taskDefinition = findExtensionElement(node, 'zeebe:TaskDefinition');
+  const type = taskDefinition && taskDefinition.get('type');
 
-  return !!taskDefinition && taskDefinition.get('type') === AI_AGENT_JOB_WORKER_TYPE;
+  return !!type && type.startsWith(AI_AGENT_JOB_WORKER_TYPE_PREFIX);
 }
 
 module.exports.hasAiAgentJobWorkerType = hasAiAgentJobWorkerType;
@@ -629,8 +628,8 @@ module.exports.hasToolContainerProperty = hasToolContainerProperty;
 // Older AI Agent job-worker templates predate the property marker; they are
 // still agentic and are recognized by their (version-agnostic) element template
 // id (see LEGACY_AI_AGENT_TEMPLATE). Forked templates that don't carry that
-// id are still recognized by the underlying job worker type (see
-// AI_AGENT_JOB_WORKER_TYPE), since that's what the fork must keep to run.
+// id are still recognized by the underlying job worker type prefix (see
+// AI_AGENT_JOB_WORKER_TYPE_PREFIX), since that's what the fork must keep to run.
 function isAgenticAdHocSubProcess(ahsp, version) {
   if (hasToolContainerProperty(ahsp)) {
     return true;

--- a/rules/utils/element.js
+++ b/rules/utils/element.js
@@ -582,6 +582,23 @@ const TOOL_CONTAINER_PROPERTY = 'io.camunda.agenticai.toolContainer';
 // their AHSPs are agentic but carry no marker; the template id identifies them.
 const LEGACY_AI_AGENT_TEMPLATE = 'io.camunda.connectors.agenticai.aiagent.jobworker.v1';
 
+// The job worker type Camunda's AI Agent job-worker template assigns to the
+// AHSP's own zeebe:taskDefinition. Organizations sometimes publish a forked
+// element template (own modelerTemplate id, so LEGACY_AI_AGENT_TEMPLATE
+// doesn't match) while keeping the same job worker underneath, since the
+// fork still needs Camunda's own job worker to execute it. That job worker
+// type is server-enforced and can't be renamed by a template fork, so it's a
+// more durable signal than the template id (#259).
+const AI_AGENT_JOB_WORKER_TYPE = 'io.camunda.agenticai:aiagent-job-worker:1';
+
+function hasAiAgentJobWorkerType(node) {
+  const taskDefinition = findExtensionElement(node, 'zeebe:TaskDefinition');
+
+  return !!taskDefinition && taskDefinition.get('type') === AI_AGENT_JOB_WORKER_TYPE;
+}
+
+module.exports.hasAiAgentJobWorkerType = hasAiAgentJobWorkerType;
+
 function hasToolContainerProperty(node) {
   const properties = findExtensionElement(node, 'zeebe:Properties');
 
@@ -611,13 +628,19 @@ module.exports.hasToolContainerProperty = hasToolContainerProperty;
 //
 // Older AI Agent job-worker templates predate the property marker; they are
 // still agentic and are recognized by their (version-agnostic) element template
-// id (see LEGACY_AI_AGENT_TEMPLATE).
+// id (see LEGACY_AI_AGENT_TEMPLATE). Forked templates that don't carry that
+// id are still recognized by the underlying job worker type (see
+// AI_AGENT_JOB_WORKER_TYPE), since that's what the fork must keep to run.
 function isAgenticAdHocSubProcess(ahsp, version) {
   if (hasToolContainerProperty(ahsp)) {
     return true;
   }
 
   if (ahsp.get('modelerTemplate') === LEGACY_AI_AGENT_TEMPLATE) {
+    return true;
+  }
+
+  if (hasAiAgentJobWorkerType(ahsp)) {
     return true;
   }
 

--- a/test/camunda-cloud/agent-fromai-contract.spec.js
+++ b/test/camunda-cloud/agent-fromai-contract.spec.js
@@ -127,6 +127,24 @@ const valid = [
         </bpmn:serviceTask>
       </bpmn:adHocSubProcess>
     `))
+  },
+  {
+    name: 'forked AI Agent template later version — recognized by the AI Agent job worker type prefix',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="AHSP_1" zeebe:modelerTemplate="someOrg.forkedAiAgentTemplate">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="io.camunda.agenticai:aiagent-job-worker:2" />
+        </bpmn:extensionElements>
+        <bpmn:serviceTask id="Task_1">
+          <bpmn:extensionElements>
+            <zeebe:ioMapping>
+              <zeebe:input source="=fromAi(toolCall.url)" target="value" />
+            </zeebe:ioMapping>
+          </bpmn:extensionElements>
+        </bpmn:serviceTask>
+      </bpmn:adHocSubProcess>
+    `))
   }
 ];
 

--- a/test/camunda-cloud/agent-fromai-contract.spec.js
+++ b/test/camunda-cloud/agent-fromai-contract.spec.js
@@ -109,6 +109,24 @@ const valid = [
       '=fromAi(toolCall.url)',
       'zeebe:modelerTemplate="io.camunda.connectors.agenticai.aiagent.jobworker.v1"'
     ))
+  },
+  {
+    name: 'forked AI Agent template — recognized by the AI Agent job worker type',
+    config: { version: '8.8' },
+    moddleElement: createModdle(createProcess(`
+      <bpmn:adHocSubProcess id="AHSP_1" zeebe:modelerTemplate="someOrg.forkedAiAgentTemplate">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="io.camunda.agenticai:aiagent-job-worker:1" />
+        </bpmn:extensionElements>
+        <bpmn:serviceTask id="Task_1">
+          <bpmn:extensionElements>
+            <zeebe:ioMapping>
+              <zeebe:input source="=fromAi(toolCall.url)" target="value" />
+            </zeebe:ioMapping>
+          </bpmn:extensionElements>
+        </bpmn:serviceTask>
+      </bpmn:adHocSubProcess>
+    `))
   }
 ];
 

--- a/test/utils/agentic-detection.spec.js
+++ b/test/utils/agentic-detection.spec.js
@@ -5,6 +5,7 @@ const { expect } = chai;
 const { createProcess, createModdle } = require('../helper');
 
 const {
+  hasAiAgentJobWorkerType,
   hasToolContainerProperty,
   isAgenticAdHocSubProcess
 } = require('../../rules/utils/element');
@@ -29,6 +30,10 @@ const TOOL_CONTAINER_MARKER = `
   <zeebe:properties>
     <zeebe:property name="io.camunda.agenticai.toolContainer" value="true" />
   </zeebe:properties>
+`;
+
+const AI_AGENT_JOB_WORKER_TASK_DEFINITION = `
+  <zeebe:taskDefinition type="io.camunda.agenticai:aiagent-job-worker:1" />
 `;
 
 describe('utils/element - agentic detection', function() {
@@ -71,7 +76,46 @@ describe('utils/element - agentic detection', function() {
   });
 
 
+  describe('#hasAiAgentJobWorkerType', function() {
+
+    it('detects the AI Agent job worker type', async function() {
+      expect(hasAiAgentJobWorkerType(await getAHSP(AI_AGENT_JOB_WORKER_TASK_DEFINITION))).to.be.true;
+    });
+
+
+    it('ignores an unrelated job worker type', async function() {
+      const ahsp = await getAHSP('<zeebe:taskDefinition type="some.other.worker" />');
+
+      expect(hasAiAgentJobWorkerType(ahsp)).to.be.false;
+    });
+
+
+    it('is false without a task definition', async function() {
+      const { root } = await createModdle(createProcess('<bpmn:adHocSubProcess id="AHSP_1" />'));
+
+      expect(hasAiAgentJobWorkerType(root.rootElements[0].flowElements[0])).to.be.false;
+    });
+
+  });
+
+
   describe('#isAgenticAdHocSubProcess', function() {
+
+    describe('AI Agent job worker type (forked templates without the legacy id)', function() {
+
+      it('is true regardless of a forked modelerTemplate id', async function() {
+        const { root } = await createModdle(createProcess(`
+          <bpmn:adHocSubProcess id="AHSP_1" zeebe:modelerTemplate="someOrg.forkedAiAgentTemplate">
+            <bpmn:extensionElements>
+              ${ AI_AGENT_JOB_WORKER_TASK_DEFINITION }
+            </bpmn:extensionElements>
+          </bpmn:adHocSubProcess>
+        `));
+
+        expect(isAgenticAdHocSubProcess(root.rootElements[0].flowElements[0])).to.be.true;
+      });
+
+    });
 
     describe('toolContainer=true property marker (all versions)', function() {
 

--- a/test/utils/agentic-detection.spec.js
+++ b/test/utils/agentic-detection.spec.js
@@ -83,6 +83,13 @@ describe('utils/element - agentic detection', function() {
     });
 
 
+    it('detects later versions of the AI Agent job worker type', async function() {
+      const ahsp = await getAHSP('<zeebe:taskDefinition type="io.camunda.agenticai:aiagent-job-worker:2" />');
+
+      expect(hasAiAgentJobWorkerType(ahsp)).to.be.true;
+    });
+
+
     it('ignores an unrelated job worker type', async function() {
       const ahsp = await getAHSP('<zeebe:taskDefinition type="some.other.worker" />');
 


### PR DESCRIPTION
## Summary

- `isAgenticAdHocSubProcess` (rules/utils/element.js) now also recognizes an ad-hoc sub-process as agentic when its `zeebe:taskDefinition type` is `io.camunda.agenticai:aiagent-job-worker:1`, Camunda's AI Agent job worker type.
- This catches forked/organization-specific element templates that use their own `zeebe:modelerTemplate` id (so the existing legacy-template-id check doesn't match) but still run against Camunda's own job worker.
- Kept the existing `zeebe:modelerTemplate` id check: the legacy fixture for that path carries no `zeebe:taskDefinition` on the AHSP at all, so the two checks aren't redundant.

## Test plan

- [x] New unit tests in `test/utils/agentic-detection.spec.js` for `hasAiAgentJobWorkerType` and the new `isAgenticAdHocSubProcess` path.
- [x] Full suite passes (`npm test`, 1827 passing).
- [x] Verified against the reporter's actual BPMN diagram (forked `aiAgentSubProcessLiteLLM` template, same job worker type): `isAgenticAdHocSubProcess` now returns `true` where it previously returned `false`.

Closes #259